### PR TITLE
[codex] Add scoped stewards and backlog slices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,11 +159,59 @@ The current prototype already has:
 
 ## Scoped Agent Guides
 
-Root `AGENTS.md` is currently the source of truth. Add nested `AGENTS.md` files
-only when a subtree has materially different rules, such as a future package
-with its own design contract, migration workflow, or generated assets. When
-nested guides exist, the closest guide should refine this one rather than
-contradicting the mission or tenant-boundary rules.
+Root `AGENTS.md` is the product constitution. Nested `AGENTS.md` files are
+scoped steward files: short local domain guides for package boundaries, docs,
+domain primitives, services, storage, web/UI, blueprints, and tests.
+
+When editing a subtree, read this root guide and the nearest nested
+`AGENTS.md` before making product or architecture decisions. The nested guide
+may add local checks, contracts, and safety boundaries, but it must refine this
+constitution rather than contradicting the mission, tenant model, product voice,
+or PBP-native shape.
+
+Cross-cutting PRs should include brief **Steward Notes** in the summary:
+which steward files were consulted, which boundary decisions were made, and
+which risks or follow-up gaps remain. Keep the notes small and practical.
+
+### Ask Stewards Workflow
+
+The trigger phrase **"ask stewards"** means run this consultation workflow and
+produce a short prioritization rollup.
+
+1. Verify the checkout/ref is current enough for the question. Run `git status
+   --short --branch`; fetch or compare with upstream when prioritization depends
+   on current remote state.
+2. Enumerate scoped steward files with `find . -name AGENTS.md -print | sort`.
+3. For implementation work, consult the stewards nearest the affected paths.
+   For backlog, roadmap, or product sequencing work, consult all stewards.
+4. Ask each consulted steward for:
+   - top priority
+   - confidence
+   - evidence from code, docs, tests, or product spine
+   - dependencies and ordering constraints
+   - risks and blast radius
+   - tempting "not now" items
+   - upstream or downstream service opportunities
+5. Synthesize with weighted voting. Favor convergence, dependency order,
+   blast-radius reduction, public-contract risk, user-visible correctness, risk
+   reduction, and reversibility.
+6. Preserve minority reports when a steward sees a real risk the majority
+   downweights.
+7. Return a short rollup: recommendation, why now, consulted stewards,
+   confidence, dependencies, risks, not-now items, and suggested next checks.
+
+The workflow is a thinking aid, not a committee. Use it to surface domain-aware
+tradeoffs quickly, then keep moving.
+
+### Plan Snapshots
+
+Save durable steward rollups, roadmap sequences, and multi-step implementation
+plans under `plans/`. Active plans live in `plans/in-progress/` and must be
+listed in `plans/README.md` with a review-by date and closure criteria.
+
+Do not use plan files as scratch notes. If a plan has gone stale, refresh it,
+split it into concrete work, or move it to `plans/archive/YYYY/` as completed,
+superseded, or abandoned.
 
 ## Development Commands
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,44 @@
+# Product And Architecture Steward
+
+## Steward
+
+Product and architecture steward for `docs/architecture/`, `docs/product/`, and
+the README/AGENTS narrative when it explains Elbysodic's direction.
+
+## Protects
+
+- The PBP-native mission: faces, rosters, scenes, plotters, wanted hooks,
+  claims, reserves, director materials, and writing flow stay first-class.
+- Architecture docs preserve tenant boundaries, membership-vs-character
+  identity, repository/service layering, and migration discipline.
+- Product docs remain decision guides for agents, not aspirational clutter.
+- UI vocabulary docs stay consistent with promoted components and current
+  route surfaces.
+
+## Must Not Become
+
+- A backlog landfill or speculative manifesto detached from code.
+- Generic SaaS language that erases roleplay culture.
+- A duplicate of implementation details better expressed in tests or code.
+
+## Documentation Ownership
+
+Owns `docs/architecture/*.md`, `docs/product/*.md`, README architecture/product
+sections, and root `AGENTS.md` product doctrine. When code changes alter a
+primitive, control pattern, navigation rule, or migration boundary, update the
+relevant doc in the same PR.
+
+## Local Checks
+
+- `rg` for conflicting terms before changing product vocabulary.
+- `uv run ruff check .` when doc examples include Python snippets.
+- `uv run pytest -q --tb=short` when documentation claims are backed by tests.
+
+## Public Contracts And Safety
+
+- Do not weaken `community_id`, membership, character, or staff-role
+  boundaries in prose.
+- Keep examples in PBP language and make clear whether a feature is current,
+  planned, or deliberately deferred.
+- Cross-cutting docs changes should include Steward Notes naming affected code
+  domains and tests that prove the claim.

--- a/docs/architecture/migrations.md
+++ b/docs/architecture/migrations.md
@@ -6,14 +6,17 @@ upgrades. Fresh databases are created from the current schema in
 legacy compatibility helpers in that module and then recorded in the migration
 ledger.
 
-## Current Baseline
+## Current Version
 
-The current checked-in schema is baseline version `1`. Calling `create_schema()`
-creates or upgrades the database, ensures `schema_migrations` exists, records
-the baseline when no ledger row exists, and sets SQLite `PRAGMA user_version`.
+The checked-in schema currently creates databases at version `6`. Calling
+`create_schema()` creates or upgrades the database, ensures
+`schema_migrations` exists, records the current schema as a baseline when no
+ledger row exists, and sets SQLite `PRAGMA user_version`.
 
-This baseline keeps the prototype's existing schema bootstrap intact while
-giving future schema changes an ordered migration path.
+Version `1` is the historical baseline. Versions `2` and later are ordered
+post-baseline migrations in `src/elbysodic/db/migrations.py`. This keeps the
+prototype's existing schema bootstrap intact while giving future schema changes
+an ordered migration path.
 
 ## Adding A Schema Change
 
@@ -21,9 +24,10 @@ When adding a table, column, index, or constraint:
 
 1. Update the fresh schema in `SCHEMA`.
 2. Add an ordered migration in `src/elbysodic/db/migrations.py`.
-3. Keep the migration idempotent where possible.
-4. Add a test that starts from an older shape and calls `create_schema()`.
-5. Include tenant scope in new tables and indexes unless the table is truly
+3. Increment `CURRENT_SCHEMA_VERSION` and keep `MIGRATIONS` contiguous.
+4. Keep the migration idempotent where possible.
+5. Add a test that starts from an older shape and calls `create_schema()`.
+6. Include tenant scope in new tables and indexes unless the table is truly
    global infrastructure.
 
 Migration names should describe the product primitive or boundary being

--- a/docs/architecture/rendered-route-privacy-matrix.md
+++ b/docs/architecture/rendered-route-privacy-matrix.md
@@ -1,0 +1,61 @@
+# Rendered Route Privacy Matrix
+
+This matrix is the route-level companion to `security-boundaries.md`. Use it
+when adding a rendered page, route action, sidebar count, notification surface,
+or Studio room that can expose community-, membership-, role-, or
+character-scoped data.
+
+Rendered privacy tests should prove what the user can see, not only what a
+repository method returns. Prefer one focused test per route family unless a
+workflow has several identity shapes.
+
+## Identity Modes
+
+Use these viewer modes when a route can expose scoped data:
+
+| Mode | Meaning | Must Prove |
+| --- | --- | --- |
+| member | Active non-staff membership in the current community. | Public/published data is visible; staff-only and private data is absent. |
+| owner | Membership that owns the object or created the hook/room/application. | Owner-only controls appear without granting staff-only power. |
+| staff | Active membership with the named capability for the current community. | Staff controls and draft/private data appear only inside this community. |
+| inactive | Membership exists but is inactive. | Actions fail and private data stays hidden. |
+| cross-tenant | Membership belongs to another community or route slug exists elsewhere. | Current community does not leak the other community's object. |
+| faceless | Membership has no active/current character. | Character-backed actions disappear or ask for a face instead of guessing. |
+
+## Route Families
+
+| Route Family | Sensitive Data | Member | Owner | Staff | Cross-Tenant / Missing |
+| --- | --- | --- | --- | --- | --- |
+| `/world`, `/world/{material}` | Draft materials, Material Studio controls, current event links. | Published materials only. | Same as member unless staff. | Drafts and edit controls visible. | Recovery page; no draft body. |
+| `/wanted`, `/wanted/{wanted}` | Archived hooks, interested faces, lifecycle controls. | Open/non-archived hooks only. | Own hook controls visible. | Casting controls visible. | Recovery page; no archived body. |
+| `/applications`, `/applications/{character}` | Applicant draft body, staff notes, checklist, revision notes. | Own applications only. | Own applicant controls. | Review queue and staff notes visible. | Recovery page or local applications hub. |
+| `/plotting`, `/plotting/{room}` | Private planning notes, messages, participants. | Participant rooms only. | Owner plan controls. | Staff access only when explicitly designed. | Recovery page; no room notes. |
+| `/notifications` | Membership-specific inbox and unread counts. | Own notifications only. | Same as member. | Staff still sees own inbox, not global inbox. | No other membership notifications. |
+| `/studio`, `/studio/*` | Draft materials, private boards, production health, edit forms. | Read-only preview or forbidden controls absent. | Same as capability. | Capability-scoped controls visible. | No staff power leakage across communities. |
+| `/boards/{board}`, `/boards/{board}/threads/{thread}` | Private boards, private threads, post bodies, moderation controls. | Public visible boards only. | Thread author controls where allowed. | Moderation controls visible. | Not found/recovery; no private activity. |
+| `/members`, `/members/{username}` | Private activity and private-board latest lines. | Public cast/activity only. | Own profile controls when present. | Staff-only private activity only when designed. | No other community profile data. |
+
+## Test Checklist
+
+For each new rendered surface, decide whether it needs tests for:
+
+- direct route access
+- index/list visibility
+- sidebar or shell counts
+- action form visibility
+- POST permission failure
+- recovery page content
+- cross-community slug collision
+- inactive membership behavior
+- active-face or faceless behavior
+
+Keep assertions semantic. It is usually better to assert that a title, note, or
+control appears or does not appear than to snapshot large HTML sections.
+
+## Covered Regressions
+
+- Draft world materials stay staff-only on `/world`, direct material routes,
+  and Studio/editor surfaces.
+- Inactive memberships are absent from `/members`, `/members/{username}`, and
+  direct character profile routes, and recovery does not offer cross-realm
+  switches for inactive faces.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -78,3 +78,7 @@ two communities and proves:
 Rendered page tests should cover privacy when a workflow exposes a new route or
 surface. Repository-only tests are enough for low-level constraints, but not
 for user-visible private rooms, staff desks, or notification inboxes.
+
+Use `docs/architecture/rendered-route-privacy-matrix.md` as the standing route
+checklist for rendered privacy coverage. Update it when adding a new route
+family, identity shape, or user-visible scoped data surface.

--- a/docs/product/program-blueprints.md
+++ b/docs/product/program-blueprints.md
@@ -214,9 +214,9 @@ Hydration should keep tenant scope explicit. Every created object belongs to
 one community, and every character or wanted hook has an intentional membership
 owner.
 
-## Future Import Flow
+## Import Flow
 
-A future studio setup screen should use a four-step flow:
+Studio intake now supports the first dry-run milestone. The complete flow is:
 
 1. Upload or paste a YAML Program Blueprint.
 2. Parse into typed blueprint objects.
@@ -228,4 +228,6 @@ The dry-run preview should summarize the resulting program in director language:
 
 Do not make file import the first user-facing milestone. The first milestone is
 the shared contract: seed data and future YAML imports should describe the same
-kind of PBP hub.
+kind of PBP hub. The current Studio preview intentionally stops before step 4:
+it validates and summarizes the packet, but does not create or update database
+state.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,44 @@
+# Plans
+
+Plans are working snapshots for product and architecture direction. They are
+not scratchpads, permanent specs, or a second issue tracker.
+
+Use a plan when a decision needs continuity across agent sessions: steward
+rollups, multi-step implementation plans, migration strategies, or roadmap
+sequencing. Keep ordinary notes in the PR, issue, or final response instead.
+
+## Lifecycle
+
+Active plans live in `plans/in-progress/` and must appear in the Active Plans
+table below. Every active plan needs a status, owner, created date, last updated
+date, review-by date, and closure criteria.
+
+When a plan is no longer active:
+
+- move completed, superseded, or abandoned plans to `plans/archive/YYYY/`
+- remove them from the Active Plans table
+- leave a short final note in the plan explaining why it moved
+
+Do not leave stale plans in `plans/in-progress/`. If a plan has not been
+updated by its review-by date, the next agent should either refresh it, split
+it into concrete work, or archive it as superseded/abandoned.
+
+## Naming
+
+Use lowercase kebab-case:
+
+```text
+plans/in-progress/<topic>-<yyyy-mm-dd>.md
+```
+
+Prefer stable topic names over vague labels. Good names:
+
+- `steward-backlog-rollup-2026-05-01.md`
+- `studio-production-workflows-2026-05-15.md`
+- `program-blueprint-intake-2026-06-02.md`
+
+## Active Plans
+
+| Plan | Status | Owner | Review By | Closure Criteria |
+| --- | --- | --- | --- | --- |
+| [Steward backlog rollup 2026-05-01](in-progress/steward-backlog-rollup-2026-05-01.md) | in-progress | Steward workflow | 2026-05-15 | Split into concrete backlog items or archive as superseded. |

--- a/plans/in-progress/steward-backlog-rollup-2026-05-01.md
+++ b/plans/in-progress/steward-backlog-rollup-2026-05-01.md
@@ -1,0 +1,177 @@
+# Steward Backlog Rollup Snapshot
+
+Status: in-progress  
+Owner: Steward workflow  
+Created: 2026-05-01  
+Last updated: 2026-05-01  
+Review by: 2026-05-15  
+Source: `ask stewards` consultation on `main` after `git fetch --prune`  
+Closure criteria: split this into concrete backlog items, implementation
+plans, or issues; then move this file to `plans/archive/2026/` as completed or
+superseded.
+
+## Purpose
+
+Capture the first scoped steward prioritization report so future agents can
+build a backlog without rerunning the conversation from scratch. This is a
+snapshot, not a permanent roadmap.
+
+## Consulted Stewards
+
+- Root constitution: `AGENTS.md`
+- Product and architecture: `docs/AGENTS.md`
+- Package and tooling: `src/elbysodic/AGENTS.md`
+- Domain model: `src/elbysodic/domain/AGENTS.md`
+- Service layer: `src/elbysodic/services/AGENTS.md`
+- Storage and migrations: `src/elbysodic/db/AGENTS.md`
+- Rendering and UI: `src/elbysodic/web/AGENTS.md`
+- Blueprint contract: `src/elbysodic/blueprints/AGENTS.md`
+- Tests: `tests/AGENTS.md`
+
+## Recommended Priority List
+
+1. Harden Studio production workflows around board, world, wanted, and
+   application operations.
+   Confidence: high.
+   Why now: strong convergence from root, docs, services, web/UI, DB, and
+   tests. The root guide says board-running materials belong in the studio
+   layer; existing routes already include Studio, applications, claims,
+   casting, wanted, and world surfaces.
+
+2. Finish the character hub and active-face discovery loop.
+   Confidence: high.
+   Why now: the root guide says character profiles are becoming hubs and the
+   active/default face should reduce cognitive load across discovery, queues,
+   joins, and filters.
+
+3. Create a privacy and tenant test matrix for rendered routes.
+   Confidence: high.
+   Why now: security docs require rendered page privacy tests for routes that
+   expose scoped data. Route count has grown, and tests are the strongest
+   risk-reduction lever before broadening workflows.
+
+4. Ship Program Blueprint YAML intake as a dry-run-first Studio flow.
+   Confidence: medium-high.
+   Why now: the typed contract and validation already exist, and
+   `docs/product/program-blueprints.md` defines the intended upload, parse,
+   validate, preview, and apply flow. Apply should wait for a safe preview and
+   service-layer hydration boundary.
+
+5. Establish the first post-baseline migration pattern when the next schema
+   feature lands.
+   Confidence: medium.
+   Why now: current baseline is version `1`; the next schema-affecting feature
+   should demonstrate the fresh-schema plus ordered-migration plus migration
+   test pattern.
+
+6. Do a paragraph, control, and component consolidation pass on the
+   highest-traffic writing surfaces.
+   Confidence: medium.
+   Why now: paragraph rhythm and UI vocabulary docs identify post bodies,
+   composer preview, thread page, board page, character hub, and Studio as dense
+   text surfaces. Start with thread reader/composer and character hub.
+
+7. Thin the service facade only where feature work creates pain.
+   Confidence: medium-low.
+   Why now: `services/forum.py` is broad, but a pure refactor is less valuable
+   than extracting narrower seams while building Studio, blueprint intake, or
+   active-face workflows.
+
+## Minority Reports
+
+- Test steward would put the rendered-route privacy matrix first before any new
+  feature work. The rollup places it third because it can move alongside Studio
+  hardening, but the risk is real.
+- Blueprint steward would move YAML intake earlier because the contract is
+  already mature. The rollup keeps it behind Studio production hardening so
+  imports hydrate into stable director workflows.
+- Package steward recommends landing the steward docs before large backlog
+  implementation so future PRs can cite the workflow cleanly.
+
+## Not Now
+
+- Hosted forum creation.
+- Billing.
+- Custom domains.
+- Cross-community dashboards.
+- Broad single-page app rewrites.
+- Raw theme CSS imports.
+- Generic admin-dashboard expansion.
+
+These are either explicitly deferred or would blur the current PBP-native
+product spine.
+
+## Remaining Work
+
+The original seven priorities have each received at least one implementation
+slice. Keep this snapshot active only while turning the remaining gaps into
+focused plans, issues, or follow-up PRs.
+
+- Stabilize and curate the current cross-cutting change set before adding more
+  surface area. Confirm the diff is reviewable, Steward Notes are ready, and
+  full CI remains green.
+- Split Studio production workflow follow-ups into smaller work: board/world
+  editor ergonomics, application/claims reviewer operations, wanted lifecycle
+  outcomes, and director operations console shortcuts.
+- Expand the rendered-route privacy matrix beyond the first draft-material and
+  inactive-identity cases. Prioritize staff desks, notification surfaces,
+  application review rooms, plotting rooms, and cross-community recovery pages.
+- Decide the next Program Blueprint step: keep dry-run preview as-is, or design
+  a separate hydration plan with repository/service boundaries, duplicate
+  handling, rollback behavior, and tenant tests.
+- Continue character hub and active-face discovery only where it reduces a real
+  writer workflow: filtered queues, discovery defaults, join/reply defaults,
+  and plot/wanted handoffs.
+- Continue component consolidation opportunistically on writing surfaces and
+  Studio controls. Avoid broad template rewrites while the current batch is
+  still unmerged.
+- Thin `AppServices` only at natural seams created by feature work. Recent
+  examples are blueprint preview and material production state.
+
+## Progress Log
+
+- 2026-05-01: Started the Studio production workflow priority with wanted-hook
+  lifecycle controls. The first scoped slice lets permitted hook managers move
+  wanted hooks through open, reserved, filled, and archived states from the
+  wanted detail page while preserving archived-hook privacy for ordinary
+  viewers.
+- 2026-05-01: Started the rendered-route privacy matrix priority with
+  `docs/architecture/rendered-route-privacy-matrix.md` and a first regression
+  proving draft world materials stay staff-only on `/world`, direct material
+  routes, and Studio/material editor surfaces.
+- 2026-05-01: Hardened the application/claims review flow by routing revision
+  requests from the applications index into the review room instead of sending
+  blank revision requests, and added coverage that private staff notes and
+  review checklists stay hidden from applicants.
+- 2026-05-01: Started the character hub active-face loop with owner-only next
+  actions on character profiles. Current faces now expose reply, discovery,
+  casting, and plot-hook actions from the hub, while non-current owned faces
+  nudge writers to make the face current before using active-face defaults.
+- 2026-05-01: Extended rendered-route privacy coverage for inactive identities.
+  Member directory/profile routes and direct character routes now treat inactive
+  memberships as absent, and cross-realm character recovery ignores inactive
+  faces instead of offering a realm switch to retired cast.
+- 2026-05-01: Started Program Blueprint YAML intake as a dry-run-only Studio
+  flow. Directors can paste YAML in Studio intake, map director-friendly keys
+  into the typed blueprint contract, see validation notes and launch counts, and
+  confirm that no hydration or database changes occur yet.
+- 2026-05-01: Tightened the schema migration pattern by documenting the actual
+  current version, making the next-schema-change checklist require contiguous
+  post-baseline migrations, and adding ledger tests that prove historical
+  baseline databases advance through ordered migrations to the current version.
+- 2026-05-01: Started the paragraph/control/component consolidation pass on
+  writing surfaces by extracting shared composer view-toggle and formatting
+  toolbar macros, then reusing them across new-thread, reply, and edit-post
+  composers without changing the existing Alpine behavior or controls.
+- 2026-05-01: Started the service-facade thinning pass where recent feature work
+  created a natural boundary: Program Blueprint preview permission and parsing
+  orchestration now lives in `services/blueprints.py`, while `AppServices`
+  remains a small delegating route-facing facade.
+- 2026-05-01: Continued Studio production workflow hardening with director-only
+  world material state controls. Studio draft-material cards can now publish a
+  material, or publish a draft event as the current event while demoting the
+  previous current event; ordinary members cannot mutate draft material state.
+- 2026-05-01: Followed the steward stabilization recommendation by turning the
+  plan's backlog split into an explicit remaining-work list and moving material
+  production-state orchestration into `services/materials.py`, leaving
+  `AppServices` as a route-facing delegator.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 dependencies = [
     "bengal-chirp[config,forms,sessions,ui]>=0.5.0",
     "chirp-ui>=0.5.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/src/elbysodic/AGENTS.md
+++ b/src/elbysodic/AGENTS.md
@@ -1,0 +1,47 @@
+# Package And Tooling Steward
+
+## Steward
+
+Package steward for the installable `elbysodic` distribution, CLI entrypoint,
+application factory import surface, and local development orchestration.
+
+## Protects
+
+- The package remains a typed Python 3.14 project with `src/` layout and the
+  `elbysodic` console script.
+- `elbysodic.cli:main`, `elbysodic.web:create_app`, and `elbysodic.services`
+  exports stay boring, importable, and friendly to tests.
+- Root tools stay aligned: `pyproject.toml`, `Makefile`, `uv.lock`,
+  `changelog.d/`, and README command examples should tell the same story.
+- Local dependency overrides keep pointing at the owned Chirp stack described
+  in README.
+
+## Must Not Become
+
+- A dumping ground for product logic that belongs in services or repositories.
+- A second configuration system beside Chirp, `pyproject.toml`, and the CLI.
+- A packaging experiment that makes local setup harder than `make setup`,
+  `make install`, and `make ci`.
+
+## Documentation Ownership
+
+Owns README sections for dependency layout, local commands, running the app,
+and package-level public imports. Coordinate with `docs/AGENTS.md` when command
+or architecture descriptions change.
+
+## Local Checks
+
+- `uv run ruff check .`
+- `uv run ruff format . --check`
+- `uv run ty check src/elbysodic/ tests/`
+- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
+- For CLI changes, run a focused smoke such as `uv run elbysodic --help`.
+
+## Public Contracts And Safety
+
+- Do not rename the console script, package, or `create_app` import path without
+  updating README, tests, and downstream usage.
+- Keep CLI commands side-effect explicit: `serve` runs the app, `init-db`
+  creates schema, and `seed-demo` creates seeded demo state.
+- Do not hide dependency downloads, destructive cleanup, or database writes
+  behind innocuous commands.

--- a/src/elbysodic/blueprints/AGENTS.md
+++ b/src/elbysodic/blueprints/AGENTS.md
@@ -1,0 +1,40 @@
+# Blueprint Contract Steward
+
+## Steward
+
+Blueprint steward for `src/elbysodic/blueprints/` and the director-authored
+program starter packet contract.
+
+## Protects
+
+- Program Blueprints describe PBP hubs in director language: program, roster
+  faces, playable boards, materials, wanted hooks, and safe theme tokens.
+- Validation errors stay human-readable for directors and import previews.
+- Hydration paths go through repository/service boundaries, not ad hoc writes.
+- Seed data and future YAML imports remain aligned to one shared shape.
+
+## Must Not Become
+
+- A live state store or replacement for normal staff tools.
+- A free-form CSS/theme engine.
+- A generic CMS import format without roleplay-specific shape.
+
+## Documentation Ownership
+
+Owns `docs/product/program-blueprints.md` and should update it with any
+contract, validation, hydration, or allowed-token change.
+
+## Local Checks
+
+- `uv run pytest tests/test_program_blueprints.py -q --tb=short`
+- `uv run pytest tests/test_tenant_repository.py -q --tb=short` when hydration
+  touches repositories or tenant boundaries.
+- `uv run ty check src/elbysodic/ tests/`
+
+## Public Contracts And Safety
+
+- Do not allow raw CSS, script tags, external font URLs, or layout-breaking
+  theme controls in blueprint input.
+- Keep created objects scoped to one community and one intentional owner.
+- Validate duplicate slugs, missing starter content, unknown board/wanted
+  types, invalid theme tokens, and broken material references before hydration.

--- a/src/elbysodic/blueprints/__init__.py
+++ b/src/elbysodic/blueprints/__init__.py
@@ -10,9 +10,11 @@ from elbysodic.blueprints.programs import (
     BlueprintValidationError,
     BlueprintWanted,
     ProgramBlueprint,
+    ProgramBlueprintPreview,
     blueprint_theme_tokens,
     ensure_valid_program_blueprint,
     ensure_valid_program_blueprints,
+    preview_program_blueprint_yaml,
     validate_program_blueprint,
     validate_program_blueprints,
 )
@@ -27,9 +29,11 @@ __all__ = [
     "BlueprintValidationError",
     "BlueprintWanted",
     "ProgramBlueprint",
+    "ProgramBlueprintPreview",
     "blueprint_theme_tokens",
     "ensure_valid_program_blueprint",
     "ensure_valid_program_blueprints",
+    "preview_program_blueprint_yaml",
     "validate_program_blueprint",
     "validate_program_blueprints",
 ]

--- a/src/elbysodic/blueprints/programs.py
+++ b/src/elbysodic/blueprints/programs.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from typing import Any
+
+import yaml
 
 from elbysodic.domain.boards import BOARD_KINDS
 
@@ -107,6 +109,76 @@ class BlueprintValidationError(ValueError):
     def __init__(self, errors: Sequence[str]) -> None:
         self.errors = tuple(errors)
         super().__init__("\n".join(self.errors))
+
+
+@dataclass(frozen=True, slots=True)
+class ProgramBlueprintPreview:
+    blueprint: ProgramBlueprint | None
+    errors: tuple[str, ...]
+
+    @property
+    def is_valid(self) -> bool:
+        return self.blueprint is not None and not self.errors
+
+    @property
+    def program_count(self) -> int:
+        return 1 if self.blueprint is not None else 0
+
+    @property
+    def character_count(self) -> int:
+        return len(self.blueprint.characters) if self.blueprint is not None else 0
+
+    @property
+    def board_count(self) -> int:
+        return len(self.blueprint.boards) if self.blueprint is not None else 0
+
+    @property
+    def material_count(self) -> int:
+        return len(self.blueprint.materials) if self.blueprint is not None else 0
+
+    @property
+    def wanted_count(self) -> int:
+        return len(self.blueprint.wanted) if self.blueprint is not None else 0
+
+    @property
+    def theme_count(self) -> int:
+        return 1 if self.blueprint is not None and self.blueprint.theme is not None else 0
+
+
+def preview_program_blueprint_yaml(source: str) -> ProgramBlueprintPreview:
+    """Parse and validate director-authored YAML without hydrating anything."""
+
+    if not source.strip():
+        return ProgramBlueprintPreview(None, ("Blueprint YAML is required.",))
+    try:
+        loaded = yaml.safe_load(source)
+    except yaml.YAMLError as exc:
+        return ProgramBlueprintPreview(
+            None,
+            (f"Blueprint YAML could not be parsed: {exc}",),
+        )
+    errors: list[str] = []
+    root = _mapping(loaded, "blueprint", errors)
+    if root is None:
+        return ProgramBlueprintPreview(None, tuple(errors))
+    if root.get("elbysodic_blueprint") != 1:
+        errors.append("elbysodic_blueprint must be 1")
+    program_data = _mapping(root.get("program"), "program", errors) or {}
+    role_data = _mapping(program_data.get("role"), "program.role", errors) or {}
+    blueprint = ProgramBlueprint(
+        slug=_text(program_data.get("slug")),
+        name=_text(program_data.get("name")),
+        role_slug=_field(role_data, "slug"),
+        role_name=_field(role_data, "name"),
+        is_admin=bool(role_data.get("is_admin")),
+        characters=_characters_from_yaml(root.get("characters"), errors),
+        boards=_boards_from_yaml(root.get("boards"), errors),
+        materials=_materials_from_yaml(root.get("materials"), errors),
+        wanted=_wanted_from_yaml(root.get("wanted", ()), errors),
+        theme=_theme_from_yaml(root.get("theme"), errors),
+    )
+    errors.extend(validate_program_blueprint(blueprint))
+    return ProgramBlueprintPreview(blueprint, tuple(errors))
 
 
 def validate_program_blueprint(blueprint: ProgramBlueprint) -> tuple[str, ...]:
@@ -299,3 +371,134 @@ def _duplicate_slug_errors(label: str, slugs: Iterable[str]) -> list[str]:
             duplicates.add(slug)
         seen.add(slug)
     return [f"{label} contains duplicate slug: {slug}" for slug in sorted(duplicates)]
+
+
+def _mapping(value: object, path: str, errors: list[str]) -> dict[str, Any] | None:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    errors.append(f"{path} must be a mapping")
+    return None
+
+
+def _mapping_items(value: object, path: str, errors: list[str]) -> tuple[dict[str, Any], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        errors.append(f"{path} must be a list")
+        return ()
+    items: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        mapping = _mapping(item, f"{path}[{index}]", errors)
+        if mapping is not None:
+            items.append(mapping)
+    return tuple(items)
+
+
+def _text(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _field(mapping: dict[str, Any], key: str) -> str:
+    return _text(mapping.get(key))
+
+
+def _characters_from_yaml(value: object, errors: list[str]) -> tuple[BlueprintCharacter, ...]:
+    return tuple(
+        BlueprintCharacter(
+            slug=_field(item, "slug"),
+            name=_field(item, "name"),
+            summary=_field(item, "summary"),
+            tagline=_field(item, "tagline"),
+        )
+        for item in _mapping_items(value, "characters", errors)
+    )
+
+
+def _boards_from_yaml(value: object, errors: list[str]) -> tuple[BlueprintBoard, ...]:
+    return tuple(
+        BlueprintBoard(
+            slug=_field(item, "slug"),
+            name=_field(item, "name"),
+            board_kind=_field(item, "kind") or _field(item, "board_kind"),
+            tagline=_field(item, "tagline"),
+            description=_field(item, "description"),
+        )
+        for item in _mapping_items(value, "boards", errors)
+    )
+
+
+def _materials_from_yaml(value: object, errors: list[str]) -> tuple[BlueprintMaterial, ...]:
+    return tuple(
+        BlueprintMaterial(
+            slug=_field(item, "slug"),
+            title=_field(item, "title"),
+            material_type=_field(item, "type") or _field(item, "material_type"),
+            summary=_field(item, "summary"),
+            body=_field(item, "body"),
+        )
+        for item in _mapping_items(value, "materials", errors)
+    )
+
+
+def _wanted_from_yaml(value: object, errors: list[str]) -> tuple[BlueprintWanted, ...]:
+    return tuple(
+        BlueprintWanted(
+            slug=_field(item, "slug"),
+            title=_field(item, "title"),
+            wanted_type=_field(item, "type") or _field(item, "wanted_type"),
+            summary=_field(item, "summary"),
+            body=_field(item, "body"),
+            related_material_slug=_field(item, "related_material")
+            or _field(item, "related_material_slug"),
+        )
+        for item in _mapping_items(value, "wanted", errors)
+    )
+
+
+def _theme_from_yaml(value: object, errors: list[str]) -> BlueprintTheme | None:
+    if value is None:
+        return None
+    theme = _mapping(value, "theme", errors)
+    if theme is None:
+        return None
+    typography = _mapping(theme.get("typography"), "theme.typography", errors) or {}
+    light = _theme_mode_from_yaml(theme.get("light"), "theme.light", errors)
+    dark = _theme_mode_from_yaml(theme.get("dark"), "theme.dark", errors)
+    return BlueprintTheme(
+        slug=_field(theme, "slug"),
+        name=_field(theme, "name"),
+        typography=BlueprintTypography(
+            display=_field(typography, "display") or "system",
+            body=_field(typography, "body") or "system",
+            mono=_field(typography, "mono") or "mono",
+        ),
+        light=light,
+        dark=dark,
+        radius=_field(theme, "radius") or "sm",
+        density=_field(theme, "density") or "calm",
+        texture=_field(theme, "texture") or "none",
+    )
+
+
+def _theme_mode_from_yaml(
+    value: object,
+    path: str,
+    errors: list[str],
+) -> BlueprintThemeMode:
+    mode = _mapping(value, path, errors) or {}
+    return BlueprintThemeMode(
+        bg=_field(mode, "bg"),
+        bg_subtle=_field(mode, "bg_subtle"),
+        surface=_field(mode, "surface"),
+        surface_elevated=_field(mode, "surface_elevated"),
+        border=_field(mode, "border"),
+        text=_field(mode, "text"),
+        text_muted=_field(mode, "text_muted"),
+        accent=_field(mode, "accent"),
+        accent_hover=_field(mode, "accent_hover"),
+        accent_dim=_field(mode, "accent_dim"),
+        accent_secondary=_field(mode, "accent_secondary"),
+        success=_field(mode, "success"),
+        warning=_field(mode, "warning"),
+        error=_field(mode, "error"),
+    )

--- a/src/elbysodic/db/AGENTS.md
+++ b/src/elbysodic/db/AGENTS.md
@@ -1,0 +1,40 @@
+# Storage And Migration Steward
+
+## Steward
+
+Storage steward for `src/elbysodic/db/`: SQLite schema, migrations,
+repositories, seed data, and tenant-boundary persistence checks.
+
+## Protects
+
+- Fresh schema and migrations describe the same current database shape.
+- Repository methods keep `community_id` in reads and writes for product rows.
+- Boundary errors are raised before cross-community joins or wrong-membership
+  character actions are persisted.
+- Demo seed data remains idempotent and useful for browser QA.
+
+## Must Not Become
+
+- A collection of page-specific SQL shortcuts.
+- A migration graveyard with non-idempotent or untested upgrades.
+- A cache for service-layer decisions that should remain explicit workflows.
+
+## Documentation Ownership
+
+Owns `docs/architecture/migrations.md` with the docs steward, and co-owns
+tenant and security-boundary docs when schema or repository behavior changes.
+
+## Local Checks
+
+- `uv run pytest tests/test_tenant_repository.py -q --tb=short`
+- `uv run pytest -q --tb=short` for schema changes.
+- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
+- Add migration tests that start from an older shape when changing schema.
+
+## Public Contracts And Safety
+
+- New product tables need `community_id` unless truly global infrastructure.
+- Prefer partial unique indexes for nullable identity variants.
+- Do not rewrite post history, read state, watches, revisions, or notification
+  targets during thread lifecycle changes.
+- Keep repository APIs tenant-aware even while the MVP seeds one community.

--- a/src/elbysodic/db/repositories/characters.py
+++ b/src/elbysodic/db/repositories/characters.py
@@ -178,7 +178,11 @@ class CharacterRepositoryMixin(IdentityRepositoryMixin):
                 communities.updated_at
             FROM communities
             JOIN characters ON characters.community_id = communities.id
+            JOIN community_memberships
+              ON community_memberships.community_id = characters.community_id
+             AND community_memberships.id = characters.membership_id
             WHERE characters.slug = ?
+              AND community_memberships.is_active = 1
             ORDER BY communities.name, communities.id
             """,
             (slug,),

--- a/src/elbysodic/domain/AGENTS.md
+++ b/src/elbysodic/domain/AGENTS.md
@@ -1,0 +1,45 @@
+# Domain Model Steward
+
+## Steward
+
+Domain model steward for `src/elbysodic/domain/` and the typed records and enum
+vocabulary that name Elbysodic's product primitives.
+
+## Protects
+
+- Community, membership, character, board, thread, post, material, wanted,
+  plotting, application, claim, reserve, and interaction records remain
+  explicit and typed.
+- Board kind, sidebar section, and realm vocabulary match navigation and
+  product docs.
+- Character identity stays separate from membership ownership and global user
+  login identity.
+- New structured primitives start with tenant scope and intentional authorship.
+
+## Must Not Become
+
+- A persistence layer with SQL, connection handling, or database defaults.
+- A service layer with permission decisions or workflow side effects.
+- A generic forum ontology that forgets PBP-specific concepts.
+
+## Documentation Ownership
+
+Co-owns `docs/architecture/primitives.md`,
+`docs/architecture/multi-tenancy.md`, and product vocabulary references that
+depend on core model names.
+
+## Local Checks
+
+- `uv run ty check src/elbysodic/ tests/`
+- `uv run pytest tests/test_tenant_repository.py -q --tb=short`
+- Add or update focused tests when a model change changes repository rows,
+  read models, or rendered pages.
+
+## Public Contracts And Safety
+
+- Do not introduce global characters or user-level staff power.
+- Keep `community_id` explicit on product records.
+- If a flow can involve both writer and face, model membership for ownership
+  and character for public story context.
+- Coordinate enum or dataclass renames with repositories, services, templates,
+  docs, and tests in the same change.

--- a/src/elbysodic/services/AGENTS.md
+++ b/src/elbysodic/services/AGENTS.md
@@ -1,0 +1,43 @@
+# Service Layer Steward
+
+## Steward
+
+Service layer steward for `src/elbysodic/services/`: workflow commands, policy
+checks, request identity resolution, read models, and product orchestration.
+
+## Protects
+
+- Page handlers call services instead of reaching around them into ad hoc SQL.
+- Services accept or resolve community, membership, role, and active-face
+  context deliberately.
+- Permission decisions route through named policy helpers in
+  `services/policies.py`.
+- Read models stay shaped for PBP workflows: writing queues, cast faces,
+  wanted interest, plotting rooms, materials, notifications, and Studio tools.
+
+## Must Not Become
+
+- A thin pass-through that leaves tenant checks to templates.
+- A hidden global singleton model for current community or current user.
+- A place where HTML, CSS, route wiring, or SQL schema details take over.
+
+## Documentation Ownership
+
+Co-owns architecture docs for security boundaries, request identity, and
+service/repository separation. Update product docs when a workflow changes
+visible writer or director behavior.
+
+## Local Checks
+
+- `uv run pytest tests/test_forum_slice.py -q --tb=short`
+- `uv run pytest tests/test_policies.py -q --tb=short`
+- `uv run pytest tests/test_tenant_repository.py -q --tb=short`
+- `uv run ty check src/elbysodic/ tests/`
+
+## Public Contracts And Safety
+
+- Validate community ownership before connecting two scoped objects.
+- Validate membership and character ownership for writer actions.
+- Keep inactive memberships and non-staff roles out of staff workflows.
+- Preserve notification, watch, read-state, and revision-history semantics when
+  editing posting or thread workflows.

--- a/src/elbysodic/services/blueprints.py
+++ b/src/elbysodic/services/blueprints.py
@@ -1,0 +1,15 @@
+"""Service boundary for director-authored Program Blueprint previews."""
+
+from __future__ import annotations
+
+from elbysodic.blueprints import ProgramBlueprintPreview, preview_program_blueprint_yaml
+from elbysodic.services import policies
+from elbysodic.services.read_models import ForumView
+
+
+def preview_program_blueprint(viewer: ForumView, source: str) -> ProgramBlueprintPreview:
+    if not policies.can_manage_world(viewer.membership, viewer.role):
+        raise PermissionError(
+            f"membership {viewer.membership.id} cannot preview program blueprints"
+        )
+    return preview_program_blueprint_yaml(source)

--- a/src/elbysodic/services/casting.py
+++ b/src/elbysodic/services/casting.py
@@ -29,6 +29,8 @@ from elbysodic.services.read_models import (
 )
 from elbysodic.services.timestamps import timestamp_label
 
+WANTED_STATUSES: tuple[str, ...] = ("open", "reserved", "filled", "archived")
+
 
 class CastingReadRepository(FacetReadRepository, PostViewRepository, Protocol):
     def get_character(self, community_id: int, character_id: int) -> Character: ...
@@ -212,7 +214,8 @@ def read_wanted_ad(
     wanted_slug: str,
 ) -> WantedAdDetail:
     wanted_ad = repo.get_wanted_ad_by_slug(viewer.community.id, wanted_slug)
-    if wanted_ad.status == "archived":
+    can_manage = can_manage_wanted_ad(viewer, wanted_ad)
+    if wanted_ad.status == "archived" and not can_manage:
         raise LookupError(f"wanted ad not found in community {viewer.community.id}: {wanted_slug}")
     facets = facet_tags(
         repo,
@@ -307,8 +310,7 @@ def read_wanted_ad(
             and not is_created_by_viewer
         ),
         is_created_by_viewer=is_created_by_viewer,
-        can_manage=is_created_by_viewer
-        or policies.can_manage_casting(viewer.membership, viewer.role),
+        can_manage=can_manage,
         rendered_body=render_prose_body(
             wanted_ad.body,
             mentions=post_mention_links(repo, viewer.community.id),
@@ -316,6 +318,27 @@ def read_wanted_ad(
         type_label=wanted_type_label(wanted_ad.wanted_type),
         related_ads=related[:4],
     )
+
+
+def update_wanted_ad_lifecycle_status(
+    repo: CastingRepository,
+    viewer: ForumView,
+    wanted_slug: str,
+    *,
+    status: str,
+) -> WantedAd:
+    wanted_ad = repo.get_wanted_ad_by_slug(viewer.community.id, wanted_slug)
+    if not can_manage_wanted_ad(viewer, wanted_ad):
+        raise PermissionError(
+            f"membership {viewer.membership.id} cannot manage wanted hook {wanted_ad.id}"
+        )
+    normalized_status = status.strip().lower()
+    if normalized_status not in WANTED_STATUSES:
+        allowed = ", ".join(WANTED_STATUSES)
+        raise ValueError(f"wanted hook status must be one of: {allowed}")
+    if wanted_ad.status == normalized_status:
+        return wanted_ad
+    return repo.update_wanted_ad_status(viewer.community.id, wanted_ad.id, normalized_status)
 
 
 def express_wanted_interest(
@@ -546,6 +569,13 @@ def character_reserve_view(
             else None
         ),
         created_at_label=timestamp_label(reserve.created_at),
+    )
+
+
+def can_manage_wanted_ad(viewer: ForumView, wanted_ad: WantedAd) -> bool:
+    return wanted_ad.creator_membership_id == viewer.membership.id or policies.can_manage_casting(
+        viewer.membership,
+        viewer.role,
     )
 
 

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -6,6 +6,7 @@ import os
 import re
 from pathlib import Path
 
+from elbysodic.blueprints import ProgramBlueprintPreview
 from elbysodic.db import ForumRepository, connect, create_schema
 from elbysodic.db.seed import DemoSeed, seed_demo_forum
 from elbysodic.domain.boards import (
@@ -36,6 +37,7 @@ from elbysodic.domain.models import (
     Role,
     SidebarSectionConfig,
     Thread,
+    WantedAd,
     WantedAdInterest,
 )
 from elbysodic.services import policies
@@ -55,6 +57,7 @@ from elbysodic.services.applications import (
 )
 from elbysodic.services.applications import update_application_draft as _update_application_draft
 from elbysodic.services.applications import update_application_review as _update_application_review
+from elbysodic.services.blueprints import preview_program_blueprint as _preview_program_blueprint
 from elbysodic.services.casting import casting_desk as _casting_desk
 from elbysodic.services.casting import (
     create_reserve_for_wanted_interest as _create_reserve_for_wanted_interest,
@@ -65,6 +68,9 @@ from elbysodic.services.casting import (
 from elbysodic.services.casting import express_wanted_interest as _express_wanted_interest
 from elbysodic.services.casting import read_wanted_ad as _read_wanted_ad
 from elbysodic.services.casting import reserve_wanted_interest as _reserve_wanted_interest
+from elbysodic.services.casting import (
+    update_wanted_ad_lifecycle_status as _update_wanted_ad_lifecycle_status,
+)
 from elbysodic.services.casting import wanted_ad_summary as _wanted_ad_summary
 from elbysodic.services.casting import wanted_board as _wanted_board
 from elbysodic.services.claims import (
@@ -102,6 +108,9 @@ from elbysodic.services.materials import (
 )
 from elbysodic.services.materials import material_detail as _material_detail
 from elbysodic.services.materials import material_summary as _material_summary
+from elbysodic.services.materials import (
+    update_material_production_state as _update_material_production_state,
+)
 from elbysodic.services.notifications import (
     mark_all_notifications_read as _mark_all_notifications_read,
 )
@@ -1035,6 +1044,9 @@ class AppServices:
             claims=_claims_directory(self.repo, viewer),
         )
 
+    def preview_program_blueprint(self, source: str) -> ProgramBlueprintPreview:
+        return _preview_program_blueprint(self.viewer(), source)
+
     def update_board_taxonomy(
         self,
         board_id: int,
@@ -1364,6 +1376,21 @@ class AppServices:
             is_featured=is_featured,
         )
 
+    def update_material_production_state(
+        self,
+        material_slug: str,
+        *,
+        status: str,
+        is_featured: bool | None = None,
+    ) -> Material:
+        return _update_material_production_state(
+            self.repo,
+            self.viewer(),
+            material_slug,
+            status=status,
+            is_featured=is_featured,
+        )
+
     def wanted_ads(self) -> WantedBoard:
         return _wanted_board(self.repo, self.viewer())
 
@@ -1397,6 +1424,14 @@ class AppServices:
         interest_id: int,
     ) -> WantedAdInterest:
         return _reserve_wanted_interest(self.repo, self.viewer(), wanted_slug, interest_id)
+
+    def update_wanted_ad_lifecycle_status(self, wanted_slug: str, *, status: str) -> WantedAd:
+        return _update_wanted_ad_lifecycle_status(
+            self.repo,
+            self.viewer(),
+            wanted_slug,
+            status=status,
+        )
 
     def create_reserve_for_wanted_interest(
         self,

--- a/src/elbysodic/services/identity.py
+++ b/src/elbysodic/services/identity.py
@@ -202,6 +202,10 @@ def character_profile(
 ) -> CharacterProfile:
     character = repo.get_character_by_slug(viewer.community.id, character_slug)
     owner_membership = repo.get_membership(viewer.community.id, character.membership_id)
+    if not owner_membership.is_active:
+        raise LookupError(
+            f"character not found in community {viewer.community.id}: {character_slug}"
+        )
     can_manage = character.membership_id == viewer.membership.id
     activity = character_activity(repo, viewer, character)
     character_facets = repo.list_character_facets(viewer.community.id, character.id)

--- a/src/elbysodic/services/materials.py
+++ b/src/elbysodic/services/materials.py
@@ -20,6 +20,7 @@ from elbysodic.services.facets import FacetReadRepository, facet_tags
 from elbysodic.services.markup import post_snippet, render_prose_body
 from elbysodic.services.posts import PostViewRepository, post_mention_links
 from elbysodic.services.read_models import (
+    MATERIAL_STATUSES,
     BoardSummary,
     ContinuityBeat,
     DiscoveryThreadResult,
@@ -41,6 +42,22 @@ class MaterialSummaryRepository(FacetReadRepository, Protocol):
 
 
 class MaterialReadRepository(MaterialSummaryRepository, PostViewRepository, Protocol):
+    def get_material_by_slug(self, community_id: int, slug: str) -> Material: ...
+
+    def update_material(
+        self,
+        community_id: int,
+        material_id: int,
+        *,
+        title: str,
+        material_type: str,
+        summary: str,
+        body: str,
+        status: str = "published",
+        sort_order: int = 0,
+        is_featured: bool = False,
+    ) -> Material: ...
+
     def list_materials(self, community_id: int, *, status: str | None = None) -> list[Material]: ...
 
     def list_boards(self, community_id: int) -> list[Board]: ...
@@ -136,6 +153,49 @@ def material_detail(
             related_wanted_ads,
         ),
         can_manage=policies.can_manage_world(viewer.membership, viewer.role),
+    )
+
+
+def update_material_production_state(
+    repo: MaterialReadRepository,
+    viewer: ForumView,
+    material_slug: str,
+    *,
+    status: str,
+    is_featured: bool | None = None,
+) -> Material:
+    if not policies.can_manage_world(viewer.membership, viewer.role):
+        raise PermissionError(f"membership {viewer.membership.id} cannot manage world materials")
+    material = repo.get_material_by_slug(viewer.community.id, material_slug)
+    cleaned_status = status.strip()
+    if cleaned_status not in MATERIAL_STATUSES:
+        raise ValueError("choose a supported material status")
+    next_featured = material.is_featured if is_featured is None else is_featured
+    if material.material_type == "event" and next_featured:
+        for event in repo.list_materials(viewer.community.id, status=None):
+            if event.id == material.id or event.material_type != "event" or not event.is_featured:
+                continue
+            repo.update_material(
+                viewer.community.id,
+                event.id,
+                title=event.title,
+                material_type=event.material_type,
+                summary=event.summary,
+                body=event.body,
+                status=event.status,
+                sort_order=event.sort_order,
+                is_featured=False,
+            )
+    return repo.update_material(
+        viewer.community.id,
+        material.id,
+        title=material.title,
+        material_type=material.material_type,
+        summary=material.summary,
+        body=material.body,
+        status=cleaned_status,
+        sort_order=material.sort_order,
+        is_featured=next_featured,
     )
 
 

--- a/src/elbysodic/web/AGENTS.md
+++ b/src/elbysodic/web/AGENTS.md
@@ -1,0 +1,47 @@
+# Rendering And UI Steward
+
+## Steward
+
+Rendering and UI steward for `src/elbysodic/web/`: Chirp app setup,
+filesystem pages, templates, static assets, navigation, composer behavior, and
+Chirp-UI integration.
+
+## Protects
+
+- Server-rendered Chirp pages stay the default, with small progressive
+  enhancement islands for focused interactions.
+- Repeated PBP UI concepts move into `web/pages/_components/` before becoming
+  page-local patterns.
+- Elbysodic-specific design tokens and styles stay in
+  `web/static/elbysodic-theme.css`.
+- Composer, previews, drafts, active face, and long-form post readability stay
+  ergonomic for real writing sessions.
+
+## Must Not Become
+
+- A single-page app or client-state rewrite.
+- A generic dashboard skin that visually outshouts the community's world.
+- A tangle of page-local CSS for shared PBP concepts.
+
+## Documentation Ownership
+
+Owns product docs for information hierarchy, control topology, navigation,
+paragraph rhythm, and notices whenever templates or static assets change those
+contracts.
+
+## Local Checks
+
+- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
+- `uv run pytest tests/test_forum_slice.py -q --tb=short`
+- `uv run pytest tests/test_markup.py -q --tb=short` for composer/prose changes.
+- Browser QA on port 8001 for substantial layout, navigation, or interaction
+  changes.
+
+## Public Contracts And Safety
+
+- Keep controls visible, labeled, keyboard reachable, and attached to the
+  object or workflow they affect.
+- Do not render unsafe post markup; preserve preview and final render parity.
+- Keep route/navigation changes aligned with `docs/product/navigation-menus.md`.
+- Avoid leaking private/staff data into pages, sidebars, shell counts, or
+  client-side state.

--- a/src/elbysodic/web/pages/_components/composer.html
+++ b/src/elbysodic/web/pages/_components/composer.html
@@ -1,0 +1,27 @@
+{% def composer_view_toggle(name) %}
+<div class="elbysodic-composer-toggle" role="radiogroup" aria-label="Composer view">
+  <label>
+    <input type="radio"
+           name="{{ name }}"
+           value="write"
+           x-model="viewMode">
+    <span>Write</span>
+  </label>
+  <label>
+    <input type="radio"
+           name="{{ name }}"
+           value="preview"
+           x-model="viewMode">
+    <span>Preview</span>
+  </label>
+</div>
+{% end %}
+
+{% def composer_toolbar(field_id) %}
+<div class="elbysodic-composer-toolbar" role="toolbar" aria-label="Formatting">
+  <button type="button" class="elbysodic-composer-tool" title="Bold" aria-label="Bold" @click="applyFormat('bold', '{{ field_id }}')">B</button>
+  <button type="button" class="elbysodic-composer-tool" title="Italic" aria-label="Italic" @click="applyFormat('italic', '{{ field_id }}')">I</button>
+  <button type="button" class="elbysodic-composer-tool" title="Quote" aria-label="Quote" @click="applyFormat('quote', '{{ field_id }}')">&gt;</button>
+  <button type="button" class="elbysodic-composer-tool" title="Link" aria-label="Link" @click="applyFormat('link', '{{ field_id }}')">[]</button>
+</div>
+{% end %}

--- a/src/elbysodic/web/pages/applications/page.html
+++ b/src/elbysodic/web/pages/applications/page.html
@@ -75,11 +75,9 @@
           Accept
         </button>
       </form>
-      <form method="post" hx-boost="false">
-        <input type="hidden" name="intent" value="request_revision">
-        <input type="hidden" name="character_slug" value="{{ item.character.slug }}">
-        <button type="submit" class="chirpui-btn chirpui-btn--secondary">Request revisions</button>
-      </form>
+      <a class="chirpui-btn chirpui-btn--secondary" href="/applications/{{ item.character.slug }}">
+        Request revisions
+      </a>
       {% end %}
     </div>
   </div>

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.html
@@ -2,6 +2,7 @@
   {% from "chirpui/badge.html" import badge %}
   {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
   {% from "chirpui/surface.html" import surface %}
+  {% from "_components/composer.html" import composer_toolbar, composer_view_toggle %}
 {% end %}
 
 {% block page_root %}
@@ -190,31 +191,11 @@
           <h3 id="thread-writing">Writing</h3>
           <p class="elbysodic-copy-helper">Drafts stay in this browser.</p>
         </div>
-        <div class="elbysodic-composer-toggle" role="radiogroup" aria-label="Composer view">
-          <label>
-            <input type="radio"
-                   name="thread-composer-view"
-                   value="write"
-                   x-model="viewMode">
-            <span>Write</span>
-          </label>
-          <label>
-            <input type="radio"
-                   name="thread-composer-view"
-                   value="preview"
-                   x-model="viewMode">
-            <span>Preview</span>
-          </label>
-        </div>
+        {{ composer_view_toggle("thread-composer-view") }}
       </div>
       <div class="elbysodic-composer-body" x-show="!previewMode">
         <label class="chirpui-field__label" for="thread-body">Opening post</label>
-        <div class="elbysodic-composer-toolbar" role="toolbar" aria-label="Formatting">
-          <button type="button" class="elbysodic-composer-tool" title="Bold" aria-label="Bold" @click="applyFormat('bold', 'thread-body')">B</button>
-          <button type="button" class="elbysodic-composer-tool" title="Italic" aria-label="Italic" @click="applyFormat('italic', 'thread-body')">I</button>
-          <button type="button" class="elbysodic-composer-tool" title="Quote" aria-label="Quote" @click="applyFormat('quote', 'thread-body')">&gt;</button>
-          <button type="button" class="elbysodic-composer-tool" title="Link" aria-label="Link" @click="applyFormat('link', 'thread-body')">[]</button>
-        </div>
+        {{ composer_toolbar("thread-body") }}
       <textarea id="thread-body"
                 class="chirpui-field__input"
                 name="body"

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
@@ -2,6 +2,7 @@
   {% from "chirpui/badge.html" import badge %}
   {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
   {% from "chirpui/surface.html" import surface %}
+  {% from "_components/composer.html" import composer_toolbar, composer_view_toggle %}
   {% from "_components/facets.html" import facet_pills %}
   {% from "_components/posts.html" import post_frame %}
   {% from "_components/ui.html" import cast_faces, event_bridge, scene_state_badges %}
@@ -426,31 +427,11 @@
             <h3 id="reply-writing">Writing</h3>
             <p class="elbysodic-copy-helper">Drafts stay in this browser.</p>
           </div>
-          <div class="elbysodic-composer-toggle" role="radiogroup" aria-label="Composer view">
-            <label>
-              <input type="radio"
-                     name="reply-composer-view"
-                     value="write"
-                     x-model="viewMode">
-              <span>Write</span>
-            </label>
-            <label>
-              <input type="radio"
-                     name="reply-composer-view"
-                     value="preview"
-                     x-model="viewMode">
-              <span>Preview</span>
-            </label>
-          </div>
+          {{ composer_view_toggle("reply-composer-view") }}
         </div>
         <div class="elbysodic-composer-body" x-show="!previewMode">
           <label class="chirpui-visually-hidden" for="reply-body">Reply body</label>
-          <div class="elbysodic-composer-toolbar" role="toolbar" aria-label="Formatting">
-            <button type="button" class="elbysodic-composer-tool" title="Bold" aria-label="Bold" @click="applyFormat('bold', 'reply-body')">B</button>
-            <button type="button" class="elbysodic-composer-tool" title="Italic" aria-label="Italic" @click="applyFormat('italic', 'reply-body')">I</button>
-            <button type="button" class="elbysodic-composer-tool" title="Quote" aria-label="Quote" @click="applyFormat('quote', 'reply-body')">&gt;</button>
-            <button type="button" class="elbysodic-composer-tool" title="Link" aria-label="Link" @click="applyFormat('link', 'reply-body')">[]</button>
-          </div>
+          {{ composer_toolbar("reply-body") }}
           <textarea id="reply-body"
                     name="body"
                     class="chirpui-field__input"

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.html
@@ -2,6 +2,7 @@
   {% from "chirpui/badge.html" import badge %}
   {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
   {% from "chirpui/surface.html" import surface %}
+  {% from "_components/composer.html" import composer_toolbar, composer_view_toggle %}
 {% end %}
 
 {% block page_root %}
@@ -54,30 +55,10 @@
     {% if error %}
     <p class="chirpui-field__error">{{ error }}</p>
     {% end %}
-    <div class="elbysodic-composer-toggle" role="radiogroup" aria-label="Composer view">
-      <label>
-        <input type="radio"
-               name="edit-post-composer-view"
-               value="write"
-               x-model="viewMode">
-        <span>Write</span>
-      </label>
-      <label>
-        <input type="radio"
-               name="edit-post-composer-view"
-               value="preview"
-               x-model="viewMode">
-        <span>Preview</span>
-      </label>
-    </div>
+    {{ composer_view_toggle("edit-post-composer-view") }}
     <div class="elbysodic-composer-body" x-show="!previewMode">
       <label class="chirpui-field__label" for="edit-post-body">Post body</label>
-      <div class="elbysodic-composer-toolbar" role="toolbar" aria-label="Formatting">
-        <button type="button" class="elbysodic-composer-tool" title="Bold" aria-label="Bold" @click="applyFormat('bold', 'edit-post-body')">B</button>
-        <button type="button" class="elbysodic-composer-tool" title="Italic" aria-label="Italic" @click="applyFormat('italic', 'edit-post-body')">I</button>
-        <button type="button" class="elbysodic-composer-tool" title="Quote" aria-label="Quote" @click="applyFormat('quote', 'edit-post-body')">&gt;</button>
-        <button type="button" class="elbysodic-composer-tool" title="Link" aria-label="Link" @click="applyFormat('link', 'edit-post-body')">[]</button>
-      </div>
+      {{ composer_toolbar("edit-post-body") }}
       <textarea id="edit-post-body"
                 class="chirpui-field__input"
                 name="body"

--- a/src/elbysodic/web/pages/characters/{character_slug}/page.html
+++ b/src/elbysodic/web/pages/characters/{character_slug}/page.html
@@ -160,6 +160,49 @@
   </section>
   {% end %}
 
+  {% if profile.can_manage %}
+  {% call surface(variant="elevated") %}
+  <section class="chirpui-stack chirpui-stack--md" aria-labelledby="face-next-actions-heading">
+    <div class="chirpui-cluster chirpui-cluster--between">
+      <div>
+        <p class="elbysodic-section-kicker">Next actions</p>
+        <h2 id="face-next-actions-heading">{{ profile.character.name }} as your working face</h2>
+      </div>
+      {% if profile.is_default %}
+      {{ badge("active-face defaults on", variant="success") }}
+      {% else %}
+      {{ badge("set current for discovery", variant="warning") }}
+      {% end %}
+    </div>
+    <div class="elbysodic-profile-section-actions">
+      {% if profile.activity.needs_reply %}
+      {% set next_reply = profile.activity.needs_reply[0] %}
+      <a class="chirpui-btn chirpui-btn--primary"
+         href="/boards/{{ next_reply.board.slug }}/threads/{{ next_reply.thread.slug }}{{ "#" ~ next_reply.jump_post.anchor if next_reply.jump_post else "" }}">
+        Reply as {{ profile.character.name }}
+      </a>
+      {% else %}
+      <a class="chirpui-btn chirpui-btn--secondary" href="/my/threads?character={{ profile.character.slug }}">
+        Open {{ profile.character.name }}'s queue
+      </a>
+      {% end %}
+      {% if profile.is_default %}
+      <a class="chirpui-btn chirpui-btn--secondary" href="/discover">Find play for {{ profile.character.name }}</a>
+      <a class="chirpui-btn chirpui-btn--secondary" href="/casting">Casting as {{ profile.character.name }}</a>
+      {% else %}
+      <form method="post" hx-boost="false">
+        <input type="hidden" name="intent" value="set_default">
+        <button type="submit" class="chirpui-btn chirpui-btn--secondary">
+          Make {{ profile.character.name }} current
+        </button>
+      </form>
+      {% end %}
+      <a class="chirpui-btn chirpui-btn--secondary" href="#new-plot-hook">Publish plot hook</a>
+    </div>
+  </section>
+  {% end %}
+  {% end %}
+
   <section id="plotter" class="chirpui-stack chirpui-stack--md">
     {% call section_header("Plotter") %}
     Character hooks, wanted hooks, and story invitations orbiting this face.

--- a/src/elbysodic/web/pages/studio/intake/page.html
+++ b/src/elbysodic/web/pages/studio/intake/page.html
@@ -52,6 +52,63 @@
   {% end %}
   {% end %}
 
+  {% if studio.can_manage %}
+  {% call surface(variant="elevated") %}
+  <section class="chirpui-stack chirpui-stack--md" aria-labelledby="program-blueprint-preview">
+    <div>
+      <p class="elbysodic-kicker">Program Blueprint</p>
+      <h2 id="program-blueprint-preview">Dry-run YAML intake</h2>
+      <p class="elbysodic-copy-section">
+        Paste a director-authored Program Blueprint to parse, validate, and preview the hub counts before any hydration work exists.
+      </p>
+    </div>
+    <form method="post" hx-boost="false" class="chirpui-stack chirpui-stack--md">
+      <input type="hidden" name="intent" value="preview_blueprint">
+      <label>
+        <span class="chirpui-field__label">Blueprint YAML</span>
+        <textarea class="chirpui-field__input"
+                  name="blueprint_yaml"
+                  rows="10"
+                  placeholder="elbysodic_blueprint: 1&#10;&#10;program:&#10;  slug: rl-small-town">{{ blueprint_yaml }}</textarea>
+      </label>
+      <div class="chirpui-cluster chirpui-cluster--end">
+        <button type="submit" class="chirpui-btn chirpui-btn--primary">Preview blueprint</button>
+      </div>
+    </form>
+    {% if blueprint_preview %}
+    <div class="chirpui-stack chirpui-stack--sm">
+      <div class="elbysodic-claim-group__badges">
+        {{ badge("valid dry run", variant="success") if blueprint_preview.is_valid else badge("needs fixes", variant="warning") }}
+        {{ badge(blueprint_preview.program_count ~ " program", variant="info") }}
+        {{ badge(blueprint_preview.character_count ~ " faces", variant="info") }}
+        {{ badge(blueprint_preview.board_count ~ " scene hubs", variant="info") }}
+        {{ badge(blueprint_preview.material_count ~ " materials", variant="info") }}
+        {{ badge(blueprint_preview.wanted_count ~ " wanted hooks", variant="info") }}
+        {{ badge(blueprint_preview.theme_count ~ " theme", variant="muted") }}
+      </div>
+      {% if blueprint_preview.blueprint %}
+      <p class="elbysodic-copy-summary">
+        {{ blueprint_preview.program_count }} program, {{ blueprint_preview.character_count }} starter faces,
+        {{ blueprint_preview.board_count }} scene hubs, {{ blueprint_preview.material_count }} materials,
+        {{ blueprint_preview.wanted_count }} wanted hooks.
+      </p>
+      {% end %}
+      {% if blueprint_preview.errors %}
+      <div class="chirpui-stack chirpui-stack--xs">
+        <p class="chirpui-field__label">Validation notes</p>
+        {% for item in blueprint_preview.errors %}
+        <p class="chirpui-field__error">{{ item }}</p>
+        {% end %}
+      </div>
+      {% else %}
+      <p class="elbysodic-copy-status">Ready for a future service-layer hydrator. Nothing has been applied.</p>
+      {% end %}
+    </div>
+    {% end %}
+  </section>
+  {% end %}
+  {% end %}
+
   <section class="elbysodic-intake-editor-layout">
     <div class="chirpui-stack chirpui-stack--md">
       {% call section_header("Claim Types") %}

--- a/src/elbysodic/web/pages/studio/intake/page.py
+++ b/src/elbysodic/web/pages/studio/intake/page.py
@@ -21,6 +21,13 @@ async def post(request: Request) -> Page | Redirect:
     form = await request.form()
     intent = str(form.get("intent") or "")
     try:
+        if intent == "preview_blueprint":
+            blueprint_yaml = str(form.get("blueprint_yaml") or "")
+            return _render_intake_editor(
+                request,
+                blueprint_yaml=blueprint_yaml,
+                blueprint_preview=services.preview_program_blueprint(blueprint_yaml),
+            )
         if intent == "create_claim_type":
             services.create_claim_type_config(
                 name=str(form.get("name") or ""),
@@ -76,7 +83,13 @@ async def post(request: Request) -> Page | Redirect:
     return Redirect("/studio/intake")
 
 
-def _render_intake_editor(request: Request, *, error: str | None = None) -> Page:
+def _render_intake_editor(
+    request: Request,
+    *,
+    error: str | None = None,
+    blueprint_yaml: str = "",
+    blueprint_preview: object | None = None,
+) -> Page:
     services = get_services(request)
     return Page(
         "studio/intake/page.html",
@@ -87,6 +100,8 @@ def _render_intake_editor(request: Request, *, error: str | None = None) -> Page
         studio=services.director_studio(),
         directory=services.claims_directory(),
         onboarding=services.application_onboarding(),
+        blueprint_yaml=blueprint_yaml,
+        blueprint_preview=blueprint_preview,
         error=error,
     )
 

--- a/src/elbysodic/web/pages/studio/page.html
+++ b/src/elbysodic/web/pages/studio/page.html
@@ -657,7 +657,29 @@
       {% if studio.draft_materials %}
       <ul class="elbysodic-director-list">
         {% for item in studio.draft_materials[:4] %}
-        <li><a href="/world/{{ item.material.slug }}">{{ item.material.title }}</a></li>
+        <li>
+          <div class="chirpui-stack chirpui-stack--xs">
+            <a href="/world/{{ item.material.slug }}">{{ item.material.title }}</a>
+            <div class="chirpui-cluster chirpui-cluster--start">
+              {{ badge(item.type_label, variant="muted") }}
+              <form method="post">
+                <input type="hidden" name="intent" value="material_status">
+                <input type="hidden" name="material_slug" value="{{ item.material.slug }}">
+                <input type="hidden" name="status" value="published">
+                <button class="chirpui-btn chirpui-btn--secondary" type="submit">Publish</button>
+              </form>
+              {% if item.material.material_type == "event" %}
+              <form method="post">
+                <input type="hidden" name="intent" value="material_status">
+                <input type="hidden" name="material_slug" value="{{ item.material.slug }}">
+                <input type="hidden" name="status" value="published">
+                <input type="hidden" name="is_featured" value="on">
+                <button class="chirpui-btn chirpui-btn--secondary" type="submit">Publish as current</button>
+              </form>
+              {% end %}
+            </div>
+          </div>
+        </li>
         {% end %}
       </ul>
       {% else %}

--- a/src/elbysodic/web/pages/studio/page.py
+++ b/src/elbysodic/web/pages/studio/page.py
@@ -26,6 +26,7 @@ async def post(request: Request) -> Page | Redirect:
     services = get_services(request)
     form = await request.form()
     intent = str(form.get("intent") or "identity_accent")
+    redirect_to = "/studio"
     try:
         if intent == "board_taxonomy":
             raw_parent_id = str(form.get("parent_board_id") or "")
@@ -89,6 +90,13 @@ async def post(request: Request) -> Page | Redirect:
                     "enabled_post_densities",
                 ),
             )
+        elif intent == "material_status":
+            services.update_material_production_state(
+                str(form.get("material_slug") or ""),
+                status=str(form.get("status") or ""),
+                is_featured=form.get("is_featured") == "on",
+            )
+            redirect_to = "/studio#continuity-events"
         else:
             raw_group_id = str(form.get("identity_accent_facet_group_id") or "")
             facet_group_id = int(raw_group_id) if raw_group_id else None
@@ -97,7 +105,7 @@ async def post(request: Request) -> Page | Redirect:
         raise HTTPError(status=403, detail=str(exc)) from exc
     except (LookupError, ValueError) as exc:
         return _render_studio(request, error=str(exc))
-    return Redirect("/studio")
+    return Redirect(redirect_to)
 
 
 def _render_studio(request: Request, *, error: str | None = None) -> Page:

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/page.html
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/page.html
@@ -133,6 +133,30 @@
       </details>
       {% end %}
     </div>
+    {% if wanted.can_manage %}
+    <details class="elbysodic-management-disclosure elbysodic-action-disclosure">
+      <summary>
+        <span id="wanted-lifecycle">Manage hook lifecycle</span>
+        <small>Open, reserve, fill, or archive this wanted without changing its history.</small>
+      </summary>
+      <form method="post" hx-boost="false" class="chirpui-stack chirpui-stack--sm" aria-labelledby="wanted-lifecycle">
+        <input type="hidden" name="intent" value="update_lifecycle_status">
+        <label class="chirpui-field__label" for="wanted-status">Lifecycle status</label>
+        <select id="wanted-status" class="chirpui-field__input" name="status">
+          <option value="open" {{ "selected" if wanted.wanted_ad.status == "open" else "" }}>Open</option>
+          <option value="reserved" {{ "selected" if wanted.wanted_ad.status == "reserved" else "" }}>Reserved</option>
+          <option value="filled" {{ "selected" if wanted.wanted_ad.status == "filled" else "" }}>Filled</option>
+          <option value="archived" {{ "selected" if wanted.wanted_ad.status == "archived" else "" }}>Archived</option>
+        </select>
+        <p class="elbysodic-copy-helper">
+          Archived hooks disappear from ordinary wanted browsing, but directors can still inspect them here.
+        </p>
+        <div class="chirpui-cluster chirpui-cluster--end">
+          <button type="submit" class="chirpui-btn chirpui-btn--secondary">Save lifecycle</button>
+        </div>
+      </form>
+    </details>
+    {% end %}
   </article>
   {% end %}
 

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
@@ -82,6 +82,19 @@ async def post(request: Request, wanted_slug: str) -> Page | Redirect:
         except ValueError as exc:
             raise HTTPError(status=400, detail=str(exc)) from exc
         return Redirect(f"/wanted/{wanted_slug}")
+    if intent == "update_lifecycle_status":
+        try:
+            services.update_wanted_ad_lifecycle_status(
+                wanted_slug,
+                status=str(form.get("status") or ""),
+            )
+        except LookupError as exc:
+            raise HTTPError(status=404, detail=str(exc)) from exc
+        except PermissionError as exc:
+            raise HTTPError(status=403, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPError(status=400, detail=str(exc)) from exc
+        return Redirect(f"/wanted/{wanted_slug}")
     raise HTTPError(status=400, detail=f"unknown wanted intent: {intent}")
 
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,42 @@
+# Test Steward
+
+## Steward
+
+Test steward for `tests/`: behavior coverage, tenant-boundary regression tests,
+rendered page tests, policy tests, and contract tests for product primitives.
+
+## Protects
+
+- Tests prove user-visible workflows as well as repository boundaries.
+- New first-class primitives get tenant, membership, role, and rendered-surface
+  coverage proportional to risk.
+- Regression tests use PBP vocabulary and realistic seeded workflows instead
+  of generic forum placeholders.
+- Tests stay fast enough for `make test` and precise enough for local triage.
+
+## Must Not Become
+
+- Snapshot sprawl that blesses accidental markup.
+- Only happy-path browser smoke tests.
+- A second product spec that contradicts docs or root `AGENTS.md`.
+
+## Documentation Ownership
+
+Co-owns README and AGENTS development-command sections when test commands,
+fixtures, or required local services change. Test names should document product
+invariants clearly enough to guide future agents.
+
+## Local Checks
+
+- `uv run pytest -q --tb=short`
+- `uv run pytest tests/test_tenant_repository.py -q --tb=short`
+- `uv run pytest tests/test_forum_slice.py -q --tb=short`
+- `uv run pytest tests/test_markup.py tests/test_policies.py tests/test_program_blueprints.py -q --tb=short`
+
+## Public Contracts And Safety
+
+- Boundary tests should seed multiple communities whenever leakage is possible.
+- Rendered page tests should cover private rooms, staff desks, notification
+  inboxes, and any route that exposes role- or membership-scoped data.
+- Avoid depending on incidental HTML structure when a semantic assertion or
+  service-level check would be clearer.

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -363,6 +363,39 @@ def test_cross_realm_character_url_renders_switchable_recovery() -> None:
     asyncio.run(run())
 
 
+def test_cross_realm_character_recovery_ignores_inactive_faces() -> None:
+    async def run() -> None:
+        app = _app()
+        services = get_services()
+        hosted, _user_id, inactive_membership_id, _character_id = _add_hosted_membership(
+            services,
+            slug="retired-program",
+            user_id=services.seed.user.id,
+            username="retired-realm",
+        )
+        services.repo.create_character(
+            hosted.id,
+            inactive_membership_id,
+            "retired-cross-face",
+            "Retired Cross Face",
+        )
+        services.repo.connection.execute(
+            "UPDATE community_memberships SET is_active = 0 WHERE community_id = ? AND id = ?",
+            (hosted.id, inactive_membership_id),
+        )
+        services.repo.connection.commit()
+
+        async with TestClient(app) as client:
+            response = await client.get("/characters/retired-cross-face")
+
+        assert response.status == 200
+        assert "That face is not in X-Men Apocalypse." in response.text
+        assert "That face lives in Hosted Program." not in response.text
+        assert "Switch to Hosted Program" not in response.text
+
+    asyncio.run(run())
+
+
 def test_cross_realm_material_url_renders_switchable_recovery() -> None:
     async def run() -> None:
         app = _app()
@@ -681,6 +714,89 @@ def test_director_studio_surfaces_community_production_work() -> None:
             assert 'href="/applications"' in operations.text
             assert 'href="/casting"' in operations.text
             assert 'href="/notifications"' in operations.text
+
+    asyncio.run(run())
+
+
+def test_studio_intake_previews_program_blueprint_yaml_without_hydration() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        repo = services.repo
+        community = repo.get_community(services.seed.community.id)
+        user = repo.get_user_by_email("moira@example.com")
+        membership = repo.get_membership_by_username(community.id, "moira")
+        character = repo.get_character_by_slug(community.id, "moira-mactaggert")
+        admin_services = AppServices(
+            repo,
+            DemoSeed(community, user, membership, character),
+        )
+        app = create_app(debug=False, services=admin_services)
+        before_count = repo.connection.execute(
+            "SELECT COUNT(*) FROM communities",
+        ).fetchone()[0]
+        blueprint_yaml = """
+elbysodic_blueprint: 1
+program:
+  slug: rl-small-town-preview
+  name: RL Small Town Preview
+  role:
+    slug: director
+    name: Director
+    is_admin: true
+characters:
+  - slug: june-calloway
+    name: June Calloway
+    summary: Florist and town council note-taker.
+boards:
+  - slug: main-street
+    name: Main Street
+    kind: location
+    tagline: One stoplight, twelve opinions.
+    description: The town's public spine.
+materials:
+  - slug: premise
+    title: Premise
+    type: premise
+    summary: A small-town ensemble.
+    body: Founder's Week should be a cozy pressure cooker.
+wanted:
+  - slug: returning-sibling
+    title: Returning sibling
+    type: relationship
+    related_material: premise
+    summary: A homecoming character with history.
+    body: Someone left, came back, and knows where the deed is hidden.
+"""
+
+        async with TestClient(app) as client:
+            page = await client.get("/studio/intake")
+            response = await client.post(
+                "/studio/intake",
+                body=urlencode(
+                    {
+                        "intent": "preview_blueprint",
+                        "blueprint_yaml": blueprint_yaml,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+
+        assert page.status == 200
+        assert "Dry-run YAML intake" in page.text
+        assert response.status == 200
+        assert "valid dry run" in response.text
+        assert "1 program" in response.text
+        assert "1 starter faces" in response.text
+        assert "1 scene hubs" in response.text
+        assert "1 materials" in response.text
+        assert "1 wanted hooks" in response.text
+        assert (
+            "Ready for a future service-layer hydrator. Nothing has been applied." in response.text
+        )
+        after_count = repo.connection.execute(
+            "SELECT COUNT(*) FROM communities",
+        ).fetchone()[0]
+        assert after_count == before_count
 
     asyncio.run(run())
 
@@ -1480,6 +1596,137 @@ def test_world_materials_render_pillars_events_and_application_guides() -> None:
     asyncio.run(run())
 
 
+def test_draft_world_materials_are_staff_only_on_rendered_routes() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        community = services.seed.community
+        services.repo.create_material(
+            community.id,
+            "director-only-event",
+            "Director Only Event",
+            material_type="event",
+            summary="This draft should stay inside Studio.",
+            body="Private director continuity that should not leak.",
+            status="draft",
+        )
+        member_services, _member_character_id = _outsider_services(
+            services,
+            prefix="draft-material-member",
+        )
+        member_app = create_app(debug=False, services=member_services)
+        async with TestClient(member_app) as member_client:
+            member_world = await member_client.get("/world")
+            member_direct = await member_client.get("/world/director-only-event")
+
+        alex_membership = services.repo.get_membership_by_username(community.id, "alex")
+        alex_user = services.repo.get_user(alex_membership.user_id)
+        cyclops = services.repo.get_character_by_slug(community.id, "cyclops")
+        alex_services = AppServices(
+            services.repo,
+            DemoSeed(community, alex_user, alex_membership, cyclops),
+        )
+        staff_app = create_app(debug=False, services=alex_services)
+        async with TestClient(staff_app) as staff_client:
+            staff_studio = await staff_client.get("/studio")
+            staff_direct = await staff_client.get("/world/director-only-event")
+
+        assert member_world.status == 200
+        assert "Director Only Event" not in member_world.text
+        assert "Private director continuity that should not leak." not in member_direct.text
+        assert "That world material is not in X-Men Apocalypse." in member_direct.text
+        assert staff_studio.status == 200
+        assert "Director Only Event" in staff_studio.text
+        assert staff_direct.status == 200
+        assert "Director Only Event" in staff_direct.text
+        assert "Private director continuity that should not leak." in staff_direct.text
+        assert "Material studio" in staff_direct.text
+
+    asyncio.run(run())
+
+
+def test_directors_can_publish_draft_materials_from_studio_queue() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        repo = services.repo
+        community = repo.get_community(services.seed.community.id)
+        draft_event = repo.create_material(
+            community.id,
+            "new-canon-pulse",
+            "New Canon Pulse",
+            material_type="event",
+            summary="Director draft for the next canon beat.",
+            body="A production note waiting for publication.",
+            status="draft",
+        )
+        member_services, _member_character_id = _outsider_services(
+            services,
+            prefix="studio-material-member",
+        )
+        member_app = create_app(debug=False, services=member_services)
+        async with TestClient(member_app) as member_client:
+            forbidden = await member_client.post(
+                "/studio",
+                body=urlencode(
+                    {
+                        "intent": "material_status",
+                        "material_slug": draft_event.slug,
+                        "status": "published",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+
+        assert forbidden.status == 403
+        assert repo.get_material_by_slug(community.id, draft_event.slug).status == "draft"
+
+        user = repo.get_user_by_email("moira@example.com")
+        membership = repo.get_membership_by_username(community.id, "moira")
+        character = repo.get_character_by_slug(community.id, "moira-mactaggert")
+        admin_services = AppServices(
+            repo,
+            DemoSeed(community, user, membership, character),
+        )
+        app = create_app(debug=False, services=admin_services)
+        async with TestClient(app) as client:
+            studio = await client.get("/studio")
+            assert studio.status == 200
+            assert "New Canon Pulse" in studio.text
+            assert "Publish as current" in studio.text
+
+            response = await client.post(
+                "/studio",
+                body=urlencode(
+                    {
+                        "intent": "material_status",
+                        "material_slug": draft_event.slug,
+                        "status": "published",
+                        "is_featured": "on",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            assert response.status == 302
+            assert _response_header(response, "location") == "/studio#continuity-events"
+
+            world = await client.get("/world/new-canon-pulse")
+            studio_after = await client.get("/studio")
+
+        updated = repo.get_material_by_slug(community.id, draft_event.slug)
+        old_event = repo.get_material_by_slug(community.id, "b-24-winter")
+        assert updated.status == "published"
+        assert updated.is_featured is True
+        assert old_event.is_featured is False
+        current_event = admin_services.director_studio().current_event
+        assert current_event is not None
+        assert current_event.material.slug == draft_event.slug
+        assert world.status == 200
+        assert "New Canon Pulse" in world.text
+        assert studio_after.status == 200
+        assert "New Canon Pulse" in studio_after.text
+
+    asyncio.run(run())
+
+
 def test_applications_desk_tracks_character_statuses() -> None:
     async def run() -> None:
         app = _app()
@@ -1594,6 +1841,7 @@ def test_applications_desk_tracks_character_statuses() -> None:
                 assert "Jubilee" in review.text
                 assert "Accept" in review.text
                 assert "Request revisions" in review.text
+                assert 'name="intent" value="request_revision"' not in review.text
 
                 review_room = await alex_client.get("/applications/jubilee")
                 assert review_room.status == 200
@@ -1644,6 +1892,17 @@ def test_applications_desk_tracks_character_statuses() -> None:
                 ).application_status
                 == "accepted"
             )
+            applicant_app = create_app(
+                debug=False, services=AppServices(services.repo, services.seed)
+            )
+            async with TestClient(applicant_app) as applicant_client:
+                accepted_room = await applicant_client.get("/applications/jubilee")
+            assert accepted_room.status == 200
+            assert "Jubilee is looking for a found-family first scene." in accepted_room.text
+            assert "Director Review" not in accepted_room.text
+            assert "Voice is clear." not in accepted_room.text
+            assert "Starter hook" not in accepted_room.text
+            assert "Cast tie" not in accepted_room.text
             assert any(
                 item.label == "Application accepted" and item.title == "Jubilee"
                 for item in services.notifications().items
@@ -1840,6 +2099,80 @@ def test_wanted_ads_render_board_detail_and_character_hub() -> None:
                 assert "Active Reserves" in casting.text
                 assert "Human UN liaison for B-24 talks" in casting.text
                 assert "Rogue&#39;s Reserves" in casting.text
+
+            charlie_app = create_app(debug=False, services=charlie_services)
+            async with TestClient(charlie_app) as charlie_client:
+                filled_response = await charlie_client.post(
+                    "/wanted/human-un-liaison-for-b24",
+                    body=urlencode(
+                        {
+                            "intent": "update_lifecycle_status",
+                            "status": "filled",
+                        }
+                    ).encode(),
+                    headers=_FORM,
+                )
+                filled_view = await charlie_client.get("/wanted/human-un-liaison-for-b24")
+
+                archive_response = await charlie_client.post(
+                    "/wanted/human-un-liaison-for-b24",
+                    body=urlencode(
+                        {
+                            "intent": "update_lifecycle_status",
+                            "status": "archived",
+                        }
+                    ).encode(),
+                    headers=_FORM,
+                )
+                archived_manager_view = await charlie_client.get("/wanted/human-un-liaison-for-b24")
+
+                reopen_response = await charlie_client.post(
+                    "/wanted/human-un-liaison-for-b24",
+                    body=urlencode(
+                        {
+                            "intent": "update_lifecycle_status",
+                            "status": "open",
+                        }
+                    ).encode(),
+                    headers=_FORM,
+                )
+
+            outsider_services, _outsider_character_id = _outsider_services(
+                services,
+                prefix="wanted-archive-outsider",
+            )
+            archived_wanted = services.repo.update_wanted_ad_status(
+                community.id,
+                wanted_ad.id,
+                "archived",
+            )
+            outsider_app = create_app(debug=False, services=outsider_services)
+            async with TestClient(outsider_app) as outsider_client:
+                archived_outsider_view = await outsider_client.get(
+                    "/wanted/human-un-liaison-for-b24"
+                )
+                archived_wanted_board = await outsider_client.get("/wanted")
+
+            reopened = services.repo.update_wanted_ad_status(
+                community.id,
+                wanted_ad.id,
+                "open",
+            )
+
+            assert filled_response.status == 302
+            assert "Manage hook lifecycle" in filled_view.text
+            assert '<option value="filled" selected>Filled</option>' in filled_view.text
+            assert archive_response.status == 302
+            assert archived_manager_view.status == 200
+            assert (
+                '<option value="archived" selected>Archived</option>' in archived_manager_view.text
+            )
+            assert reopen_response.status == 302
+            assert archived_wanted.status == "archived"
+            assert archived_outsider_view.status == 200
+            assert "That wanted hook is not in X-Men Apocalypse." in archived_outsider_view.text
+            assert "Human UN liaison for B-24 talks" not in archived_wanted_board.text
+            assert reopened.status == "open"
 
             missing = await client.get("/wanted/not-a-hook")
             assert missing.status == 200
@@ -3330,6 +3663,27 @@ def test_members_directory_and_profile_show_visible_community_cast() -> None:
             character.id,
             "Private activity should stay private.",
         )
+        role = repo.get_role_by_slug(community.id, "member")
+        inactive_user = repo.create_user("retired@example.com", "hash")
+        inactive_membership = repo.create_membership(
+            community.id,
+            inactive_user.id,
+            role.id,
+            "retiredlane",
+            "Retired Lane",
+        )
+        repo.create_character(
+            community.id,
+            inactive_membership.id,
+            "retired-face",
+            "Retired Face",
+            summary="Retired profile copy should not render.",
+        )
+        repo.connection.execute(
+            "UPDATE community_memberships SET is_active = 0 WHERE community_id = ? AND id = ?",
+            (community.id, inactive_membership.id),
+        )
+        repo.connection.commit()
 
         async with TestClient(app) as client:
             directory = await client.get("/members")
@@ -3341,6 +3695,8 @@ def test_members_directory_and_profile_show_visible_community_cast() -> None:
             assert "Rogue" in directory.text
             assert "/members/starlane" in directory.text
             assert "Private activity should stay private." not in directory.text
+            assert "Retired Lane" not in directory.text
+            assert "Retired Face" not in directory.text
 
             profile = await client.get("/members/starlane")
             assert profile.status == 200
@@ -3356,6 +3712,12 @@ def test_members_directory_and_profile_show_visible_community_cast() -> None:
 
             missing = await client.get("/members/nope")
             assert missing.status == 404
+            inactive_member = await client.get("/members/retiredlane")
+            assert inactive_member.status == 404
+            inactive_character = await client.get("/characters/retired-face")
+            assert inactive_character.status == 200
+            assert "That face is not in X-Men Apocalypse." in inactive_character.text
+            assert "Retired profile copy should not render." not in inactive_character.text
 
     asyncio.run(run())
 
@@ -3770,6 +4132,11 @@ def test_character_activity_center_tracks_identity_specific_threads() -> None:
 
             profile = await client.get("/characters/rogue")
             assert profile.status == 200
+            assert "Next actions" in profile.text
+            assert "active-face defaults on" in profile.text
+            assert "Reply as Rogue" in profile.text
+            assert "Find play for Rogue" in profile.text
+            assert "Casting as Rogue" in profile.text
             assert "Tracker" in profile.text
             assert "Open filtered queue" in profile.text
             assert "Open thread roster" in profile.text
@@ -3815,6 +4182,11 @@ def test_character_profile_can_set_current_face() -> None:
         app = _app()
 
         async with TestClient(app) as client:
+            pending_profile = await client.get("/characters/storm")
+            assert pending_profile.status == 200
+            assert "set current for discovery" in pending_profile.text
+            assert "Make Storm current" in pending_profile.text
+
             response = await client.post(
                 "/characters/storm",
                 body=b"intent=set_default",
@@ -3825,6 +4197,8 @@ def test_character_profile_can_set_current_face() -> None:
 
             profile = await client.get("/characters/storm")
             assert "current" in profile.text
+            assert "active-face defaults on" in profile.text
+            assert "Find play for Storm" in profile.text
 
             index = await client.get("/")
             assert "Current face: Storm" in index.text

--- a/tests/test_program_blueprints.py
+++ b/tests/test_program_blueprints.py
@@ -13,6 +13,7 @@ from elbysodic.blueprints import (
     BlueprintWanted,
     ProgramBlueprint,
     ensure_valid_program_blueprint,
+    preview_program_blueprint_yaml,
     validate_program_blueprint,
 )
 from elbysodic.db import ForumRepository, connect, create_schema
@@ -196,6 +197,83 @@ def test_program_blueprint_reports_missing_wanted_material_reference() -> None:
         "program demo-program.wanted.missing-deed.related_material_slug "
         "references unknown material: current-event"
     ) in errors
+
+
+def test_program_blueprint_yaml_preview_maps_director_friendly_keys() -> None:
+    preview = preview_program_blueprint_yaml(
+        """
+elbysodic_blueprint: 1
+program:
+  slug: rl-small-town
+  name: RL Small Town
+  role:
+    slug: director
+    name: Director
+    is_admin: true
+characters:
+  - slug: june-calloway
+    name: June Calloway
+    summary: Florist and town council note-taker.
+boards:
+  - slug: main-street
+    name: Main Street
+    kind: location
+    tagline: One stoplight, twelve opinions.
+    description: The town's public spine.
+materials:
+  - slug: premise
+    title: Premise
+    type: premise
+    summary: A small-town ensemble.
+    body: Founder's Week should be a cozy pressure cooker.
+wanted:
+  - slug: returning-sibling
+    title: Returning sibling
+    type: relationship
+    related_material: premise
+    summary: A homecoming character with history.
+    body: Someone left, came back, and knows where the deed is hidden.
+"""
+    )
+
+    assert preview.is_valid
+    assert preview.blueprint is not None
+    assert preview.blueprint.slug == "rl-small-town"
+    assert preview.blueprint.boards[0].board_kind == "location"
+    assert preview.blueprint.materials[0].material_type == "premise"
+    assert preview.blueprint.wanted[0].wanted_type == "relationship"
+    assert preview.blueprint.wanted[0].related_material_slug == "premise"
+    assert preview.character_count == 1
+    assert preview.board_count == 1
+    assert preview.material_count == 1
+    assert preview.wanted_count == 1
+
+
+def test_program_blueprint_yaml_preview_reports_parse_and_validation_errors() -> None:
+    parse_preview = preview_program_blueprint_yaml("program: [")
+    validation_preview = preview_program_blueprint_yaml(
+        """
+elbysodic_blueprint: 2
+program:
+  slug: broken
+  name: Broken
+  role:
+    slug: director
+    name: Director
+characters: []
+boards: []
+materials: []
+"""
+    )
+
+    assert not parse_preview.is_valid
+    assert "Blueprint YAML could not be parsed:" in parse_preview.errors[0]
+    assert not validation_preview.is_valid
+    assert "elbysodic_blueprint must be 1" in validation_preview.errors
+    assert (
+        "program broken.characters must include at least one starter face"
+        in validation_preview.errors
+    )
 
 
 def test_seed_hydrates_program_blueprints_into_network_programs() -> None:

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import pytest
 
 from elbysodic.db import ForumRepository, connect, create_schema
-from elbysodic.db.migrations import BASELINE_MIGRATION_NAME, CURRENT_SCHEMA_VERSION
+from elbysodic.db.migrations import (
+    BASELINE_MIGRATION_NAME,
+    CURRENT_SCHEMA_VERSION,
+    MIGRATIONS,
+)
 from elbysodic.db.repositories.base import TenantBoundaryError
 
 
@@ -44,6 +48,39 @@ def test_schema_records_migration_baseline() -> None:
             "name": BASELINE_MIGRATION_NAME,
         }
     ]
+    assert user_version == CURRENT_SCHEMA_VERSION
+
+
+def test_schema_migration_versions_are_contiguous_after_baseline() -> None:
+    versions = [migration.version for migration in MIGRATIONS]
+
+    assert versions == list(range(2, CURRENT_SCHEMA_VERSION + 1))
+    assert len({migration.name for migration in MIGRATIONS}) == len(MIGRATIONS)
+
+
+def test_schema_applies_ordered_migrations_from_historical_baseline() -> None:
+    connection = connect()
+    create_schema(connection)
+    connection.execute("DELETE FROM schema_migrations")
+    connection.execute(
+        """
+        INSERT INTO schema_migrations (version, name, applied_at)
+        VALUES (1, ?, '2026-01-01T00:00:00+00:00')
+        """,
+        (BASELINE_MIGRATION_NAME,),
+    )
+    connection.execute("PRAGMA user_version = 1")
+    connection.commit()
+
+    create_schema(connection)
+
+    rows = connection.execute(
+        "SELECT version, name FROM schema_migrations ORDER BY version"
+    ).fetchall()
+    user_version = connection.execute("PRAGMA user_version").fetchone()[0]
+
+    assert [row["version"] for row in rows] == list(range(1, CURRENT_SCHEMA_VERSION + 1))
+    assert [row["name"] for row in rows][1:] == [migration.name for migration in MIGRATIONS]
     assert user_version == CURRENT_SCHEMA_VERSION
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -394,6 +394,7 @@ source = { editable = "." }
 dependencies = [
     { name = "bengal-chirp", extra = ["config", "forms", "sessions", "ui"] },
     { name = "chirp-ui" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -417,6 +418,7 @@ docs = [
 requires-dist = [
     { name = "bengal-chirp", extras = ["config", "forms", "sessions", "ui"], editable = "../python/b-stack/chirp" },
     { name = "chirp-ui", editable = "../python/chirp-ui" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- add scoped AGENTS.md steward guides across the repo
- save the initial steward backlog rollup snapshot and plan lifecycle guidance
- implement first backlog slices for Studio workflows, privacy coverage, blueprint dry-run preview, character hub actions, migration discipline, composer consolidation, and service-boundary cleanup

## Steward Notes

Consulted root, docs, package, domain, service, storage, web/UI, blueprint, and test stewards. Root AGENTS.md remains the constitution; nested guides define local domain boundaries. The ask stewards workflow is documented and the rollup snapshot preserves remaining work and minority reports.

## Validation

- make ci