### PR TITLE
Harden plotting notifications and clarify the Program Blueprint hydration gate

### DIFF
--- a/docs/architecture/rendered-route-privacy-matrix.md
+++ b/docs/architecture/rendered-route-privacy-matrix.md
@@ -59,3 +59,6 @@ control appears or does not appear than to snapshot large HTML sections.
 - Inactive memberships are absent from `/members`, `/members/{username}`, and
   direct character profile routes, and recovery does not offer cross-realm
   switches for inactive faces.
+- Plotting room notifications do not render private room titles, unread counts,
+  or open redirects for memberships that are not room owners, participants, or
+  casting-capable staff.

--- a/docs/product/program-blueprints.md
+++ b/docs/product/program-blueprints.md
@@ -231,3 +231,17 @@ the shared contract: seed data and future YAML imports should describe the same
 kind of PBP hub. The current Studio preview intentionally stops before step 4:
 it validates and summarizes the packet, but does not create or update database
 state.
+
+## Hydration Gate
+
+Keep apply disabled until the hydrator has an explicit service-layer plan for:
+
+- duplicate handling for existing program, role, face, board, material, wanted,
+  and theme slugs
+- ownership defaults for starter faces and director-authored wanted hooks
+- rollback behavior when a later object fails after earlier objects validate
+- tenant tests that prove every created object stays in the selected community
+- a dry-run diff that names create, update, and skipped objects before mutation
+
+Until those pieces exist, Studio intake should keep saying that preview is a
+hydration gate, not a launch button.

--- a/plans/in-progress/steward-backlog-rollup-2026-05-01.md
+++ b/plans/in-progress/steward-backlog-rollup-2026-05-01.md
@@ -116,6 +116,8 @@ focused plans, issues, or follow-up PRs.
 - Expand the rendered-route privacy matrix beyond the first draft-material and
   inactive-identity cases. Prioritize staff desks, notification surfaces,
   application review rooms, plotting rooms, and cross-community recovery pages.
+  Plotting-room notification leakage now has a rendered regression; continue
+  with staff desks, application review rooms, and cross-community recovery pages.
 - Decide the next Program Blueprint step: keep dry-run preview as-is, or design
   a separate hydration plan with repository/service boundaries, duplicate
   handling, rollback behavior, and tenant tests.
@@ -175,3 +177,9 @@ focused plans, issues, or follow-up PRs.
   plan's backlog split into an explicit remaining-work list and moving material
   production-state orchestration into `services/materials.py`, leaving
   `AppServices` as a route-facing delegator.
+- 2026-05-01: Continued the next priority batch on
+  `codex/steward-next-priorities`: plotting room notifications now filter
+  private room targets from non-participant inboxes, visible unread counts honor
+  target visibility, notifications expose current-face discovery and plotter
+  handoffs, Studio operations links to dry-run blueprint intake, and the Program
+  Blueprint docs/UI name the hydration gate before apply work.

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -112,6 +112,9 @@ from elbysodic.services.materials import (
     update_material_production_state as _update_material_production_state,
 )
 from elbysodic.services.notifications import (
+    count_visible_unread_notifications as _count_visible_unread_notifications,
+)
+from elbysodic.services.notifications import (
     mark_all_notifications_read as _mark_all_notifications_read,
 )
 from elbysodic.services.notifications import notification_inbox as _notification_inbox
@@ -307,8 +310,11 @@ class AppServices:
                 item for item in navigation_boards if is_studio_sidebar_board(item.board)
             ],
             studio_sidebar_section=sidebar_sections["studio"],
-            unread_notification_count=self.repo.count_unread_notifications(
-                community.id, membership.id
+            unread_notification_count=_count_visible_unread_notifications(
+                self.repo,
+                community.id,
+                membership,
+                role,
             ),
             identity_options=self._identity_options(identity),
             program_theme=community_theme_view(self.repo.get_default_theme(community.id)),
@@ -328,9 +334,11 @@ class AppServices:
                     membership=membership,
                     role=role,
                     current_character=_resolve_current_character(self.repo, membership, roster),
-                    unread_notification_count=self.repo.count_unread_notifications(
+                    unread_notification_count=_count_visible_unread_notifications(
+                        self.repo,
                         community.id,
-                        membership.id,
+                        membership,
+                        role,
                     ),
                     is_current=(
                         community.id == identity.community_id
@@ -407,9 +415,11 @@ class AppServices:
                             membership.id,
                         )
                     ),
-                    unread_notification_count=self.repo.count_unread_notifications(
+                    unread_notification_count=_count_visible_unread_notifications(
+                        self.repo,
                         community.id,
-                        membership.id,
+                        membership,
+                        role,
                     ),
                     theme_preview=_network_theme_preview(theme),
                     is_current=(

--- a/src/elbysodic/services/notifications.py
+++ b/src/elbysodic/services/notifications.py
@@ -12,7 +12,9 @@ from elbysodic.domain.models import (
     CommunityMembership,
     Notification,
     PlottingRoom,
+    PlottingRoomParticipant,
     Post,
+    Role,
     Thread,
     WantedAd,
     WantedAdInterest,
@@ -45,6 +47,12 @@ class NotificationRepository(PostViewRepository, Protocol):
     ) -> CharacterPlotHook: ...
 
     def get_plotting_room(self, community_id: int, plotting_room_id: int) -> PlottingRoom: ...
+
+    def list_plotting_room_participants(
+        self,
+        community_id: int,
+        plotting_room_id: int,
+    ) -> list[PlottingRoomParticipant]: ...
 
     def get_notification(self, community_id: int, notification_id: int) -> Notification: ...
 
@@ -103,10 +111,26 @@ def notification_inbox(
             items.append(item)
     return NotificationInbox(
         items=items,
-        unread_count=repo.count_unread_notifications(
+        unread_count=count_visible_unread_notifications(
+            repo,
             viewer.community.id,
-            viewer.membership.id,
+            viewer.membership,
+            viewer.role,
         ),
+    )
+
+
+def count_visible_unread_notifications(
+    repo: NotificationRepository,
+    community_id: int,
+    membership: CommunityMembership,
+    role: Role | None,
+) -> int:
+    return sum(
+        1
+        for notification in repo.list_notifications(community_id, membership.id, limit=1000)
+        if notification.read_at is None
+        and _can_view_notification_target(repo, community_id, membership, role, notification)
     )
 
 
@@ -269,6 +293,14 @@ def notification_item(
         )
     if notification.plotting_room_id is not None:
         room = repo.get_plotting_room(viewer.community.id, notification.plotting_room_id)
+        if not _can_view_plotting_room_notification(
+            repo,
+            viewer.community.id,
+            viewer.membership,
+            viewer.role,
+            room,
+        ):
+            return None
         if notification.kind == "plotting_room_threaded":
             snippet = f"{actor_label} started a scene from this plotting room."
         else:
@@ -313,6 +345,47 @@ def notification_item(
         snippet=rendered_post.snippet,
         href=f"/boards/{board.slug}/threads/{thread.slug}#{rendered_post.anchor}",
     )
+
+
+def _can_view_plotting_room_notification(
+    repo: NotificationRepository,
+    community_id: int,
+    membership: CommunityMembership,
+    role: Role | None,
+    room: PlottingRoom,
+) -> bool:
+    if room.owner_membership_id == membership.id or policies.can_manage_casting(membership, role):
+        return True
+    return any(
+        participant.membership_id == membership.id
+        for participant in repo.list_plotting_room_participants(community_id, room.id)
+    )
+
+
+def _can_view_notification_target(
+    repo: NotificationRepository,
+    community_id: int,
+    membership: CommunityMembership,
+    role: Role | None,
+    notification: Notification,
+) -> bool:
+    try:
+        if notification.thread_id is not None:
+            thread = repo.get_thread(community_id, notification.thread_id)
+            board = repo.get_board(community_id, thread.board_id)
+            return policies.can_view_board(membership, board, role)
+        if notification.plotting_room_id is not None:
+            room = repo.get_plotting_room(community_id, notification.plotting_room_id)
+            return _can_view_plotting_room_notification(
+                repo,
+                community_id,
+                membership,
+                role,
+                room,
+            )
+    except LookupError:
+        return False
+    return True
 
 
 def notification_label(kind: str) -> str:

--- a/src/elbysodic/web/pages/notifications/page.html
+++ b/src/elbysodic/web/pages/notifications/page.html
@@ -21,6 +21,12 @@
         {{ metric_item(inbox.unread_count, "Unread") }}
         {{ metric_item(inbox.items | length, "Recent") }}
       </div>
+      {% if viewer.current_character %}
+      <div class="chirpui-cluster chirpui-cluster--sm">
+        <a class="chirpui-btn chirpui-btn--secondary" href="/discover">Find hooks for {{ viewer.current_character.name }}</a>
+        <a class="chirpui-btn chirpui-btn--secondary" href="/characters/{{ viewer.current_character.slug }}#plotter">Open plotter</a>
+      </div>
+      {% end %}
       {% if inbox.unread_count %}
       <form method="post" hx-boost="false">
         <input type="hidden" name="intent" value="mark_all_read">

--- a/src/elbysodic/web/pages/studio/intake/page.html
+++ b/src/elbysodic/web/pages/studio/intake/page.html
@@ -59,7 +59,7 @@
       <p class="elbysodic-kicker">Program Blueprint</p>
       <h2 id="program-blueprint-preview">Dry-run YAML intake</h2>
       <p class="elbysodic-copy-section">
-        Paste a director-authored Program Blueprint to parse, validate, and preview the hub counts before any hydration work exists.
+        Paste a director-authored Program Blueprint to parse, validate, and preview the hub counts before hydration is designed.
       </p>
     </div>
     <form method="post" hx-boost="false" class="chirpui-stack chirpui-stack--md">
@@ -101,7 +101,12 @@
         {% end %}
       </div>
       {% else %}
-      <p class="elbysodic-copy-status">Ready for a future service-layer hydrator. Nothing has been applied.</p>
+      <div class="chirpui-stack chirpui-stack--xs">
+        <p class="elbysodic-copy-status">Hydration gate: nothing has been applied.</p>
+        <p class="elbysodic-copy-helper">
+          Apply needs a service-layer plan for duplicate handling, ownership defaults, rollback behavior, and tenant tests.
+        </p>
+      </div>
       {% end %}
     </div>
     {% end %}

--- a/src/elbysodic/web/pages/studio/operations/page.py
+++ b/src/elbysodic/web/pages/studio/operations/page.py
@@ -143,6 +143,19 @@ def _director_operations(
             cta="Review materials",
             items=tuple(item.material.title for item in studio.draft_materials[:4]),
         ),
+        OperationsCard(
+            kicker="Blueprints",
+            title="Dry-run intake",
+            summary="Validate director starter packets before any hydration work is allowed.",
+            count=0,
+            href="/studio/intake#program-blueprint-preview",
+            cta="Open intake",
+            variant="status",
+            items=(
+                "Apply stays gated behind a service-layer hydration plan.",
+                "Preview checks counts, slugs, references, and safe theme tokens.",
+            ),
+        ),
     ]
     return DirectorOperations(
         cards=cards,

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -710,6 +710,8 @@ def test_director_studio_surfaces_community_production_work() -> None:
             assert "Staff notifications" in operations.text
             assert "Production health" in operations.text
             assert "Draft materials" in operations.text
+            assert "Dry-run intake" in operations.text
+            assert 'href="/studio/intake#program-blueprint-preview"' in operations.text
             assert "Application Triage" in operations.text
             assert 'href="/applications"' in operations.text
             assert 'href="/casting"' in operations.text
@@ -790,9 +792,8 @@ wanted:
         assert "1 scene hubs" in response.text
         assert "1 materials" in response.text
         assert "1 wanted hooks" in response.text
-        assert (
-            "Ready for a future service-layer hydrator. Nothing has been applied." in response.text
-        )
+        assert "Hydration gate: nothing has been applied." in response.text
+        assert "duplicate handling, ownership defaults, rollback behavior" in response.text
         after_count = repo.connection.execute(
             "SELECT COUNT(*) FROM communities",
         ).fetchone()[0]
@@ -3278,6 +3279,78 @@ def test_plotting_room_plan_can_turn_into_scene() -> None:
 
         lane_inbox = services.notifications()
         assert any(item.label == "Scene started" for item in lane_inbox.items)
+
+    asyncio.run(run())
+
+
+def test_plotting_room_notifications_do_not_leak_to_non_participants() -> None:
+    async def run() -> None:
+        app = _app()
+        async with TestClient(app) as client:
+            response = await client.post(
+                "/wanted/human-un-liaison-for-b24",
+                body=b"intent=express_interest",
+                headers=_FORM,
+            )
+            assert response.status == 302
+
+        services = get_services()
+        repo = services.repo
+        community = services.seed.community
+        wanted_ad = repo.get_wanted_ad_by_slug(community.id, "human-un-liaison-for-b24")
+        rogue = repo.get_character_by_slug(community.id, "rogue")
+        interest = repo.get_wanted_ad_interest_for_character(community.id, wanted_ad.id, rogue.id)
+        charlie_membership = repo.get_membership_by_username(community.id, "charlie")
+        charlie_user = repo.get_user(charlie_membership.user_id)
+        xavier = repo.get_character_by_slug(community.id, "charles-xavier")
+        charlie_services = AppServices(
+            repo,
+            DemoSeed(community, charlie_user, charlie_membership, xavier),
+        )
+        charlie_app = create_app(debug=False, services=charlie_services)
+        async with TestClient(charlie_app) as charlie_client:
+            room_response = await charlie_client.post(
+                "/wanted/human-un-liaison-for-b24",
+                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                headers=_FORM,
+            )
+            assert room_response.status == 302
+
+        room = repo.get_plotting_room_for_wanted_interest(community.id, interest.id)
+        outsider_services, _character_id = _outsider_services(services, prefix="room-notify")
+        notification = repo.create_notification(
+            community.id,
+            outsider_services.seed.membership.id,
+            kind="plotting_room_created",
+            plotting_room_id=room.id,
+            actor_membership_id=charlie_membership.id,
+            actor_character_id=xavier.id,
+        )
+        outsider_app = create_app(debug=False, services=outsider_services)
+        async with TestClient(outsider_app) as outsider_client:
+            inbox = await outsider_client.get("/notifications")
+            open_attempt = await outsider_client.post(
+                "/notifications",
+                body=urlencode(
+                    {
+                        "intent": "open",
+                        "notification_id": str(notification.id),
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            room_attempt = await outsider_client.get(f"/plotting/{room.id}")
+
+        assert outsider_services.viewer().unread_notification_count == 0
+        assert outsider_services.notifications().unread_count == 0
+        assert inbox.status == 200
+        assert "No notifications are waiting on you." in inbox.text
+        assert "Find hooks for Room-Notify Face" in inbox.text
+        assert 'href="/characters/room-notify-face#plotter"' in inbox.text
+        assert room.title not in inbox.text
+        assert "Human UN liaison for B-24 talks: Rogue" not in inbox.text
+        assert open_attempt.status == 404
+        assert room_attempt.status == 403
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- Tighten notification visibility so plotting-room targets and unread counts stay scoped to room owners, participants, or casting-capable staff.
- Add rendered regression coverage for non-participant notification leakage and expose active-face handoffs from the notifications inbox.
- Update Studio operations and Program Blueprint intake copy so dry-run preview is clearly separated from any future hydration/apply flow.
- Refresh the privacy matrix, program-blueprint docs, and active steward rollup with the new boundary and sequencing notes.

## Testing
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`