### PR TITLE
Add auth and seed QA flows

### DIFF
--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -82,3 +82,6 @@ for user-visible private rooms, staff desks, or notification inboxes.
 Use `docs/architecture/rendered-route-privacy-matrix.md` as the standing route
 checklist for rendered privacy coverage. Update it when adding a new route
 family, identity shape, or user-visible scoped data surface.
+
+Use `docs/architecture/seed-personas.md` when a test or browser QA pass needs a
+stable seeded account, membership, role, and active-face combination.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -51,6 +51,12 @@ When adding a staff workflow, add or reuse a named capability in
 `src/elbysodic/services/policies.py` and route service-layer checks through the
 helper. Avoid direct `role.is_admin` checks outside the policy module.
 
+V1 keeps `roles.is_admin` as the storage shorthand for "has every current
+staff capability." Do not add role-capability rows until partial staff roles
+become product-visible. Even while storage is coarse, page handlers and
+workflow services should still depend on named policy helpers rather than the
+storage flag.
+
 ## Nullable Identity Shapes
 
 Some PBP workflows support a character-backed path and a prospective-character

--- a/docs/architecture/seed-personas.md
+++ b/docs/architecture/seed-personas.md
@@ -1,0 +1,50 @@
+# Seed Personas
+
+Seed personas are the browser QA layer for Elbysodic's identity model. They are
+not product accounts, fixtures for every test, or a replacement for the real
+authorization checks. They are stable named entry points for manually testing
+global account, community membership, role, and active-face combinations.
+
+Use `src/elbysodic/db/seed.py` as the source of truth. The `SEED_PERSONAS`
+catalog gives each persona a semantic key, account email, community,
+membership username, default face, default route, and QA purpose.
+
+Tests should use `resolve_seed_persona(repo, "<key>")` when they need a seeded
+identity by purpose instead of hard-coding a username and hoping the role is
+obvious.
+
+## Matrix
+
+| Key | Account | Community | Membership | Role | Face | QA Purpose |
+| --- | --- | --- | --- | --- | --- | --- |
+| `xmen_writer` | `writer@example.com` | X-Men Apocalypse | `starlane` | Member | Rogue | ordinary writer, accepted faces, active-face queue, scene posting |
+| `xmen_staff` | `moira@example.com` | X-Men Apocalypse | `moira` | Staff | Moira MacTaggert | Studio, applications, claims, private production rooms |
+| `xmen_mod` | `alex@example.com` | X-Men Apocalypse | `alex` | Moderator | Cyclops | thread lifecycle and moderation controls |
+| `xmen_partner` | `charlie@example.com` | X-Men Apocalypse | `charlie` | Member | Charles Xavier | wanted, plotter, plotting-room, and notification counterparty checks |
+| `xmen_applicant` | `mira@example.com` | X-Men Apocalypse | `mira` | Member | Kitty Pryde | submitted application and writer-side revision workflow |
+| `xmen_outsider` | `simon@example.com` | X-Men Apocalypse | `simon` | Member | Bolivar Trask | outsider, private-room denial, and notification visibility checks |
+| `xmen_inactive` | `inactive@example.com` | X-Men Apocalypse | `sleepingstar` | Member | Sleeping Star | inactive membership denial and recovery checks |
+| `hp_director` | `writer@example.com` | HP Universe | `starlane` | Director | Rowan Ash | same account with staff power in another community |
+| `jp_director` | `writer@example.com` | Jurassic Park Universe | `starlane` | Director | Dr. Lena Marquez | visual/theme and director controls in another genre |
+| `nyc_writer` | `writer@example.com` | RL NYC | `starlane` | Member | Lena Park | same account without staff power in another community |
+| `smalltown_writer` | `writer@example.com` | RL Small Town | `starlane` | Member | June Calloway | low-stakes ensemble writer checks |
+
+## Browser QA
+
+When development tools are enabled, `/dev/personas` lists these personas and
+can switch the current local identity. The page must remain development-only:
+production or disabled dev-tools mode should return 404.
+
+Login sessions use the same catalog indirectly: seeded accounts currently use
+the local password `password`, and the request resolver still resolves staff
+power through the selected community membership and role.
+
+## Boundaries
+
+- Staff power is never global. `writer@example.com` is a Director in HP and
+  Jurassic Park, but only a Member in X-Men, RL NYC, and RL Small Town.
+- Characters remain community-local and membership-owned.
+- Inactive personas should be visible for QA, but not switchable into an active
+  viewer.
+- Dev persona switching is a local QA shortcut. Real flows should use login
+  sessions and normal membership resolution.

--- a/plans/README.md
+++ b/plans/README.md
@@ -42,4 +42,5 @@ Prefer stable topic names over vague labels. Good names:
 | Plan | Status | Owner | Review By | Closure Criteria |
 | --- | --- | --- | --- | --- |
 | [Appearance Studio roadmap 2026-05-01](in-progress/appearance-studio-roadmap-2026-05-01.md) | in-progress | Product/UI stewardship | 2026-05-22 | Split into implementation issues or PR-sized plans covering the theme editor, ritual-surface variants, validation, and import/export support. |
+| [Auth and seed QA roadmap 2026-05-01](in-progress/auth-seed-qa-roadmap-2026-05-01.md) | in-progress | Auth, seed, and browser QA stewardship | 2026-05-22 | Split into PR-sized tasks for seed personas, local login sessions, persona matrix docs, and capability granularity. |
 | [Steward backlog rollup 2026-05-01](in-progress/steward-backlog-rollup-2026-05-01.md) | in-progress | Steward workflow | 2026-05-15 | Split into concrete backlog items or archive as superseded. |

--- a/plans/in-progress/auth-seed-qa-roadmap-2026-05-01.md
+++ b/plans/in-progress/auth-seed-qa-roadmap-2026-05-01.md
@@ -1,0 +1,211 @@
+# Auth And Seed QA Roadmap
+
+Created: 2026-05-01
+Last updated: 2026-05-01
+Review by: 2026-05-22
+Owner: Auth, seed, and browser QA stewardship
+Status: in-progress
+
+## Problem
+
+Elbysodic has the right internal identity model: global `User`,
+community-local `CommunityMembership`, membership-scoped roles, and
+membership-owned characters. The browser experience is still hard to test
+because identity is mostly a development switcher layered over the seeded user.
+
+That makes staff/member differences, multi-community membership, inactive
+memberships, and active-face behavior technically covered in tests but awkward
+to exercise manually.
+
+## Current Boundary
+
+- `users.password_hash` already exists, but there are no login/logout routes.
+- `RequestIdentityResolver` resolves request identity from dev headers, host,
+  a development identity cookie, or the seeded default.
+- `/identity` can switch among memberships for the current seeded user.
+- Studio edit access is correctly membership-role based through named policy
+  helpers.
+- Seed data has useful roles and characters, but persona intent is implicit.
+
+## Goals
+
+1. Make manual browser QA possible across predictable user, membership, role,
+   and face combinations.
+2. Keep staff power community-local. A user who is staff in one board must not
+   gain staff powers elsewhere.
+3. Preserve pseudonymous PBP identity: login account, community membership, and
+   character face stay distinct.
+4. Add enough real auth flow to test the product without committing to hosted
+   account recovery, email verification, billing, or OAuth.
+5. Keep all dev QA helpers visibly development-only.
+
+## Non-Goals
+
+- Public registration.
+- Password reset and email verification.
+- OAuth/social login.
+- Invite-only onboarding.
+- Multi-tenant billing, custom domain onboarding, or hosted community creation.
+- A full permission matrix UI. V1 can keep role capabilities mapped through
+  `role.is_admin` while preserving named policy helpers.
+
+## Phase 1: Seed Personas And QA Directory
+
+Goal: make the current dev identity switcher reliable and understandable.
+
+Work:
+
+- Define named seed personas with stable email, password, membership, role,
+  default face, and test purpose.
+- Add a `/dev/personas` or Studio-only QA panel listing seeded personas,
+  community memberships, roles, active/default faces, and direct switch actions.
+- Rename or supplement ambiguous seeded identities so the browser tells the
+  tester what each persona is for.
+- Ensure each core community has at least:
+  - one director/staff membership
+  - one ordinary writer with accepted faces
+  - one writer with an application/draft-facing flow
+  - one outsider/non-participant for private room and notification checks
+  - one inactive membership for denial/recovery checks
+- Keep persona seed data idempotent.
+
+Acceptance checks:
+
+- Browser can switch to each seeded persona without knowing database IDs.
+- Studio controls are editable for staff personas and read-only for ordinary
+  writers.
+- Notifications, private rooms, applications, claims, wanted interest, and
+  plotting rooms have at least one manual QA persona each.
+- Tests assert the persona directory does not render outside development mode.
+
+## Phase 2: Minimal Local Login Session
+
+Goal: replace the seeded-user assumption with a real signed-in user session for
+local/manual QA while keeping the same request identity boundary.
+
+Work:
+
+- Add `user_sessions` table with `id`, `user_id`, `token_hash`, `created_at`,
+  `last_seen_at`, and optional `expires_at`/`revoked_at`.
+- Add repository methods to create, look up, touch, and revoke sessions.
+- Add `AuthService` methods for login, logout, and current-user resolution.
+- Add `/login` and `/logout` routes with server-rendered forms.
+- Resolve user from a secure-ish local session cookie first, then fall back to
+  dev identity behavior only when development mode is enabled.
+- Keep membership selection separate from login. Login selects the user;
+  community/host and membership resolver selects the community-local identity.
+
+Acceptance checks:
+
+- Signing in as one seeded account shows only that user's memberships in the
+  identity menu.
+- Logout clears the session and returns to the intended development fallback.
+- A forged membership id cannot be used by another logged-in user.
+- Inactive membership cannot become the viewer.
+- Session cookies use `HttpOnly`, `SameSite=Lax`, and a path scoped to the app.
+
+## Phase 3: Persona Matrix Seed Upgrade
+
+Goal: seed data should be a deliberate QA fixture, not just sample content.
+
+Work:
+
+- Add a small typed seed layer for personas, separate from world/story seed
+  content.
+- Document the matrix in a product or architecture page:
+  - account
+  - community
+  - membership username/display name
+  - role/capabilities
+  - default face
+  - relevant workflows
+- Add repository helpers or seed helpers that can assert a persona exists and
+  return its stable ids for tests.
+- Align Program Blueprint starter communities with explicit director/member
+  persona expectations.
+
+Acceptance checks:
+
+- Tests can ask for personas by semantic key rather than hard-coded username
+  guesses.
+- The matrix covers multi-community role differences: same user staff in one
+  program, member in another.
+- Seed reset stays idempotent and does not duplicate personas, memberships,
+  characters, notifications, or rooms.
+
+## Phase 4: Capability Granularity
+
+Goal: make authz testable before role editing exists.
+
+Work:
+
+- Keep named policy helpers as the public contract.
+- Decide whether V1 needs role-capability rows or whether `role.is_admin`
+  remains sufficient until staff role editing.
+- If adding capability rows, migrate existing admin roles into full capability
+  grants and update tests for partial staff roles.
+- Add manual QA personas for partial staff if and only if partial capability
+  roles become real product behavior.
+
+Acceptance checks:
+
+- Staff actions continue to route through policy helpers.
+- A partial staff persona, if introduced, can manage only its own capability
+  area.
+- No page handler directly checks `role.is_admin`.
+
+## Suggested Persona Matrix
+
+| Key | Account | Community | Membership | Role | Face | QA Purpose |
+| --- | --- | --- | --- | --- | --- | --- |
+| `xmen_writer` | `writer@example.com` | X-Men Apocalypse | `starlane` | Member | Rogue | ordinary writer, active face, queue, thread posting |
+| `xmen_staff` | `moira@example.com` | X-Men Apocalypse | `moira` | Staff | Moira | Studio, applications, claims, private staff rooms |
+| `xmen_mod` | `alex@example.com` | X-Men Apocalypse | `alex` | Moderator | Cyclops | thread lifecycle, moderation controls |
+| `xmen_partner` | `charlie@example.com` | X-Men Apocalypse | `charlie` | Member | Xavier | wanted/plotting-room counterparty |
+| `xmen_applicant` | `mira@example.com` | X-Men Apocalypse | `mira` | Member | Kitty | application and revision workflow |
+| `hp_director` | `writer@example.com` | HP Universe | `starlane` | Director | Rowan Ash | same login with staff power in another community |
+| `jp_director` | `writer@example.com` | Jurassic Park Universe | `starlane` | Director | Dr. Mara Vale | visual/theme and director controls |
+| `nyc_writer` | `writer@example.com` | RL NYC | `starlane` | Member | Mina Park | same login without staff power in another community |
+| `smalltown_writer` | `writer@example.com` | RL Small Town | `starlane` | Member | June Calloway | low-stakes writer community |
+
+## Ordering
+
+1. Phase 1 first. It gives immediate browser QA value without schema risk.
+2. Phase 2 next. Login/session should reuse the same resolver instead of
+   replacing it.
+3. Phase 3 after login shape is clear, so seed personas match how testers enter
+   the app.
+4. Phase 4 only when staff role differences become product-visible.
+
+## Risks
+
+- Dev helpers accidentally becoming production UI. Gate them through explicit
+  development mode and tests.
+- Confusing user, membership, and face labels. The UI should call them account,
+  membership, and wearing/current face consistently.
+- Overbuilding auth before hosted product needs are clear. Keep V1 local and
+  session-based.
+- Letting a global user carry staff power across communities. Tests must cover
+  same-user, different-community role differences.
+
+## Steward Notes
+
+Consulted:
+
+- root `AGENTS.md`: global user, community-local membership, no global
+  characters, staff power belongs to membership.
+- `src/elbysodic/services/AGENTS.md`: request identity, policy helpers, and
+  inactive-membership boundaries.
+- `src/elbysodic/web/AGENTS.md`: server-rendered flows and no private data
+  leakage into rendered surfaces.
+- `src/elbysodic/db/AGENTS.md`: idempotent seed data and tenant-scoped storage.
+- `src/elbysodic/domain/AGENTS.md`: identity primitives remain explicit.
+- `docs/architecture/multi-tenancy.md` and
+  `docs/architecture/security-boundaries.md`: request identity is current
+  scaffolding, not final authentication.
+
+Open follow-up:
+
+- Decide exact development-mode flag name before building `/dev/personas`.
+- Decide whether to use a simple standard-library password hash first or bring
+  in a dedicated password hashing dependency.

--- a/src/elbysodic/db/migrations.py
+++ b/src/elbysodic/db/migrations.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-CURRENT_SCHEMA_VERSION = 7
+CURRENT_SCHEMA_VERSION = 8
 BASELINE_MIGRATION_NAME = "baseline-current-schema"
 
 
@@ -353,6 +353,28 @@ def _add_community_media_slots(connection: sqlite3.Connection) -> None:
             )
 
 
+def _add_user_sessions(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_sessions (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            token_hash TEXT NOT NULL UNIQUE,
+            created_at TEXT NOT NULL,
+            last_seen_at TEXT NOT NULL,
+            expires_at TEXT,
+            revoked_at TEXT
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_user_sessions_user
+        ON user_sessions(user_id, revoked_at, expires_at)
+        """
+    )
+
+
 MIGRATIONS: tuple[Migration, ...] = (
     Migration(2, "plotting-room-planning-fields", _add_plotting_room_planning_fields),
     Migration(3, "plotting-room-messages", _add_plotting_room_messages),
@@ -360,6 +382,7 @@ MIGRATIONS: tuple[Migration, ...] = (
     Migration(5, "realm-interactions", _add_realm_interactions),
     Migration(6, "intake-claims", _add_intake_claims),
     Migration(7, "community-media-slots", _add_community_media_slots),
+    Migration(8, "user-sessions", _add_user_sessions),
 )
 
 

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -9,9 +9,17 @@ from elbysodic.db.repositories.rows import (
     _membership_from_row,
     _role_from_row,
     _user_from_row,
+    _user_session_from_row,
 )
 from elbysodic.domain.context import DEFAULT_COMMUNITY_ID, DEFAULT_COMMUNITY_SLUG
-from elbysodic.domain.models import Community, CommunityMembership, CommunityTheme, Role, User
+from elbysodic.domain.models import (
+    Community,
+    CommunityMembership,
+    CommunityTheme,
+    Role,
+    User,
+    UserSession,
+)
 
 
 class IdentityRepositoryMixin(RepositoryBase):
@@ -401,6 +409,76 @@ class IdentityRepositoryMixin(RepositoryBase):
         if row is None:
             raise LookupError(f"user not found: {email}")
         return _user_from_row(row)
+
+    def create_user_session(
+        self,
+        user_id: int,
+        token_hash: str,
+        *,
+        expires_at: str | None = None,
+    ) -> UserSession:
+        self.get_user(user_id)
+        now = _utc_now()
+        cursor = self.connection.execute(
+            """
+            INSERT INTO user_sessions (
+                user_id, token_hash, created_at, last_seen_at, expires_at, revoked_at
+            )
+            VALUES (?, ?, ?, ?, ?, NULL)
+            """,
+            (user_id, token_hash, now, now, expires_at),
+        )
+        self.connection.commit()
+        return self.get_user_session(_last_id(cursor))
+
+    def get_user_session(self, session_id: int) -> UserSession:
+        row = self.connection.execute(
+            """
+            SELECT id, user_id, token_hash, created_at, last_seen_at, expires_at, revoked_at
+            FROM user_sessions
+            WHERE id = ?
+            """,
+            (session_id,),
+        ).fetchone()
+        if row is None:
+            raise LookupError(f"user session not found: {session_id}")
+        return _user_session_from_row(row)
+
+    def get_user_session_by_token_hash(self, token_hash: str) -> UserSession:
+        row = self.connection.execute(
+            """
+            SELECT id, user_id, token_hash, created_at, last_seen_at, expires_at, revoked_at
+            FROM user_sessions
+            WHERE token_hash = ?
+            """,
+            (token_hash,),
+        ).fetchone()
+        if row is None:
+            raise LookupError("user session not found")
+        return _user_session_from_row(row)
+
+    def touch_user_session(self, session_id: int) -> UserSession:
+        self.connection.execute(
+            """
+            UPDATE user_sessions
+            SET last_seen_at = ?
+            WHERE id = ?
+            """,
+            (_utc_now(), session_id),
+        )
+        self.connection.commit()
+        return self.get_user_session(session_id)
+
+    def revoke_user_session_by_token_hash(self, token_hash: str) -> None:
+        self.connection.execute(
+            """
+            UPDATE user_sessions
+            SET revoked_at = COALESCE(revoked_at, ?)
+            WHERE token_hash = ?
+            """,
+            (_utc_now(), token_hash),
+        )
+        self.connection.commit()
 
     def create_role(
         self,

--- a/src/elbysodic/db/repositories/rows.py
+++ b/src/elbysodic/db/repositories/rows.py
@@ -44,6 +44,7 @@ from elbysodic.domain.models import (
     ThreadParticipant,
     ThreadWatch,
     User,
+    UserSession,
     WantedAd,
     WantedAdInterest,
 )
@@ -89,6 +90,18 @@ def _user_from_row(row: sqlite3.Row) -> User:
         email=row["email"],
         password_hash=row["password_hash"],
         created_at=row["created_at"],
+    )
+
+
+def _user_session_from_row(row: sqlite3.Row) -> UserSession:
+    return UserSession(
+        id=row["id"],
+        user_id=row["user_id"],
+        token_hash=row["token_hash"],
+        created_at=row["created_at"],
+        last_seen_at=row["last_seen_at"],
+        expires_at=row["expires_at"],
+        revoked_at=row["revoked_at"],
     )
 
 

--- a/src/elbysodic/db/schema.py
+++ b/src/elbysodic/db/schema.py
@@ -38,6 +38,16 @@ CREATE TABLE IF NOT EXISTS users (
     created_at TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS user_sessions (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    expires_at TEXT,
+    revoked_at TEXT
+);
+
 CREATE TABLE IF NOT EXISTS roles (
     id INTEGER PRIMARY KEY,
     community_id INTEGER NOT NULL REFERENCES communities(id) ON DELETE CASCADE,

--- a/src/elbysodic/db/seed.py
+++ b/src/elbysodic/db/seed.py
@@ -96,6 +96,132 @@ class ClaimSeed:
     status: str = "claimed"
 
 
+@dataclass(frozen=True, slots=True)
+class SeedPersona:
+    key: str
+    label: str
+    email: str
+    community_slug: str
+    username: str
+    character_slug: str
+    purpose: str
+    default_path: str = "/"
+
+
+SEED_PERSONAS: tuple[SeedPersona, ...] = (
+    SeedPersona(
+        "xmen_writer",
+        "X-Men writer",
+        "writer@example.com",
+        "default",
+        "starlane",
+        "rogue",
+        "Ordinary writer with accepted faces, active-face queue, and scene posting.",
+        "/my/threads",
+    ),
+    SeedPersona(
+        "xmen_staff",
+        "X-Men staff",
+        "moira@example.com",
+        "default",
+        "moira",
+        "moira-mactaggert",
+        "Staff controls for Studio, applications, claims, and private production rooms.",
+        "/studio",
+    ),
+    SeedPersona(
+        "xmen_mod",
+        "X-Men moderator",
+        "alex@example.com",
+        "default",
+        "alex",
+        "cyclops",
+        "Thread lifecycle and moderation controls without changing the default writer.",
+        "/studio/operations",
+    ),
+    SeedPersona(
+        "xmen_partner",
+        "X-Men plotting partner",
+        "charlie@example.com",
+        "default",
+        "charlie",
+        "charles-xavier",
+        "Wanted, plotter, plotting-room, and notification counterparty checks.",
+        "/plotting",
+    ),
+    SeedPersona(
+        "xmen_applicant",
+        "X-Men applicant",
+        "mira@example.com",
+        "default",
+        "mira",
+        "kitty-pryde",
+        "Submitted application and writer-side revision workflow.",
+        "/applications",
+    ),
+    SeedPersona(
+        "xmen_outsider",
+        "X-Men outsider",
+        "simon@example.com",
+        "default",
+        "simon",
+        "bolivar-trask",
+        "Non-staff outsider for private-room, notification, and denial checks.",
+        "/notifications",
+    ),
+    SeedPersona(
+        "xmen_inactive",
+        "X-Men inactive member",
+        "inactive@example.com",
+        "default",
+        "sleepingstar",
+        "sleeping-star",
+        "Inactive membership for recovery and authorization denial checks.",
+        "/members",
+    ),
+    SeedPersona(
+        "hp_director",
+        "HP director",
+        "writer@example.com",
+        "hp-universe",
+        "starlane",
+        "rowan-ash",
+        "Same login as X-Men writer, but with director powers in another community.",
+        "/studio",
+    ),
+    SeedPersona(
+        "jp_director",
+        "Jurassic Park director",
+        "writer@example.com",
+        "jurassic-park-universe",
+        "starlane",
+        "lena-marquez",
+        "Director controls for a visually different action-survival community.",
+        "/studio",
+    ),
+    SeedPersona(
+        "nyc_writer",
+        "NYC writer",
+        "writer@example.com",
+        "rl-nyc",
+        "starlane",
+        "lena-park",
+        "Same login without staff power in a contemporary city community.",
+        "/my/threads",
+    ),
+    SeedPersona(
+        "smalltown_writer",
+        "Small-town writer",
+        "writer@example.com",
+        "rl-small-town",
+        "starlane",
+        "june-calloway",
+        "Same login in a low-stakes ensemble community.",
+        "/my/threads",
+    ),
+)
+
+
 STUDIO_NETWORK_PROGRAMS: tuple[ProgramBlueprint, ...] = (
     ProgramBlueprint(
         slug="hp-universe",
@@ -1339,6 +1465,29 @@ def seed_demo_forum(repo: ForumRepository) -> DemoSeed:
             "Simon",
         ),
     )
+    inactive_user = _get_or_create(
+        lambda: repo.get_user_by_email("inactive@example.com"),
+        lambda: repo.create_user("inactive@example.com", "dev-password-hash"),
+    )
+    inactive_membership = _get_or_create(
+        lambda: repo.get_membership_for_user(community.id, inactive_user.id),
+        lambda: repo.create_membership(
+            community.id,
+            inactive_user.id,
+            member_role.id,
+            "sleepingstar",
+            "Sleeping Star",
+        ),
+    )
+    repo.connection.execute(
+        """
+        UPDATE community_memberships
+        SET is_active = 0
+        WHERE community_id = ? AND id = ?
+        """,
+        (community.id, inactive_membership.id),
+    )
+    repo.connection.commit()
 
     rogue = _get_or_create(
         lambda: repo.get_character_by_slug(community.id, "rogue"),
@@ -1426,6 +1575,17 @@ def seed_demo_forum(repo: ForumRepository) -> DemoSeed:
             make_default=True,
         ),
     )
+    sleeping_star = _get_or_create(
+        lambda: repo.get_character_by_slug(community.id, "sleeping-star"),
+        lambda: repo.create_character(
+            community.id,
+            inactive_membership.id,
+            "sleeping-star",
+            "Sleeping Star",
+            summary="Inactive QA face used to prove dormant memberships cannot act.",
+            make_default=True,
+        ),
+    )
     rogue = repo.update_character_application_status(community.id, rogue.id, "accepted")
     storm = repo.update_character_application_status(community.id, storm.id, "accepted")
     magneto = repo.update_character_application_status(community.id, magneto.id, "accepted")
@@ -1434,6 +1594,11 @@ def seed_demo_forum(repo: ForumRepository) -> DemoSeed:
     cyclops = repo.update_character_application_status(community.id, cyclops.id, "accepted")
     moira = repo.update_character_application_status(community.id, moira.id, "accepted")
     trask = repo.update_character_application_status(community.id, trask.id, "revision_requested")
+    sleeping_star = repo.update_character_application_status(
+        community.id,
+        sleeping_star.id,
+        "accepted",
+    )
 
     rogue = _ensure_character_identity(
         repo,
@@ -1531,6 +1696,18 @@ def seed_demo_forum(repo: ForumRepository) -> DemoSeed:
         post_title_style="condensed",
         post_density="dramatic",
     )
+    sleeping_star = _ensure_character_identity(
+        repo,
+        community.id,
+        sleeping_star,
+        tagline="Dormant by design.",
+        accent_color="",
+        post_profile_variant="bio",
+        post_accent_style="soft",
+        post_border_style="hairline",
+        post_title_style="standard",
+        post_density="calm",
+    )
 
     membership = repo.get_membership(community.id, membership.id)
     if membership.default_character_id is None:
@@ -1550,6 +1727,9 @@ def seed_demo_forum(repo: ForumRepository) -> DemoSeed:
     simon_membership = repo.get_membership(community.id, simon_membership.id)
     if simon_membership.default_character_id is None:
         repo.set_default_character(community.id, simon_membership.id, trask.id)
+    inactive_membership = repo.get_membership(community.id, inactive_membership.id)
+    if inactive_membership.default_character_id is None:
+        repo.set_default_character(community.id, inactive_membership.id, sleeping_star.id)
 
     announcements = _ensure_board(
         repo,

--- a/src/elbysodic/db/seed.py
+++ b/src/elbysodic/db/seed.py
@@ -26,6 +26,7 @@ from elbysodic.domain.models import (
     CommunityMembership,
     Facet,
     Material,
+    Role,
     User,
 )
 
@@ -106,6 +107,16 @@ class SeedPersona:
     character_slug: str
     purpose: str
     default_path: str = "/"
+
+
+@dataclass(frozen=True, slots=True)
+class SeedPersonaContext:
+    persona: SeedPersona
+    user: User
+    community: Community
+    membership: CommunityMembership
+    role: Role
+    character: Character | None
 
 
 SEED_PERSONAS: tuple[SeedPersona, ...] = (
@@ -220,6 +231,40 @@ SEED_PERSONAS: tuple[SeedPersona, ...] = (
         "/my/threads",
     ),
 )
+
+
+def seed_persona_by_key(persona_key: str) -> SeedPersona:
+    for persona in SEED_PERSONAS:
+        if persona.key == persona_key:
+            return persona
+    raise LookupError(f"seed persona not found: {persona_key}")
+
+
+def resolve_seed_persona(repo: ForumRepository, persona_key: str) -> SeedPersonaContext:
+    persona = seed_persona_by_key(persona_key)
+    community = repo.get_community_by_slug(persona.community_slug)
+    user = repo.get_user_by_email(persona.email)
+    membership = repo.get_membership_by_username(community.id, persona.username)
+    if membership.user_id != user.id:
+        raise LookupError(
+            f"seed persona {persona.key} membership does not belong to {persona.email}"
+        )
+    role = repo.get_role(community.id, membership.role_id)
+    character = None
+    if persona.character_slug:
+        character = repo.get_character_by_slug(community.id, persona.character_slug)
+        if character.membership_id != membership.id:
+            raise LookupError(
+                f"seed persona {persona.key} character does not belong to @{persona.username}"
+            )
+    return SeedPersonaContext(
+        persona=persona,
+        user=user,
+        community=community,
+        membership=membership,
+        role=role,
+        character=character,
+    )
 
 
 STUDIO_NETWORK_PROGRAMS: tuple[ProgramBlueprint, ...] = (

--- a/src/elbysodic/domain/models.py
+++ b/src/elbysodic/domain/models.py
@@ -48,6 +48,17 @@ class User:
 
 
 @dataclass(frozen=True, slots=True)
+class UserSession:
+    id: int
+    user_id: int
+    token_hash: str
+    created_at: str
+    last_seen_at: str
+    expires_at: str | None
+    revoked_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class Role:
     id: int
     community_id: int

--- a/src/elbysodic/services/access.py
+++ b/src/elbysodic/services/access.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from elbysodic.domain.context import RequestIdentityContext
-from elbysodic.domain.models import Community, CommunityMembership, User
+from elbysodic.domain.models import Community, CommunityMembership, User, UserSession
+from elbysodic.services.auth import SESSION_COOKIE, user_for_session_token
 
 DEV_COMMUNITY_HEADER = "x-elbysodic-community"
 DEV_MEMBERSHIP_HEADER = "x-elbysodic-membership-id"
@@ -26,6 +27,10 @@ class AccessRepository(Protocol):
     def get_membership_for_user(self, community_id: int, user_id: int) -> CommunityMembership: ...
 
     def get_user(self, user_id: int) -> User: ...
+
+    def get_user_session_by_token_hash(self, token_hash: str) -> UserSession: ...
+
+    def touch_user_session(self, session_id: int) -> UserSession: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,7 +58,8 @@ class RequestIdentityResolver:
         community = self._resolve_community(request)
         header_user_id = _optional_int_header(request, DEV_USER_HEADER)
         header_membership_id = _optional_int_header(request, DEV_MEMBERSHIP_HEADER)
-        user_id = header_user_id
+        session_user = None if header_user_id is not None else _session_user(self._repo, request)
+        user_id = header_user_id if header_user_id is not None else _user_id(session_user)
         membership_id = header_membership_id
         user_from_cookie = False
         membership_from_cookie = False
@@ -177,6 +183,23 @@ def _dev_identity_cookie(request: object | None) -> RequestIdentityContext | Non
         user_id=user_id,
         membership_id=membership_id,
     )
+
+
+def _session_user(repo: AccessRepository, request: object | None) -> User | None:
+    cookies = getattr(request, "cookies", None)
+    if cookies is None:
+        return None
+    getter = getattr(cookies, "get", None)
+    if getter is None:
+        return None
+    raw_value = getter(SESSION_COOKIE)
+    if raw_value is None:
+        return None
+    return user_for_session_token(repo, str(raw_value))
+
+
+def _user_id(user: User | None) -> int | None:
+    return user.id if user is not None else None
 
 
 def _request_host(request: object | None) -> str | None:

--- a/src/elbysodic/services/auth.py
+++ b/src/elbysodic/services/auth.py
@@ -1,0 +1,131 @@
+"""Small local authentication helpers for seed and browser QA flows."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Protocol
+
+from elbysodic.domain.models import User, UserSession
+
+SESSION_COOKIE = "elbysodic_session"
+SESSION_TTL = timedelta(days=30)
+HASH_SCHEME = "pbkdf2_sha256"
+HASH_ITERATIONS = 210_000
+SEED_LOGIN_PHRASE = "password"
+
+
+class AuthRepository(Protocol):
+    def get_user_by_email(self, email: str) -> User: ...
+
+    def get_user(self, user_id: int) -> User: ...
+
+    def create_user_session(
+        self,
+        user_id: int,
+        token_hash: str,
+        *,
+        expires_at: str | None = None,
+    ) -> UserSession: ...
+
+    def get_user_session_by_token_hash(self, token_hash: str) -> UserSession: ...
+
+    def touch_user_session(self, session_id: int) -> UserSession: ...
+
+    def revoke_user_session_by_token_hash(self, token_hash: str) -> None: ...
+
+
+class SessionLookupRepository(Protocol):
+    def get_user(self, user_id: int) -> User: ...
+
+    def get_user_session_by_token_hash(self, token_hash: str) -> UserSession: ...
+
+    def touch_user_session(self, session_id: int) -> UserSession: ...
+
+
+@dataclass(frozen=True, slots=True)
+class LoginSession:
+    user: User
+    token: str
+    expires_at: str
+
+
+def hash_password(password: str, *, salt: str | None = None) -> str:
+    normalized_salt = salt or secrets.token_urlsafe(16)
+    derived = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        normalized_salt.encode("utf-8"),
+        HASH_ITERATIONS,
+    )
+    digest = base64.urlsafe_b64encode(derived).decode("ascii").rstrip("=")
+    return f"{HASH_SCHEME}${HASH_ITERATIONS}${normalized_salt}${digest}"
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    if stored_hash == "dev-password-hash":
+        return hmac.compare_digest(password, SEED_LOGIN_PHRASE)
+    parts = stored_hash.split("$")
+    if len(parts) != 4 or parts[0] != HASH_SCHEME:
+        return False
+    _scheme, raw_iterations, salt, expected = parts
+    try:
+        iterations = int(raw_iterations)
+    except ValueError:
+        return False
+    derived = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt.encode("utf-8"),
+        iterations,
+    )
+    actual = base64.urlsafe_b64encode(derived).decode("ascii").rstrip("=")
+    return hmac.compare_digest(actual, expected)
+
+
+def create_login_session(repo: AuthRepository, email: str, password: str) -> LoginSession:
+    normalized_email = email.strip().lower()
+    if not normalized_email or not password:
+        raise PermissionError("email and password are required")
+    try:
+        user = repo.get_user_by_email(normalized_email)
+    except LookupError as exc:
+        raise PermissionError("email or password is incorrect") from exc
+    if not verify_password(password, user.password_hash):
+        raise PermissionError("email or password is incorrect")
+    token = secrets.token_urlsafe(32)
+    expires_at = (datetime.now(UTC) + SESSION_TTL).isoformat(timespec="seconds")
+    repo.create_user_session(
+        user.id,
+        session_token_hash(token),
+        expires_at=expires_at,
+    )
+    return LoginSession(user=user, token=token, expires_at=expires_at)
+
+
+def session_token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def user_for_session_token(repo: SessionLookupRepository, token: str) -> User | None:
+    if not token:
+        return None
+    try:
+        session = repo.get_user_session_by_token_hash(session_token_hash(token))
+    except LookupError:
+        return None
+    if session.revoked_at is not None:
+        return None
+    if session.expires_at is not None:
+        try:
+            expires_at = datetime.fromisoformat(session.expires_at)
+        except ValueError:
+            return None
+        if expires_at <= datetime.now(UTC):
+            return None
+    repo.touch_user_session(session.id)
+    return repo.get_user(session.user_id)

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -8,7 +8,14 @@ from pathlib import Path
 
 from elbysodic.blueprints import ProgramBlueprintPreview
 from elbysodic.db import ForumRepository, connect, create_schema
-from elbysodic.db.seed import SEED_PERSONAS, DemoSeed, SeedPersona, seed_demo_forum
+from elbysodic.db.seed import (
+    SEED_PERSONAS,
+    DemoSeed,
+    SeedPersona,
+    resolve_seed_persona,
+    seed_demo_forum,
+    seed_persona_by_key,
+)
 from elbysodic.domain.boards import (
     BOARD_KIND_GUIDANCE,
     BOARD_KIND_LABELS,
@@ -387,7 +394,7 @@ class AppServices:
         return [self._dev_persona_view(persona, identity) for persona in SEED_PERSONAS]
 
     def switch_dev_persona(self, persona_key: str) -> RequestIdentityContext:
-        persona = _seed_persona_by_key(persona_key)
+        persona = seed_persona_by_key(persona_key)
         view = self._dev_persona_view(
             persona,
             self._identity_context or self._identity_resolver.resolve(),
@@ -406,39 +413,26 @@ class AppServices:
         persona: SeedPersona,
         identity: RequestIdentityContext,
     ) -> DevPersonaView:
-        community = self.repo.get_community_by_slug(persona.community_slug)
-        user = self.repo.get_user_by_email(persona.email)
-        membership = self.repo.get_membership_by_username(community.id, persona.username)
-        if membership.user_id != user.id:
-            raise LookupError(
-                f"seed persona {persona.key} membership does not belong to {persona.email}"
-            )
-        role = self.repo.get_role(community.id, membership.role_id)
-        character = None
-        if persona.character_slug:
-            character = self.repo.get_character_by_slug(community.id, persona.character_slug)
-            if character.membership_id != membership.id:
-                raise LookupError(
-                    f"seed persona {persona.key} character does not belong to @{persona.username}"
-                )
+        context = resolve_seed_persona(self.repo, persona.key)
         return DevPersonaView(
             key=persona.key,
             label=persona.label,
             purpose=persona.purpose,
             default_path=persona.default_path,
-            user=user,
-            community=community,
-            membership=membership,
-            role=role,
-            character=character,
-            can_switch=membership.is_active,
+            user=context.user,
+            community=context.community,
+            membership=context.membership,
+            role=context.role,
+            character=context.character,
+            can_switch=context.membership.is_active,
             is_current=(
-                identity.community_id == community.id and identity.membership_id == membership.id
+                identity.community_id == context.community.id
+                and identity.membership_id == context.membership.id
             ),
             can_manage_studio=(
-                policies.can_manage_world(membership, role)
-                or policies.can_manage_casting(membership, role)
-                or policies.can_manage_navigation(membership, role)
+                policies.can_manage_world(context.membership, context.role)
+                or policies.can_manage_casting(context.membership, context.role)
+                or policies.can_manage_navigation(context.membership, context.role)
             ),
         )
 
@@ -2951,13 +2945,6 @@ def _network_theme_preview(theme: object | None) -> StudioNetworkThemePreview:
             "var(--elbysodic-display-font-family)",
         ),
     )
-
-
-def _seed_persona_by_key(persona_key: str) -> SeedPersona:
-    for persona in SEED_PERSONAS:
-        if persona.key == persona_key:
-            return persona
-    raise LookupError(f"seed persona not found: {persona_key}")
 
 
 def _apply_post_style_preset(

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -57,6 +57,7 @@ from elbysodic.services.applications import (
 )
 from elbysodic.services.applications import update_application_draft as _update_application_draft
 from elbysodic.services.applications import update_application_review as _update_application_review
+from elbysodic.services.auth import LoginSession, create_login_session, session_token_hash
 from elbysodic.services.blueprints import preview_program_blueprint as _preview_program_blueprint
 from elbysodic.services.casting import casting_desk as _casting_desk
 from elbysodic.services.casting import (
@@ -383,10 +384,7 @@ class AppServices:
 
     def dev_personas(self) -> list[DevPersonaView]:
         identity = self._identity_context or self._identity_resolver.resolve()
-        personas: list[DevPersonaView] = []
-        for persona in SEED_PERSONAS:
-            personas.append(self._dev_persona_view(persona, identity))
-        return personas
+        return [self._dev_persona_view(persona, identity) for persona in SEED_PERSONAS]
 
     def switch_dev_persona(self, persona_key: str) -> RequestIdentityContext:
         persona = _seed_persona_by_key(persona_key)
@@ -443,6 +441,50 @@ class AppServices:
                 or policies.can_manage_navigation(membership, role)
             ),
         )
+
+    def login(self, email: str, password: str) -> tuple[LoginSession, RequestIdentityContext]:
+        session = create_login_session(self.repo, email, password)
+        current_identity = self._identity_context or self._identity_resolver.resolve()
+        identity = self._default_identity_for_user(
+            session.user.id,
+            preferred_community_id=current_identity.community_id,
+        )
+        return session, identity
+
+    def logout(self, session_token: str) -> None:
+        if session_token:
+            self.repo.revoke_user_session_by_token_hash(session_token_hash(session_token))
+
+    def _default_identity_for_user(
+        self,
+        user_id: int,
+        *,
+        preferred_community_id: int | None = None,
+    ) -> RequestIdentityContext:
+        if preferred_community_id is not None:
+            try:
+                membership = self.repo.get_membership_for_user(preferred_community_id, user_id)
+                if membership.is_active:
+                    community = self.repo.get_community(preferred_community_id)
+                    return RequestIdentityContext(
+                        community_id=community.id,
+                        community_slug=community.slug,
+                        user_id=user_id,
+                        membership_id=membership.id,
+                    )
+            except LookupError:
+                pass
+        for membership in self.repo.list_memberships_for_user(user_id):
+            if not membership.is_active:
+                continue
+            community = self.repo.get_community(membership.community_id)
+            return RequestIdentityContext(
+                community_id=community.id,
+                community_slug=community.slug,
+                user_id=user_id,
+                membership_id=membership.id,
+            )
+        raise PermissionError(f"user {user_id} has no active memberships")
 
     def studio_network(self) -> StudioNetworkDirectory:
         identity = self._identity_context or self._identity_resolver.resolve()

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from elbysodic.blueprints import ProgramBlueprintPreview
 from elbysodic.db import ForumRepository, connect, create_schema
-from elbysodic.db.seed import DemoSeed, seed_demo_forum
+from elbysodic.db.seed import SEED_PERSONAS, DemoSeed, SeedPersona, seed_demo_forum
 from elbysodic.domain.boards import (
     BOARD_KIND_GUIDANCE,
     BOARD_KIND_LABELS,
@@ -175,6 +175,7 @@ from elbysodic.services.read_models import (
     CharacterRosterDashboard,
     ClaimsDirectory,
     CreatedThread,
+    DevPersonaView,
     DirectorStudio,
     EditablePostView,
     FacetTag,
@@ -378,6 +379,69 @@ class AppServices:
             )
         raise PermissionError(
             f"user {identity.user_id} cannot switch to membership {membership_id}"
+        )
+
+    def dev_personas(self) -> list[DevPersonaView]:
+        identity = self._identity_context or self._identity_resolver.resolve()
+        personas: list[DevPersonaView] = []
+        for persona in SEED_PERSONAS:
+            personas.append(self._dev_persona_view(persona, identity))
+        return personas
+
+    def switch_dev_persona(self, persona_key: str) -> RequestIdentityContext:
+        persona = _seed_persona_by_key(persona_key)
+        view = self._dev_persona_view(
+            persona,
+            self._identity_context or self._identity_resolver.resolve(),
+        )
+        if not view.can_switch:
+            raise PermissionError(f"persona {persona.key} is inactive")
+        return RequestIdentityContext(
+            community_id=view.community.id,
+            community_slug=view.community.slug,
+            user_id=view.user.id,
+            membership_id=view.membership.id,
+        )
+
+    def _dev_persona_view(
+        self,
+        persona: SeedPersona,
+        identity: RequestIdentityContext,
+    ) -> DevPersonaView:
+        community = self.repo.get_community_by_slug(persona.community_slug)
+        user = self.repo.get_user_by_email(persona.email)
+        membership = self.repo.get_membership_by_username(community.id, persona.username)
+        if membership.user_id != user.id:
+            raise LookupError(
+                f"seed persona {persona.key} membership does not belong to {persona.email}"
+            )
+        role = self.repo.get_role(community.id, membership.role_id)
+        character = None
+        if persona.character_slug:
+            character = self.repo.get_character_by_slug(community.id, persona.character_slug)
+            if character.membership_id != membership.id:
+                raise LookupError(
+                    f"seed persona {persona.key} character does not belong to @{persona.username}"
+                )
+        return DevPersonaView(
+            key=persona.key,
+            label=persona.label,
+            purpose=persona.purpose,
+            default_path=persona.default_path,
+            user=user,
+            community=community,
+            membership=membership,
+            role=role,
+            character=character,
+            can_switch=membership.is_active,
+            is_current=(
+                identity.community_id == community.id and identity.membership_id == membership.id
+            ),
+            can_manage_studio=(
+                policies.can_manage_world(membership, role)
+                or policies.can_manage_casting(membership, role)
+                or policies.can_manage_navigation(membership, role)
+            ),
         )
 
     def studio_network(self) -> StudioNetworkDirectory:
@@ -2845,6 +2909,13 @@ def _network_theme_preview(theme: object | None) -> StudioNetworkThemePreview:
             "var(--elbysodic-display-font-family)",
         ),
     )
+
+
+def _seed_persona_by_key(persona_key: str) -> SeedPersona:
+    for persona in SEED_PERSONAS:
+        if persona.key == persona_key:
+            return persona
+    raise LookupError(f"seed persona not found: {persona_key}")
 
 
 def _apply_post_style_preset(

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -36,6 +36,7 @@ from elbysodic.domain.models import (
     Role,
     SidebarSectionConfig,
     Thread,
+    User,
     WantedAd,
     WantedAdInterest,
 )
@@ -1321,6 +1322,22 @@ class StudioIdentityOption:
     current_character: Character | None
     unread_notification_count: int
     is_current: bool
+
+
+@dataclass(frozen=True, slots=True)
+class DevPersonaView:
+    key: str
+    label: str
+    purpose: str
+    default_path: str
+    user: User
+    community: Community
+    membership: CommunityMembership
+    role: Role
+    character: Character | None
+    can_switch: bool
+    is_current: bool
+    can_manage_studio: bool
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/elbysodic/web/app.py
+++ b/src/elbysodic/web/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any, cast
 
@@ -12,10 +13,11 @@ from chirp.middleware.static import StaticFiles
 
 from elbysodic.services import AppServices, create_services
 from elbysodic.web.navigation import location_nav_tree_items
-from elbysodic.web.state import configure_services
+from elbysodic.web.state import configure_services, dev_tools_enabled
 
 PAGES_DIR = Path(__file__).parent / "pages"
 STATIC_DIR = Path(__file__).parent / "static"
+DEV_TOOLS_ENV = "ELBYSODIC_DEV_TOOLS"
 
 
 def create_app(
@@ -23,18 +25,32 @@ def create_app(
     debug: bool = True,
     services: AppServices | None = None,
     db_path: str | Path | None = None,
+    dev_tools: bool | None = None,
 ) -> App:
     config = AppConfig(template_dir=PAGES_DIR, debug=debug)
     app = App(config=config)
 
-    configure_services(services or create_services(db_path))
+    configure_services(
+        services or create_services(db_path),
+        dev_tools_enabled=_resolve_dev_tools(debug=debug, dev_tools=dev_tools),
+    )
     use_chirp_ui(app)
     app.template_global()(location_nav_tree_items)
+    app.template_global()(dev_tools_enabled)
     app.add_middleware(StaticFiles(directory=str(STATIC_DIR), prefix="/elbysodic-static"))
     app.mount_pages(str(PAGES_DIR))
     _copy_page_contracts(app)
 
     return app
+
+
+def _resolve_dev_tools(*, debug: bool, dev_tools: bool | None) -> bool:
+    if dev_tools is not None:
+        return dev_tools
+    configured = os.environ.get(DEV_TOOLS_ENV)
+    if configured is not None:
+        return configured.strip().lower() not in {"0", "false", "no", "off"}
+    return debug
 
 
 def _copy_page_contracts(app: App) -> None:

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -196,6 +196,14 @@
           <span>Theme</span>
           {{ theme_toggle() }}
         </div>
+        {% if dev_tools_enabled() %}
+        <a class="elbysodic-identity-menu__notification-link{{ " elbysodic-identity-menu__notification-link--active" if topbar_path == "/dev/personas" or topbar_path.startswith("/dev/personas/") else "" }}"
+           href="/dev/personas"
+           {% if topbar_path == "/dev/personas" or topbar_path.startswith("/dev/personas/") %}aria-current="page"{% end %}>
+          Dev personas
+          <span>QA switcher</span>
+        </a>
+        {% end %}
       </div>
       {% if viewer.current_character %}
       <form action="/identity" method="post" hx-boost="false" class="elbysodic-identity-menu__face-form">

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -204,6 +204,16 @@
           <span>QA switcher</span>
         </a>
         {% end %}
+        <a class="elbysodic-identity-menu__notification-link{{ " elbysodic-identity-menu__notification-link--active" if topbar_path == "/login" else "" }}"
+           href="/login?next={{ current_path or "/" }}"
+           {% if topbar_path == "/login" %}aria-current="page"{% end %}>
+          Log in
+          <span>account session</span>
+        </a>
+        <a class="elbysodic-identity-menu__notification-link" href="/logout">
+          Log out
+          <span>clear session</span>
+        </a>
       </div>
       {% if viewer.current_character %}
       <form action="/identity" method="post" hx-boost="false" class="elbysodic-identity-menu__face-form">

--- a/src/elbysodic/web/pages/dev/personas/_meta.py
+++ b/src/elbysodic/web/pages/dev/personas/_meta.py
@@ -1,0 +1,3 @@
+from chirp.pages.types import RouteMeta
+
+META = RouteMeta(title="Dev Personas", breadcrumb_label="Dev Personas")

--- a/src/elbysodic/web/pages/dev/personas/page.html
+++ b/src/elbysodic/web/pages/dev/personas/page.html
@@ -1,0 +1,95 @@
+{% imports %}
+  {% from "chirpui/badge.html" import badge %}
+  {% from "chirpui/layout.html" import container, stack, section_header %}
+  {% from "chirpui/surface.html" import surface %}
+{% end %}
+
+{% def persona_card(persona) %}
+{% call surface(variant="elevated") %}
+<article class="chirpui-stack chirpui-stack--sm">
+  <header class="chirpui-cluster chirpui-cluster--between">
+    <div>
+      <p class="elbysodic-kicker">{{ persona.key }}</p>
+      <h2>{{ persona.label }}</h2>
+    </div>
+    <div class="chirpui-cluster chirpui-cluster--xs">
+      {{ badge("current", variant="success") if persona.is_current else "" }}
+      {{ badge("staff tools", variant="info") if persona.can_manage_studio else badge("writer", variant="muted") }}
+      {{ badge("inactive", variant="warning") if not persona.can_switch else "" }}
+    </div>
+  </header>
+  <p class="elbysodic-copy-summary">{{ persona.purpose }}</p>
+  <dl class="elbysodic-definition-grid">
+    <div>
+      <dt>Account</dt>
+      <dd>{{ persona.user.email }}</dd>
+    </div>
+    <div>
+      <dt>Community</dt>
+      <dd>{{ persona.community.name }}</dd>
+    </div>
+    <div>
+      <dt>Membership</dt>
+      <dd>@{{ persona.membership.username }} · {{ persona.role.name }}</dd>
+    </div>
+    <div>
+      <dt>Face</dt>
+      <dd>{{ persona.character.name if persona.character else "No face" }}</dd>
+    </div>
+  </dl>
+  <div class="chirpui-cluster chirpui-cluster--end">
+    {% if persona.can_switch %}
+    <form action="/dev/personas" method="post" hx-boost="false">
+      <input type="hidden" name="persona_key" value="{{ persona.key }}">
+      <input type="hidden" name="next" value="{{ persona.default_path }}">
+      <button class="chirpui-btn chirpui-btn--primary" type="submit">Use persona</button>
+    </form>
+    <form action="/dev/personas" method="post" hx-boost="false">
+      <input type="hidden" name="persona_key" value="{{ persona.key }}">
+      <input type="hidden" name="next" value="/dev/personas">
+      <button class="chirpui-btn chirpui-btn--secondary" type="submit">Switch and stay</button>
+    </form>
+    {% else %}
+    <button class="chirpui-btn chirpui-btn--secondary" type="button" disabled>Inactive membership</button>
+    {% end %}
+  </div>
+</article>
+{% end %}
+{% end %}
+
+{% block page_root %}
+<div id="page-root">
+{% block page_root_inner %}
+{% block page_content %}
+{% call container(max_width="76rem") %}
+{% call stack(gap="lg") %}
+  {% call section_header("Dev Personas") %}
+  Development-only browser QA identities for role, membership, and active-face checks.
+  {% end %}
+
+  {% call surface(variant="elevated") %}
+  <section class="chirpui-stack chirpui-stack--sm" aria-labelledby="current-persona-heading">
+    <p class="elbysodic-kicker">Current viewer</p>
+    <h1 id="current-persona-heading">@{{ viewer.membership.username }} in {{ viewer.community.name }}</h1>
+    <p class="elbysodic-copy-section">
+      {{ viewer.role.name }}
+      {% if viewer.current_character %}
+      · wearing {{ viewer.current_character.name }}
+      {% else %}
+      · no active face
+      {% end %}
+    </p>
+  </section>
+  {% end %}
+
+  <section class="elbysodic-network-grid" aria-label="Seed personas">
+    {% for persona in personas %}
+    {{ persona_card(persona) }}
+    {% end %}
+  </section>
+{% end %}
+{% end %}
+{% end %}
+</div>
+{% endblock %}
+{% endblock %}

--- a/src/elbysodic/web/pages/dev/personas/page.py
+++ b/src/elbysodic/web/pages/dev/personas/page.py
@@ -1,0 +1,72 @@
+"""Development-only seed persona switcher."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from chirp.contracts import FormContract, contract
+from chirp.errors import HTTPError
+from chirp.http.cookies import SetCookie
+from chirp.http.request import Request
+from chirp.http.response import Redirect
+from chirp.templating.returns import Page
+
+from elbysodic.services.access import DEV_IDENTITY_COOKIE, dev_identity_cookie_value
+from elbysodic.web.state import dev_tools_enabled, get_services
+
+
+@dataclass(frozen=True, slots=True)
+class DevPersonaForm:
+    persona_key: str = ""
+    next: str = "/dev/personas"
+
+
+def get(request: Request) -> Page:
+    if not dev_tools_enabled():
+        raise HTTPError(status=404, detail="dev personas are disabled")
+    services = get_services(request)
+    return Page(
+        "dev/personas/page.html",
+        "page_content",
+        page_block_name="page_root",
+        current_path=request.url,
+        viewer=services.viewer(),
+        personas=services.dev_personas(),
+    )
+
+
+@contract(form=FormContract(DevPersonaForm, "dev/personas/page.html"))
+async def post(request: Request) -> Redirect:
+    if not dev_tools_enabled():
+        raise HTTPError(status=404, detail="dev personas are disabled")
+    services = get_services(request)
+    form = await request.form()
+    persona_key = str(form.get("persona_key") or "")
+    next_url = _safe_next(str(form.get("next") or "/dev/personas"))
+    try:
+        identity = services.switch_dev_persona(persona_key)
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    return Redirect(
+        next_url,
+        headers=(
+            (
+                "Set-Cookie",
+                SetCookie(
+                    DEV_IDENTITY_COOKIE,
+                    dev_identity_cookie_value(identity),
+                    max_age=60 * 60 * 24 * 30,
+                    httponly=True,
+                    samesite="lax",
+                ).to_header_value(),
+            ),
+        ),
+    )
+
+
+def _safe_next(next_url: str) -> str:
+    if not next_url.startswith("/") or next_url.startswith("//"):
+        return "/dev/personas"
+    return next_url

--- a/src/elbysodic/web/pages/login/_meta.py
+++ b/src/elbysodic/web/pages/login/_meta.py
@@ -1,0 +1,3 @@
+from chirp.pages.types import RouteMeta
+
+META = RouteMeta(title="Log In", breadcrumb_label="Log In")

--- a/src/elbysodic/web/pages/login/page.html
+++ b/src/elbysodic/web/pages/login/page.html
@@ -1,0 +1,41 @@
+{% imports %}
+  {% from "chirpui/layout.html" import container, stack, section_header %}
+  {% from "chirpui/surface.html" import surface %}
+{% end %}
+
+{% block page_root %}
+<div id="page-root">
+{% block page_root_inner %}
+{% block page_content %}
+{% call container(max_width="42rem") %}
+{% call stack(gap="lg") %}
+  {% call section_header("Log In") %}
+  Choose the account first; Elbysodic will resolve the current community membership and active face after that.
+  {% end %}
+
+  {% call surface(variant="elevated") %}
+  <form method="post" class="chirpui-stack chirpui-stack--md" hx-boost="false">
+    <input type="hidden" name="next" value="{{ next_url }}">
+    {% if error %}
+    <p class="elbysodic-form-error">{{ error }}</p>
+    {% end %}
+    <label class="elbysodic-form-field">
+      <span>Email</span>
+      <input name="email" type="email" value="{{ email }}" autocomplete="username" required>
+    </label>
+    <label class="elbysodic-form-field">
+      <span>Password</span>
+      <input name="password" type="password" autocomplete="current-password" required>
+    </label>
+    <div class="chirpui-cluster chirpui-cluster--between">
+      <p class="elbysodic-copy-helper">Seed accounts use password: <code>password</code>.</p>
+      <button class="chirpui-btn chirpui-btn--primary" type="submit">Log in</button>
+    </div>
+  </form>
+  {% end %}
+{% end %}
+{% end %}
+{% end %}
+</div>
+{% endblock %}
+{% endblock %}

--- a/src/elbysodic/web/pages/login/page.py
+++ b/src/elbysodic/web/pages/login/page.py
@@ -1,0 +1,86 @@
+"""Local login route for seeded browser QA."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from chirp.contracts import FormContract, contract
+from chirp.http.cookies import SetCookie
+from chirp.http.request import Request
+from chirp.http.response import Response
+from chirp.templating.returns import Page
+
+from elbysodic.services.access import DEV_IDENTITY_COOKIE, dev_identity_cookie_value
+from elbysodic.services.auth import SESSION_COOKIE
+from elbysodic.web.state import get_services
+
+
+@dataclass(frozen=True, slots=True)
+class LoginForm:
+    email: str = ""
+    password: str = ""
+    next: str = "/"
+
+
+def get(request: Request) -> Page:
+    return _render_login(request)
+
+
+@contract(form=FormContract(LoginForm, "login/page.html"))
+async def post(request: Request) -> Page | Response:
+    form = await request.form()
+    next_url = _safe_next(str(form.get("next") or "/"))
+    email = str(form.get("email") or "")
+    password = str(form.get("password") or "")
+    services = get_services(request)
+    try:
+        session, identity = services.login(email, password)
+    except PermissionError as exc:
+        return _render_login(request, email=email, next_url=next_url, error=str(exc))
+    return Response(
+        "",
+        status=302,
+        headers=(("Location", next_url),),
+        cookies=(
+            SetCookie(
+                SESSION_COOKIE,
+                session.token,
+                max_age=60 * 60 * 24 * 30,
+                httponly=True,
+                samesite="lax",
+            ),
+            SetCookie(
+                DEV_IDENTITY_COOKIE,
+                dev_identity_cookie_value(identity),
+                max_age=60 * 60 * 24 * 30,
+                httponly=True,
+                samesite="lax",
+            ),
+        ),
+    )
+
+
+def _render_login(
+    request: Request,
+    *,
+    email: str = "",
+    next_url: str | None = None,
+    error: str | None = None,
+) -> Page:
+    services = get_services(request)
+    return Page(
+        "login/page.html",
+        "page_content",
+        page_block_name="page_root",
+        current_path=request.url,
+        viewer=services.viewer(),
+        email=email,
+        next_url=next_url or _safe_next(str(getattr(request, "query", {}).get("next", "/"))),
+        error=error,
+    )
+
+
+def _safe_next(next_url: str) -> str:
+    if not next_url.startswith("/") or next_url.startswith("//"):
+        return "/"
+    return next_url

--- a/src/elbysodic/web/pages/logout/_meta.py
+++ b/src/elbysodic/web/pages/logout/_meta.py
@@ -1,0 +1,3 @@
+from chirp.pages.types import RouteMeta
+
+META = RouteMeta(title="Log Out", breadcrumb_label="Log Out")

--- a/src/elbysodic/web/pages/logout/page.py
+++ b/src/elbysodic/web/pages/logout/page.py
@@ -1,0 +1,41 @@
+"""Local logout route."""
+
+from __future__ import annotations
+
+from chirp.http.cookies import SetCookie
+from chirp.http.request import Request
+from chirp.http.response import Response
+
+from elbysodic.services.access import DEV_IDENTITY_COOKIE
+from elbysodic.services.auth import SESSION_COOKIE
+from elbysodic.web.state import get_services
+
+
+def get(request: Request) -> Response:
+    return _logout(request)
+
+
+async def post(request: Request) -> Response:
+    _ = await request.form()
+    return _logout(request)
+
+
+def _logout(request: Request) -> Response:
+    services = get_services(request)
+    token = _cookie_value(request, SESSION_COOKIE)
+    if token is not None:
+        services.logout(token)
+    return Response(
+        "",
+        status=302,
+        headers=(("Location", "/login"),),
+        cookies=(
+            SetCookie(SESSION_COOKIE, "", max_age=0, httponly=True, samesite="lax"),
+            SetCookie(DEV_IDENTITY_COOKIE, "", max_age=0, httponly=True, samesite="lax"),
+        ),
+    )
+
+
+def _cookie_value(request: Request, name: str) -> str | None:
+    value = request.cookies.get(name)
+    return str(value) if value is not None else None

--- a/src/elbysodic/web/state.py
+++ b/src/elbysodic/web/state.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from elbysodic.services import AppServices
 
 _services: AppServices | None = None
+_dev_tools_enabled = False
 
 
-def configure_services(services: AppServices) -> None:
+def configure_services(services: AppServices, *, dev_tools_enabled: bool = False) -> None:
     global _services
+    global _dev_tools_enabled
     _services = services
+    _dev_tools_enabled = dev_tools_enabled
 
 
 def get_services(request: object | None = None) -> AppServices:
@@ -18,3 +21,7 @@ def get_services(request: object | None = None) -> AppServices:
     if request is not None:
         return _services.for_request(request)
     return _services
+
+
+def dev_tools_enabled() -> bool:
+    return _dev_tools_enabled

--- a/src/elbysodic/web/static/elbysodic-theme.css
+++ b/src/elbysodic/web/static/elbysodic-theme.css
@@ -6749,6 +6749,37 @@ body {
     margin: 0;
 }
 
+.elbysodic-definition-grid {
+    display: grid;
+    gap: 0.55rem;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 11rem), 1fr));
+    margin: 0;
+}
+
+.elbysodic-definition-grid div {
+    border: 1px solid var(--chirpui-border);
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    gap: 0.2rem;
+    min-inline-size: 0;
+    padding: 0.65rem;
+}
+
+.elbysodic-definition-grid dt {
+    color: var(--chirpui-text-muted);
+    font-size: 0.74rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.elbysodic-definition-grid dd {
+    color: var(--chirpui-text);
+    margin: 0;
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
+}
+
 .elbysodic-application-starter {
     align-items: start;
     display: grid;

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -48,6 +48,18 @@ def _response_header(response: Any, name: str) -> str:
     raise AssertionError(f"response header not found: {name}")
 
 
+def _response_headers(response: Any, name: str) -> list[str]:
+    headers = response.headers
+    if isinstance(headers, dict):
+        value = headers.get(name)
+        return [] if value is None else [str(value)]
+    values = []
+    for key, value in headers:
+        if str(key).lower() == name.lower():
+            values.append(str(value))
+    return values
+
+
 def _app():
     return create_app(debug=False, services=create_services(path=":memory:"))
 
@@ -385,6 +397,126 @@ def test_dev_persona_switcher_refuses_inactive_seed_persona() -> None:
             )
 
         assert response.status == 403
+
+    asyncio.run(run())
+
+
+def test_login_route_creates_account_session_and_membership_context() -> None:
+    async def run() -> None:
+        app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=True,
+        )
+
+        async with TestClient(app) as client:
+            page = await client.get("/login?next=/studio")
+            login = await client.post(
+                "/login",
+                body=urlencode(
+                    {
+                        "email": "moira@example.com",
+                        "password": "password",
+                        "next": "/studio",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            set_cookies = _response_headers(login, "set-cookie")
+            cookie_header = "; ".join(cookie.split(";", 1)[0] for cookie in set_cookies)
+            studio = await client.get("/studio", headers={"Cookie": cookie_header})
+
+        assert page.status == 200
+        assert "Seed accounts use password" in page.text
+        assert login.status == 302
+        assert _response_header(login, "location") == "/studio"
+        assert any(cookie.startswith("elbysodic_session=") for cookie in set_cookies)
+        assert any(cookie.startswith("elbysodic_dev_identity=") for cookie in set_cookies)
+        assert studio.status == 200
+        assert "Staff in X-Men Apocalypse" in studio.text
+        assert "Save theme tokens" in studio.text
+
+    asyncio.run(run())
+
+
+def test_session_user_overrides_forged_dev_identity_cookie() -> None:
+    async def run() -> None:
+        app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=True,
+        )
+        services = get_services()
+        community = services.seed.community
+        moira = services.repo.get_membership_by_username(community.id, "moira")
+
+        async with TestClient(app) as client:
+            login = await client.post(
+                "/login",
+                body=urlencode(
+                    {
+                        "email": "writer@example.com",
+                        "password": "password",
+                        "next": "/studio",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            session_cookie = next(
+                cookie.split(";", 1)[0]
+                for cookie in _response_headers(login, "set-cookie")
+                if cookie.startswith("elbysodic_session=")
+            )
+            forged_identity = f"elbysodic_dev_identity={community.id}:{moira.user_id}:{moira.id}"
+            studio = await client.get(
+                "/studio",
+                headers={"Cookie": f"{session_cookie}; {forged_identity}"},
+            )
+
+        assert studio.status == 200
+        assert "Member in X-Men Apocalypse" in studio.text
+        assert "Director Studio is visible as a preview" in studio.text
+        assert "Staff in X-Men Apocalypse" not in studio.text
+
+    asyncio.run(run())
+
+
+def test_logout_revokes_session_and_clears_identity_cookies() -> None:
+    async def run() -> None:
+        app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=True,
+        )
+
+        async with TestClient(app) as client:
+            login = await client.post(
+                "/login",
+                body=urlencode(
+                    {
+                        "email": "moira@example.com",
+                        "password": "password",
+                        "next": "/studio",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            cookie_header = "; ".join(
+                cookie.split(";", 1)[0] for cookie in _response_headers(login, "set-cookie")
+            )
+            logout = await client.get("/logout", headers={"Cookie": cookie_header})
+
+        set_cookies = _response_headers(logout, "set-cookie")
+        assert logout.status == 302
+        assert _response_header(logout, "location") == "/login"
+        assert any(
+            cookie.startswith("elbysodic_session=") and "Max-Age=0" in cookie
+            for cookie in set_cookies
+        )
+        assert any(
+            cookie.startswith("elbysodic_dev_identity=") and "Max-Age=0" in cookie
+            for cookie in set_cookies
+        )
 
     asyncio.run(run())
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -14,7 +14,7 @@ from chirp.testing import TestClient
 from chirp_ui.alpine import check_alpine_runtime
 
 from elbysodic.db import ForumRepository, connect, create_schema
-from elbysodic.db.seed import DemoSeed
+from elbysodic.db.seed import DemoSeed, resolve_seed_persona
 from elbysodic.domain import Community, Thread
 from elbysodic.services import AppServices, create_services
 from elbysodic.web import create_app
@@ -334,6 +334,29 @@ def test_dev_personas_are_gated_by_development_tools() -> None:
         assert "inactive" in enabled.text
 
     asyncio.run(run())
+
+
+def test_seed_persona_matrix_names_multi_community_role_differences() -> None:
+    services = create_services(path=":memory:")
+    xmen_writer = resolve_seed_persona(services.repo, "xmen_writer")
+    hp_director = resolve_seed_persona(services.repo, "hp_director")
+    nyc_writer = resolve_seed_persona(services.repo, "nyc_writer")
+    inactive = resolve_seed_persona(services.repo, "xmen_inactive")
+
+    assert xmen_writer.user.id == hp_director.user.id == nyc_writer.user.id
+    assert xmen_writer.community.slug == "default"
+    assert xmen_writer.role.name == "Member"
+    assert not xmen_writer.role.is_admin
+    assert hp_director.community.slug == "hp-universe"
+    assert hp_director.role.name == "Director"
+    assert hp_director.role.is_admin
+    assert nyc_writer.community.slug == "rl-nyc"
+    assert nyc_writer.role.name == "Member"
+    assert not nyc_writer.role.is_admin
+    assert inactive.membership.username == "sleepingstar"
+    assert not inactive.membership.is_active
+    assert inactive.character is not None
+    assert inactive.character.name == "Sleeping Star"
 
 
 def test_dev_persona_switcher_can_change_seeded_user_and_membership() -> None:

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -296,6 +296,99 @@ def test_identity_switcher_persists_dev_membership_cookie() -> None:
     asyncio.run(run())
 
 
+def test_dev_personas_are_gated_by_development_tools() -> None:
+    async def run() -> None:
+        disabled_app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=False,
+        )
+
+        async with TestClient(disabled_app) as client:
+            disabled = await client.get("/dev/personas")
+        enabled_app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=True,
+        )
+        async with TestClient(enabled_app) as client:
+            enabled = await client.get("/dev/personas")
+
+        assert disabled.status == 404
+        assert enabled.status == 200
+        assert "Dev Personas" in enabled.text
+        assert "xmen_staff" in enabled.text
+        assert "HP director" in enabled.text
+        assert "inactive" in enabled.text
+
+    asyncio.run(run())
+
+
+def test_dev_persona_switcher_can_change_seeded_user_and_membership() -> None:
+    async def run() -> None:
+        app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=True,
+        )
+
+        async with TestClient(app) as client:
+            page = await client.get("/dev/personas")
+            switch = await client.post(
+                "/dev/personas",
+                body=urlencode(
+                    {
+                        "persona_key": "xmen_staff",
+                        "next": "/studio",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            set_cookie = _response_header(switch, "set-cookie")
+            cookie = set_cookie.split(";", 1)[0]
+            studio = await client.get("/studio", headers={"Cookie": cookie})
+
+        assert page.status == 200
+        assert "X-Men staff" in page.text
+        assert switch.status == 302
+        assert _response_header(switch, "location") == "/studio"
+        assert "elbysodic_dev_identity=" in set_cookie
+        assert "HttpOnly" in set_cookie
+        assert "SameSite=lax" in set_cookie
+        assert studio.status == 200
+        assert "Staff in X-Men Apocalypse" in studio.text
+        assert "wearing Moira MacTaggert" in studio.text
+        assert "Save theme tokens" in studio.text
+        assert "Director Studio is visible as a preview" not in studio.text
+
+    asyncio.run(run())
+
+
+def test_dev_persona_switcher_refuses_inactive_seed_persona() -> None:
+    async def run() -> None:
+        app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=True,
+        )
+
+        async with TestClient(app) as client:
+            response = await client.post(
+                "/dev/personas",
+                body=urlencode(
+                    {
+                        "persona_key": "xmen_inactive",
+                        "next": "/members",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+
+        assert response.status == 403
+
+    asyncio.run(run())
+
+
 def test_stale_dev_identity_cookie_falls_back_to_membership_for_program() -> None:
     async def run() -> None:
         app = _app()

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
@@ -60,6 +61,25 @@ def test_admin_role_grants_named_capabilities(
     assert policies.can_manage_navigation(membership, admin_role)
     assert policies.can_manage_casting(membership, admin_role)
     assert policies.can_manage_applications(membership, admin_role)
+
+
+def test_page_handlers_and_services_do_not_check_admin_flag_directly() -> None:
+    checked_paths = [
+        *Path("src/elbysodic/web/pages").rglob("page.py"),
+        *(
+            path
+            for path in Path("src/elbysodic/services").glob("*.py")
+            if path.name != "policies.py"
+        ),
+    ]
+
+    offenders = [
+        str(path)
+        for path in checked_paths
+        if ".is_admin" in path.read_text(encoding="utf-8")
+    ]
+
+    assert offenders == []
 
 
 def test_capabilities_require_active_membership_and_matching_role(

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -74,9 +74,7 @@ def test_page_handlers_and_services_do_not_check_admin_flag_directly() -> None:
     ]
 
     offenders = [
-        str(path)
-        for path in checked_paths
-        if ".is_admin" in path.read_text(encoding="utf-8")
+        str(path) for path in checked_paths if ".is_admin" in path.read_text(encoding="utf-8")
     ]
 
     assert offenders == []

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -84,6 +84,25 @@ def test_schema_applies_ordered_migrations_from_historical_baseline() -> None:
     assert user_version == CURRENT_SCHEMA_VERSION
 
 
+def test_user_sessions_can_be_created_touched_and_revoked(repo: ForumRepository) -> None:
+    user = repo.create_user("session@example.com", "hash")
+    session = repo.create_user_session(
+        user.id,
+        "abc123",
+        expires_at="2026-06-01T00:00:00+00:00",
+    )
+
+    stored = repo.get_user_session_by_token_hash("abc123")
+    touched = repo.touch_user_session(session.id)
+    repo.revoke_user_session_by_token_hash("abc123")
+    revoked = repo.get_user_session_by_token_hash("abc123")
+
+    assert stored.user_id == user.id
+    assert stored.expires_at == "2026-06-01T00:00:00+00:00"
+    assert touched.last_seen_at >= session.last_seen_at
+    assert revoked.revoked_at is not None
+
+
 def test_schema_migrates_existing_boards_for_place_navigation() -> None:
     connection = connect()
     connection.executescript(


### PR DESCRIPTION
## Summary
- add a durable auth/seed QA roadmap and seed persona matrix docs
- add dev-only seed persona switcher at /dev/personas for browser QA across user, membership, role, and face combinations
- add local login/logout sessions backed by user_sessions while preserving membership-scoped authorization
- add guardrails for named policy helpers and tests for session/persona boundaries

## Verification
- uv run ruff check .
- uv run ruff format . --check
- uv run pytest -q --tb=short
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

## Steward Notes
- Consulted root, service, web, db, domain, docs, and test stewards.
- Kept login account, community membership, role, and active face distinct.
- Kept dev persona switching behind explicit dev tools and preserved membership-scoped staff power.