### PR TITLE
[codex] Seed community art direction

### DIFF
--- a/src/elbysodic/db/seed.py
+++ b/src/elbysodic/db/seed.py
@@ -89,6 +89,14 @@ class ApplicationFieldSeed:
 
 
 @dataclass(frozen=True, slots=True)
+class CommunityMediaSeed:
+    mark_url: str
+    mark_alt: str
+    hero_url: str
+    hero_alt: str
+
+
+@dataclass(frozen=True, slots=True)
 class ClaimSeed:
     claim_type_slug: str
     character_slug: str
@@ -117,6 +125,41 @@ class SeedPersonaContext:
     membership: CommunityMembership
     role: Role
     character: Character | None
+
+
+SEED_MEDIA_BASE = "/elbysodic-static/seed-media"
+X_MEN_MEDIA = CommunityMediaSeed(
+    mark_url=f"{SEED_MEDIA_BASE}/xmen-mark.svg",
+    mark_alt="X-Men Apocalypse academy signal mark",
+    hero_url=f"{SEED_MEDIA_BASE}/xmen-hero.svg",
+    hero_alt="Snow-lit academy and B-24 signal lines",
+)
+STUDIO_PROGRAM_MEDIA: dict[str, CommunityMediaSeed] = {
+    "hp-universe": CommunityMediaSeed(
+        mark_url=f"{SEED_MEDIA_BASE}/hp-mark.svg",
+        mark_alt="HP Universe glass staircase mark",
+        hero_url=f"{SEED_MEDIA_BASE}/hp-hero.svg",
+        hero_alt="Glass staircase rising through castle stacks",
+    ),
+    "jurassic-park-universe": CommunityMediaSeed(
+        mark_url=f"{SEED_MEDIA_BASE}/jurassic-mark.svg",
+        mark_alt="Jurassic Park Universe operations mark",
+        hero_url=f"{SEED_MEDIA_BASE}/jurassic-hero.svg",
+        hero_alt="Island operations fence and paddock monitors",
+    ),
+    "rl-nyc": CommunityMediaSeed(
+        mark_url=f"{SEED_MEDIA_BASE}/nyc-mark.svg",
+        mark_alt="RL NYC late train mark",
+        hero_url=f"{SEED_MEDIA_BASE}/nyc-hero.svg",
+        hero_alt="Night street windows above a subway platform",
+    ),
+    "rl-small-town": CommunityMediaSeed(
+        mark_url=f"{SEED_MEDIA_BASE}/smalltown-mark.svg",
+        mark_alt="RL Small Town founders week mark",
+        hero_url=f"{SEED_MEDIA_BASE}/smalltown-hero.svg",
+        hero_alt="Town square noticeboard and storefront lights",
+    ),
+}
 
 
 SEED_PERSONAS: tuple[SeedPersona, ...] = (
@@ -1412,7 +1455,11 @@ def seed_demo_forum(repo: ForumRepository) -> DemoSeed:
     duplicating boards, characters, or sample posts.
     """
 
-    community = repo.seed_default_community("X-Men Apocalypse")
+    community = _ensure_community_media_defaults(
+        repo,
+        repo.seed_default_community("X-Men Apocalypse"),
+        X_MEN_MEDIA,
+    )
     member_role = _get_or_create(
         lambda: repo.get_role_by_slug(community.id, "member"),
         lambda: repo.create_role(community.id, "member", "Member"),
@@ -2997,6 +3044,9 @@ def _seed_studio_network_programs(repo: ForumRepository, user: User) -> None:
     ensure_valid_program_blueprints(STUDIO_NETWORK_PROGRAMS)
     for program in STUDIO_NETWORK_PROGRAMS:
         community = _ensure_studio_program_community(repo, program)
+        media_seed = STUDIO_PROGRAM_MEDIA.get(program.slug)
+        if media_seed is not None:
+            community = _ensure_community_media_defaults(repo, community, media_seed)
         if program.theme is not None:
             repo.upsert_default_theme(
                 community.id,
@@ -3138,6 +3188,35 @@ def _ensure_studio_program_community(
     if community.name == program.name and community.slug == program.slug:
         return community
     return repo.update_community_name_and_slug(community.id, slug=program.slug, name=program.name)
+
+
+def _ensure_community_media_defaults(
+    repo: ForumRepository,
+    community: Community,
+    media_seed: CommunityMediaSeed,
+) -> Community:
+    mark_url = community.community_mark_url or media_seed.mark_url
+    mark_alt = community.community_mark_alt
+    if community.community_mark_url is None:
+        mark_alt = media_seed.mark_alt
+    hero_url = community.world_hero_image_url or media_seed.hero_url
+    hero_alt = community.world_hero_image_alt
+    if community.world_hero_image_url is None:
+        hero_alt = media_seed.hero_alt
+    if (
+        mark_url == community.community_mark_url
+        and mark_alt == community.community_mark_alt
+        and hero_url == community.world_hero_image_url
+        and hero_alt == community.world_hero_image_alt
+    ):
+        return community
+    return repo.update_community_media(
+        community.id,
+        community_mark_url=mark_url,
+        community_mark_alt=mark_alt,
+        world_hero_image_url=hero_url,
+        world_hero_image_alt=hero_alt,
+    )
 
 
 def _ensure_character_identity(

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -51,6 +51,11 @@
 
 {% block brand_link %}
 {% call shell_brand_link(href="/", cls="elbysodic-community-brand") %}
+  {% if viewer and viewer.community.community_mark_url %}
+  <img class="elbysodic-community-brand__mark"
+       src="{{ viewer.community.community_mark_url }}"
+       alt="{{ viewer.community.community_mark_alt }}">
+  {% end %}
   <span class="elbysodic-community-brand__name">{{ viewer.community.name if viewer else "Elbysodic" }}</span>
 {% end %}
 {% end %}

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -7,7 +7,7 @@
 {% block title %}{{ viewer.community.name if viewer else "Elbysodic" }}{% end %}
 
 {% block head_extra %}
-    <link rel="stylesheet" href="/elbysodic-static/elbysodic-theme.css?v=small-maintenance-1">
+    <link rel="stylesheet" href="/elbysodic-static/elbysodic-theme.css?v=seed-art-direction-1">
     {% if viewer and viewer.program_theme %}
     <style id="elbysodic-program-theme">
       :root {

--- a/src/elbysodic/web/pages/page.html
+++ b/src/elbysodic/web/pages/page.html
@@ -18,10 +18,7 @@
       <p class="elbysodic-kicker">World status</p>
       <h1>{{ viewer.community.name }}</h1>
       <p class="elbysodic-copy-lead">
-        The school has reopened under a fragile truce while B-24 turns mutant fear into
-        policy, prediction, and weaponry. Choose a door into the crisis: academy halls,
-        frozen streets, underground networks, diplomatic rooms, or the labs pretending
-        this was all inevitable.
+        <strong>{{ world_status_label }}</strong> {{ world_status_copy }}
       </p>
       {% if viewer.current_character %}
       <p class="elbysodic-copy-helper">

--- a/src/elbysodic/web/pages/page.py
+++ b/src/elbysodic/web/pages/page.py
@@ -6,19 +6,44 @@ from chirp.http.request import Request
 from chirp.templating.returns import Page
 
 from elbysodic.domain.boards import is_community_board, is_desk_board, is_location_board
+from elbysodic.services.read_models import MaterialSummary, WorldHub
 from elbysodic.web.state import get_services
+
+
+def _home_world_status(hub: WorldHub) -> tuple[str, str]:
+    current_event = _first_material(hub.events)
+    if current_event is not None:
+        return current_event.material.title, current_event.rendered_summary
+
+    featured = _first_material(hub.featured)
+    if featured is not None:
+        return featured.material.title, featured.rendered_summary
+
+    guide = _first_material(hub.guides)
+    if guide is not None:
+        return guide.material.title, guide.rendered_summary
+
+    return "World status", "Choose a door into the board's story, locations, and current threads."
+
+
+def _first_material(materials: list[MaterialSummary]) -> MaterialSummary | None:
+    return materials[0] if materials else None
 
 
 def get(request: Request) -> Page:
     services = get_services(request)
     viewer = services.viewer()
     boards = services.list_boards()
+    hub = services.world_hub()
+    world_status_label, world_status_copy = _home_world_status(hub)
     return Page(
         "page.html",
         "page_content",
         page_block_name="page_root",
         current_path=request.url,
         viewer=viewer,
+        world_status_label=world_status_label,
+        world_status_copy=world_status_copy,
         boards=boards,
         location_boards=[
             summary

--- a/src/elbysodic/web/static/elbysodic-theme.css
+++ b/src/elbysodic/web/static/elbysodic-theme.css
@@ -1046,7 +1046,7 @@ body {
 }
 
 .elbysodic-world-hero--with-media {
-    grid-template-columns: minmax(0, 1fr) minmax(18rem, 28rem);
+    grid-template-columns: minmax(22rem, 1fr) minmax(14rem, 42%);
 }
 
 .elbysodic-world-hero__copy {
@@ -1085,7 +1085,7 @@ body {
     grid-column: 2;
     grid-row: 1 / span 2;
     margin: 0;
-    min-height: 18rem;
+    min-height: clamp(12rem, 24vw, 18rem);
     overflow: hidden;
 }
 

--- a/src/elbysodic/web/static/elbysodic-theme.css
+++ b/src/elbysodic/web/static/elbysodic-theme.css
@@ -383,7 +383,21 @@ body {
 }
 
 .elbysodic-community-brand {
+    align-items: center;
+    display: inline-flex;
+    gap: 0.65rem;
     min-width: 0;
+}
+
+.elbysodic-community-brand__mark {
+    aspect-ratio: 1;
+    border: 1px solid color-mix(in srgb, var(--chirpui-border) 74%, transparent);
+    border-radius: calc(var(--chirpui-radius) * 0.75);
+    display: block;
+    flex: 0 0 auto;
+    height: 2rem;
+    object-fit: cover;
+    width: 2rem;
 }
 
 .elbysodic-community-brand__name {

--- a/src/elbysodic/web/static/seed-media/hp-hero.svg
+++ b/src/elbysodic/web/static/seed-media/hp-hero.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1100" role="img" aria-labelledby="title desc">
+  <title id="title">Glass staircase rising through castle stacks</title>
+  <desc id="desc">An old castle library with suspended staircases and violet glass light.</desc>
+  <rect width="1600" height="1100" fill="#171020"/>
+  <path d="M0 820h1600v280H0z" fill="#2a2032"/>
+  <path d="M160 140h300v720H160zM1140 140h300v720h-300z" fill="#3d2f40"/>
+  <path d="M218 220h184v34H218zM218 310h184v34H218zM218 400h184v34H218zM218 490h184v34H218zM218 580h184v34H218zM1198 220h184v34h-184zM1198 310h184v34h-184zM1198 400h184v34h-184zM1198 490h184v34h-184zM1198 580h184v34h-184z" fill="#c8b174"/>
+  <path d="M430 760 980 500l80 80-550 260z" fill="#d7c1ff" opacity=".72"/>
+  <path d="M620 620 1050 330l70 85-430 290z" fill="#95d7cf" opacity=".68"/>
+  <path d="M500 850h600l-110 120H390z" fill="#705c85"/>
+  <path d="M760 120h150l70 650H690z" fill="#23172f"/>
+  <path d="M790 180h88v500h-88z" fill="#f3e1aa"/>
+  <path d="M710 255h250M725 365h235M742 475h230M760 585h205" stroke="#7b4f9f" stroke-width="18" opacity=".7"/>
+  <path d="M0 920c210 44 450 44 720 0s520-44 880 0v180H0z" fill="#f8f2df" opacity=".16"/>
+</svg>

--- a/src/elbysodic/web/static/seed-media/hp-mark.svg
+++ b/src/elbysodic/web/static/seed-media/hp-mark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">HP Universe glass staircase mark</title>
+  <rect width="128" height="128" rx="16" fill="#1d172a"/>
+  <path d="M20 22h25v82H20zM83 22h25v82H83z" fill="#4a394f"/>
+  <path d="M36 90 88 58l9 12-52 32zM42 70 86 36l10 12-44 34z" fill="#d7c1ff"/>
+  <path d="M55 28h20l9 76H46z" fill="#f3e1aa"/>
+</svg>

--- a/src/elbysodic/web/static/seed-media/jurassic-hero.svg
+++ b/src/elbysodic/web/static/seed-media/jurassic-hero.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1100" role="img" aria-labelledby="title desc">
+  <title id="title">Island operations fence and paddock monitors</title>
+  <desc id="desc">A green island operations room looking over paddock fences and warning screens.</desc>
+  <rect width="1600" height="1100" fill="#10251d"/>
+  <path d="M0 650c180-190 360-220 540-90 150-210 390-250 650-80 140-110 275-120 410-30v650H0z" fill="#244b33"/>
+  <path d="M0 805h1600v295H0z" fill="#1b2e27"/>
+  <path d="M240 705h1120v170H240z" fill="#2e463c"/>
+  <path d="M290 615h1020v120H290z" fill="#466458"/>
+  <path d="M350 660h170v110H350zM580 660h170v110H580zM810 660h170v110H810zM1040 660h170v110h-170z" fill="#111e1b"/>
+  <path d="M392 690h86M622 690h86M852 690h86M1082 690h86" stroke="#6bbf7a" stroke-width="10"/>
+  <path d="M90 900h1420M150 780l90 320M330 780l90 320M510 780l90 320M690 780l90 320M870 780l90 320M1050 780l90 320M1230 780l90 320M1410 780l90 320" stroke="#e8d26e" stroke-width="10" opacity=".72"/>
+  <path d="M120 450c240-75 410-74 520 3M960 430c205-54 365-42 480 38" fill="none" stroke="#8ad096" stroke-width="18" opacity=".55"/>
+  <path d="M1110 235h260v165h-260z" fill="#13251f" stroke="#6bbf7a" stroke-width="12"/>
+  <path d="M1145 330h56l35-48 50 72 34-36" fill="none" stroke="#efc84a" stroke-width="12"/>
+</svg>

--- a/src/elbysodic/web/static/seed-media/jurassic-mark.svg
+++ b/src/elbysodic/web/static/seed-media/jurassic-mark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">Jurassic Park Universe operations mark</title>
+  <rect width="128" height="128" rx="16" fill="#13251f"/>
+  <path d="M12 78h104v38H12z" fill="#1f3c2b"/>
+  <path d="M20 82h88M30 64l18 52M58 64l18 52M86 64l18 52" stroke="#e8d26e" stroke-width="5"/>
+  <path d="M28 28h72v40H28z" fill="#0f1c19" stroke="#6bbf7a" stroke-width="6"/>
+  <path d="M38 50h18l11-14 18 22 10-10" fill="none" stroke="#efc84a" stroke-width="5"/>
+</svg>

--- a/src/elbysodic/web/static/seed-media/nyc-hero.svg
+++ b/src/elbysodic/web/static/seed-media/nyc-hero.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1100" role="img" aria-labelledby="title desc">
+  <title id="title">Night street windows above a subway platform</title>
+  <desc id="desc">Tall city apartment blocks, late windows, and a subway platform under rain.</desc>
+  <rect width="1600" height="1100" fill="#111820"/>
+  <path d="M90 180h260v650H90zM410 80h310v750H410zM790 230h240v600H790zM1090 120h330v710h-330z" fill="#22313d"/>
+  <path d="M130 235h48v64h-48zM235 235h48v64h-48zM130 380h48v64h-48zM235 525h48v64h-48zM470 150h54v70h-54zM590 260h54v70h-54zM470 410h54v70h-54zM590 540h54v70h-54zM840 305h48v64h-48zM930 445h48v64h-48zM1150 190h55v72h-55zM1280 335h55v72h-55zM1150 505h55v72h-55zM1280 640h55v72h-55z" fill="#f1c76f"/>
+  <path d="M0 815h1600v285H0z" fill="#2f3640"/>
+  <path d="M0 900h1600" stroke="#d75667" stroke-width="16"/>
+  <path d="M140 930h1320v90H140z" fill="#141b22"/>
+  <path d="M205 955h160v34H205zM470 955h160v34H470zM735 955h160v34H735zM1000 955h160v34h-160zM1265 955h160v34h-160z" fill="#7bbfbd"/>
+  <path d="M180 845h1240" stroke="#f0eadf" stroke-width="8" stroke-dasharray="34 28" opacity=".75"/>
+  <path d="M250 60v730M540 35v760M890 90v705M1220 55v740M1430 110v685" stroke="#7bbfbd" stroke-width="4" opacity=".35"/>
+</svg>

--- a/src/elbysodic/web/static/seed-media/nyc-mark.svg
+++ b/src/elbysodic/web/static/seed-media/nyc-mark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">RL NYC late train mark</title>
+  <rect width="128" height="128" rx="16" fill="#111820"/>
+  <path d="M18 20h24v70H18zM52 12h30v78H52zM92 25h22v65H92z" fill="#243541"/>
+  <path d="M25 32h9v12h-9zM61 27h10v13H61zM62 56h10v13H62zM100 43h8v12h-8z" fill="#f1c76f"/>
+  <path d="M10 86h108v24H10z" fill="#2f3640"/>
+  <path d="M16 94h96" stroke="#d75667" stroke-width="5"/>
+  <path d="M28 99h22M62 99h22M96 99h12" stroke="#7bbfbd" stroke-width="4"/>
+</svg>

--- a/src/elbysodic/web/static/seed-media/smalltown-hero.svg
+++ b/src/elbysodic/web/static/seed-media/smalltown-hero.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1100" role="img" aria-labelledby="title desc">
+  <title id="title">Town square noticeboard and storefront lights</title>
+  <desc id="desc">A town square with storefront awnings, a noticeboard, and founders week lights.</desc>
+  <rect width="1600" height="1100" fill="#f3ead9"/>
+  <path d="M0 740h1600v360H0z" fill="#5f7d6a"/>
+  <path d="M120 330h390v430H120zM560 260h450v500H560zM1060 360h420v400h-420z" fill="#fff7e5"/>
+  <path d="M120 330h390l-55-92H175zM560 260h450l-70-110H630zM1060 360h420l-50-88h-320z" fill="#b74b55"/>
+  <path d="M185 430h105v130H185zM340 430h105v130H340zM635 370h120v145H635zM815 370h120v145H815zM1135 455h115v125h-115zM1310 455h115v125h-115z" fill="#f2c56d"/>
+  <path d="M640 660h300v290H640z" fill="#6b4b35"/>
+  <path d="M688 705h205M688 755h205M688 805h205" stroke="#f7e6c8" stroke-width="16"/>
+  <path d="M250 830c180-90 365-90 555 0s365 90 535 0" fill="none" stroke="#fff4bf" stroke-width="14" stroke-dasharray="18 20"/>
+  <path d="M0 990c185-58 380-58 585 0s410 58 615 0 338-58 400-58v168H0z" fill="#d9ccb8"/>
+</svg>

--- a/src/elbysodic/web/static/seed-media/smalltown-mark.svg
+++ b/src/elbysodic/web/static/seed-media/smalltown-mark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">RL Small Town founders week mark</title>
+  <rect width="128" height="128" rx="16" fill="#f3ead9"/>
+  <path d="M18 47h92v49H18z" fill="#fff7e5"/>
+  <path d="M18 47h92L96 28H32z" fill="#b74b55"/>
+  <path d="M43 66h42v42H43z" fill="#6b4b35"/>
+  <path d="M49 76h30M49 88h30" stroke="#f7e6c8" stroke-width="5"/>
+  <path d="M20 106h88" stroke="#5f7d6a" stroke-width="10"/>
+</svg>

--- a/src/elbysodic/web/static/seed-media/xmen-hero.svg
+++ b/src/elbysodic/web/static/seed-media/xmen-hero.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1100" role="img" aria-labelledby="title desc">
+  <title id="title">Snow-lit academy and B-24 signal lines</title>
+  <desc id="desc">A winter academy silhouette crossed by signal grids and containment lines.</desc>
+  <rect width="1600" height="1100" fill="#111722"/>
+  <path d="M0 840h1600v260H0z" fill="#e8edf0"/>
+  <path d="M150 730h1300l75 170H75z" fill="#182536"/>
+  <path d="M330 350h940v430H330z" fill="#26364a"/>
+  <path d="M465 240h670v125H465z" fill="#324963"/>
+  <path d="M570 120h460v135H570z" fill="#405b78"/>
+  <path d="M760 255h80v525h-80z" fill="#111722"/>
+  <path d="M520 455h90v105h-90zM670 455h90v105h-90zM840 455h90v105h-90zM990 455h90v105h-90z" fill="#f5d38b"/>
+  <path d="M390 650h110v130H390zM1100 650h110v130h-110z" fill="#a6c8e5"/>
+  <path d="M80 250c230 180 460 270 690 270s480-90 750-270" fill="none" stroke="#79c6ff" stroke-width="8" stroke-dasharray="20 28" opacity=".72"/>
+  <path d="M180 180c210 220 420 330 630 330s420-110 630-330" fill="none" stroke="#d75b68" stroke-width="7" stroke-dasharray="12 22" opacity=".8"/>
+  <circle cx="800" cy="510" r="145" fill="none" stroke="#79c6ff" stroke-width="10" opacity=".45"/>
+  <path d="M0 905c215-42 430-42 645 0s430 42 645 0 310-40 310-40v235H0z" fill="#cfdde5"/>
+</svg>

--- a/src/elbysodic/web/static/seed-media/xmen-mark.svg
+++ b/src/elbysodic/web/static/seed-media/xmen-mark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">X-Men Apocalypse academy signal mark</title>
+  <rect width="128" height="128" rx="16" fill="#142033"/>
+  <path d="M18 102h92L96 70H32z" fill="#e8edf0"/>
+  <path d="M35 42h58v39H35z" fill="#314862"/>
+  <path d="M48 30h32v12H48z" fill="#496c8d"/>
+  <path d="M61 42h7v39h-7z" fill="#101722"/>
+  <path d="M20 29c26 22 54 33 84 0" fill="none" stroke="#79c6ff" stroke-width="5"/>
+  <path d="M28 22c22 32 50 48 72 0" fill="none" stroke="#d75b68" stroke-width="4"/>
+</svg>

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -847,6 +847,8 @@ def test_shell_centers_community_brand_and_quiet_platform_mark() -> None:
             index = await client.get("/")
 
             assert index.status == 200
+            assert "/elbysodic-static/seed-media/xmen-mark.svg" in index.text
+            assert 'alt="X-Men Apocalypse academy signal mark"' in index.text
             assert (
                 '<span class="elbysodic-community-brand__name">X-Men Apocalypse</span>'
                 in index.text
@@ -857,6 +859,38 @@ def test_shell_centers_community_brand_and_quiet_platform_mark() -> None:
             assert index.text.count("Writer Desk") == 2
             assert "elbysodic-mobile-realm-nav" in index.text
             assert 'class="elbysodic-topnav__link" href="/notifications"' not in index.text
+
+    asyncio.run(run())
+
+
+def test_seeded_program_homepage_uses_community_media_and_world_status() -> None:
+    async def run() -> None:
+        app = _app()
+        services = get_services()
+        hp = services.repo.get_community_by_slug("hp-universe")
+        hp_membership = services.repo.get_membership_for_user(hp.id, 1)
+        cookie = f"elbysodic_dev_identity={hp.id}:1:{hp_membership.id}"
+
+        async with TestClient(app) as client:
+            xmen = await client.get("/")
+            hp_home = await client.get("/", headers={"Cookie": cookie})
+
+        assert xmen.status == 200
+        assert "/elbysodic-static/seed-media/xmen-hero.svg" in xmen.text
+        assert 'alt="Snow-lit academy and B-24 signal lines"' in xmen.text
+        assert "Current Event: B-24 Winter" in xmen.text
+        assert "Iceman is infected with B-24" in xmen.text
+
+        assert hp_home.status == 200
+        assert "/elbysodic-static/seed-media/hp-mark.svg" in hp_home.text
+        assert "/elbysodic-static/seed-media/hp-hero.svg" in hp_home.text
+        assert 'alt="Glass staircase rising through castle stacks"' in hp_home.text
+        assert "Current Event: No Reflection" in hp_home.text
+        assert (
+            "One student has gone missing, and every portrait remembers a different last sighting."
+            in hp_home.text
+        )
+        assert "The school has reopened under a fragile truce" not in hp_home.text
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary

- Adds local seed media for the X-Men, HP, Jurassic Park, NYC, and small-town communities so each seed has a distinct mark and world hero.
- Hydrates community media defaults during dev seed setup while preserving existing local custom media.
- Renders the community mark in the shell brand and pulls the homepage world-status copy from the active community's event/premise material instead of hardcoding the X-Men intro.
- Adds rendered coverage for the seed media and community-specific homepage status.

## Validation

- `uv run pytest tests/test_forum_slice.py::test_shell_centers_community_brand_and_quiet_platform_mark tests/test_forum_slice.py::test_seeded_program_homepage_uses_community_media_and_world_status -q --tb=short`
- `uv run pytest tests/test_forum_slice.py tests/test_tenant_repository.py -q --tb=short`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`
- Local HTTP smoke against `http://127.0.0.1:8001/` confirmed the X-Men seed mark, hero, and current-event status render.

## Steward Notes

- Consulted root, web/rendering, db, services, domain, docs, tests, and blueprint stewards.
- Kept this out of the Program Blueprint import contract for now: seed defaults use safe local static assets and existing media fields rather than introducing director-importable media fields.
- Tenant boundary stays repository-backed through existing community media APIs; rendering reads from the active viewer community.
- Follow-up risk: the seed SVGs are intentionally lightweight placeholders. The next art pass can replace them with richer generated or uploaded media without changing the product contract.
