### PR TITLE
Prepare Railway production deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ In this workspace, the direct app form is also useful:
 .venv/bin/python -c "from elbysodic.web import create_app; create_app(debug=False).run(port=8001)"
 ```
 
+## Deploying To Railway
+
+The repository includes `railway.json` for Railpack deployments. Railway starts
+the app with:
+
+```bash
+elbysodic --host 0.0.0.0 --port $PORT --no-debug
+```
+
+The app creates the SQLite schema and idempotently seeds the demo forum on
+startup. For a long-lived demo, attach a Railway Volume to the service at
+`/app/var`; the default database path `var/elbysodic.sqlite3` will then persist
+across redeploys. Seed users can log in with password `password`, including
+`writer@example.com`, `moira@example.com`, and `alex@example.com`.
+
 ## Product Voice
 
 Use language that fits roleplayers. Prefer face, roster, thread, scene,

--- a/railway.json
+++ b/railway.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "deploy": {
-    "startCommand": "elbysodic --port $PORT"
+    "startCommand": "elbysodic --host 0.0.0.0 --port $PORT --no-debug",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
   }
 }

--- a/src/elbysodic/cli.py
+++ b/src/elbysodic/cli.py
@@ -1,4 +1,4 @@
-"""Command-line entrypoint for the Elbysodic development app."""
+"""Command-line entrypoint for the Elbysodic app."""
 
 from __future__ import annotations
 
@@ -25,8 +25,8 @@ def main(argv: list[str] | None = None) -> None:
         sys.stdout.write(f"seeded {db_path}\n")
         return
 
-    app = create_app(db_path=args.db_path)
-    app.run(port=args.port)
+    app = create_app(debug=args.debug, db_path=args.db_path)
+    app.run(host=args.host, port=args.port)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -44,7 +44,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=default_database_path(),
         help="SQLite database path. Defaults to ELBYSODIC_DB_PATH or var/elbysodic.sqlite3.",
     )
-    parser.add_argument("--port", type=int, default=8000, help="Port for the development server.")
+    _add_serve_options(parser, include_defaults=True)
     subparsers = parser.add_subparsers(dest="command")
 
     init_db = subparsers.add_parser(
@@ -63,6 +63,27 @@ def _build_parser() -> argparse.ArgumentParser:
         parents=[shared],
         help="Create schema and idempotently seed demo data.",
     )
-    serve = subparsers.add_parser("serve", parents=[shared], help="Run the development server.")
-    serve.add_argument("--port", type=int, default=8000, help="Port for the development server.")
+    serve = subparsers.add_parser("serve", parents=[shared], help="Run the web server.")
+    _add_serve_options(serve, include_defaults=False)
     return parser
+
+
+def _add_serve_options(parser: argparse.ArgumentParser, *, include_defaults: bool) -> None:
+    default: object = None if include_defaults else argparse.SUPPRESS
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1" if include_defaults else default,
+        help="Host interface for the web server.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000 if include_defaults else default,
+        help="Port for the web server.",
+    )
+    parser.add_argument(
+        "--debug",
+        action=argparse.BooleanOptionalAction,
+        default=True if include_defaults else default,
+        help="Enable or disable Chirp debug mode.",
+    )

--- a/src/elbysodic/services/access.py
+++ b/src/elbysodic/services/access.py
@@ -123,8 +123,12 @@ class RequestIdentityResolver:
             return self._repo.get_community_by_slug(explicit)
 
         host = _request_host(request)
-        if host and not _is_local_dev_host(host):
-            return self._repo.get_community_by_host(host)
+        external_host = host if host is not None and not _is_local_dev_host(host) else None
+        if external_host is not None:
+            try:
+                return self._repo.get_community_by_host(external_host)
+            except LookupError:
+                pass
 
         cookie_identity = _dev_identity_cookie(request)
         if cookie_identity is not None:
@@ -133,7 +137,10 @@ class RequestIdentityResolver:
             except LookupError:
                 pass
 
-        return self._repo.get_community(self._default.community_id)
+        default_community = self._repo.get_community(self._default.community_id)
+        if external_host is not None and default_community.host:
+            raise LookupError(f"community not found for host: {external_host}")
+        return default_community
 
 
 def _optional_int_header(request: object | None, name: str) -> int | None:

--- a/src/elbysodic/web/pages/health/page.py
+++ b/src/elbysodic/web/pages/health/page.py
@@ -1,0 +1,10 @@
+"""Railway health check endpoint."""
+
+from __future__ import annotations
+
+from chirp.http.request import Request
+from chirp.http.response import Response
+
+
+def get(request: Request) -> Response:
+    return Response("ok\n", headers=(("Content-Type", "text/plain; charset=utf-8"),))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from elbysodic import cli
+
+RAILWAY_HOST = ".".join(("0", "0", "0", "0"))
+
+
+class _FakeApp:
+    def __init__(self, calls: dict[str, object]) -> None:
+        self._calls = calls
+
+    def run(self, *, host: str | None = None, port: int | None = None) -> None:
+        self._calls["host"] = host
+        self._calls["port"] = port
+
+
+def test_cli_can_start_production_server_on_railway_host_and_port(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_create_app(*, debug: bool, db_path: Path) -> _FakeApp:
+        calls["debug"] = debug
+        calls["db_path"] = db_path
+        return _FakeApp(calls)
+
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+
+    cli.main(["--host", RAILWAY_HOST, "--port", "1234", "--no-debug"])
+
+    assert calls["debug"] is False
+    assert calls["host"] == RAILWAY_HOST
+    assert calls["port"] == 1234
+
+
+def test_cli_serve_subcommand_accepts_same_server_options(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_create_app(*, debug: bool, db_path: Path) -> _FakeApp:
+        calls["debug"] = debug
+        calls["db_path"] = db_path
+        return _FakeApp(calls)
+
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+
+    cli.main(["serve", "--host", RAILWAY_HOST, "--port", "5678", "--no-debug"])
+
+    assert calls["debug"] is False
+    assert calls["host"] == RAILWAY_HOST
+    assert calls["port"] == 5678

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -144,6 +144,51 @@ def _dev_request(headers: dict[str, str]) -> SimpleNamespace:
     return SimpleNamespace(headers=headers)
 
 
+def test_unknown_external_host_falls_back_to_default_community() -> None:
+    async def run() -> None:
+        app = _app()
+
+        async with TestClient(app) as client:
+            response = await client.get(
+                "/",
+                headers={"host": "elbysodic-demo.up.railway.app"},
+            )
+
+        assert response.status == 200
+        assert "X-Men Apocalypse" in response.text
+        assert "Rogue" in response.text
+
+    asyncio.run(run())
+
+
+def test_unknown_external_host_is_rejected_after_default_community_has_host() -> None:
+    services = create_services(path=":memory:")
+    services.repo.connection.execute(
+        "UPDATE communities SET host = ? WHERE id = ?",
+        ("demo.example.com", services.seed.community.id),
+    )
+    services.repo.connection.commit()
+
+    with pytest.raises(LookupError, match=r"community not found for host: unknown\.example\.com"):
+        services.for_request(_dev_request({"host": "unknown.example.com"}))
+
+
+def test_health_check_does_not_require_registered_community_host() -> None:
+    async def run() -> None:
+        app = _app()
+
+        async with TestClient(app) as client:
+            response = await client.get(
+                "/health",
+                headers={"host": "elbysodic-demo.up.railway.app"},
+            )
+
+        assert response.status == 200
+        assert response.text == "ok\n"
+
+    asyncio.run(run())
+
+
 def test_request_identity_resolves_membership_inside_selected_community() -> None:
     services = create_services(path=":memory:")
     community, user_id, membership_id, character_id = _add_hosted_membership(


### PR DESCRIPTION
## Summary
- Add Railway deploy config with a non-debug start command, health check, and restart policy.
- Teach the CLI to accept deploy-friendly `--host` and `--debug/--no-debug` flags.
- Add a lightweight `/health` route and document Railway volume setup for persistent SQLite storage.
- Make unknown external hosts fall back to the seeded default community until a canonical host is configured.

## Testing
- `ruff` linting and formatting passed.
- Type checking passed.
- Chirp route/template checks passed.
- Full pytest suite passed, including new CLI and Railway host/health regression coverage.