### PR TITLE
[codex] Package nested static assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Changelog = "https://github.com/lbliii/elbysodic/blob/main/CHANGELOG.md"
 where = ["src"]
 
 [tool.setuptools.package-data]
-elbysodic = ["py.typed", "web/pages/**/*.html", "web/static/*"]
+elbysodic = ["py.typed", "web/pages/**/*.html", "web/static/**/*"]
 
 # =============================================================================
 # Ruff - Linter & Formatter


### PR DESCRIPTION
## Summary
- Include nested Elbysodic static assets in the installable package.
- Fix Railway deploys missing seed-media SVGs such as community marks, heroes, and location art.

## Root Cause
The package-data glob only matched top-level `web/static/*`, so CSS and JS shipped but nested `web/static/seed-media/**` files were omitted from built artifacts.

## Validation
- `uv run ruff check pyproject.toml`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path='':memory:'').check()"`
- `uv build` and wheel inspection for nested X-Men seed-media SVGs

## Steward Notes
Consulted root `AGENTS.md`, `src/elbysodic/AGENTS.md`, and `src/elbysodic/web/AGENTS.md`. Scope is packaging/static asset inclusion only; no runtime routing or auth behavior changes.