### PR TITLE
Use thread-scoped public numbers for posts and other iterable records

### DIFF
--- a/docs/architecture/primitives.md
+++ b/docs/architecture/primitives.md
@@ -15,6 +15,28 @@ belong here.
 `Character` is the public posting identity. Characters are not global. A
 character belongs to exactly one membership in exactly one community.
 
+## Public Identifiers
+
+Database ids are internal persistence identities. They are for foreign keys,
+repository joins, audit trails, and service internals, not public URLs or
+visible labels.
+
+Public identities should be scoped to the object writers already understand:
+
+- named community objects use community-scoped slugs, such as character,
+  material, wanted, board, and claim-type slugs
+- named child objects use parent-scoped slugs, such as thread slugs under a
+  board or plot-hook slugs under a character
+- visible append-only records use parent-scoped ordinals, such as post numbers
+  inside one thread
+- private, sensitive, or capability-bearing records should use opaque public
+  ids when they need public links at all
+
+Ordinals are assigned once and are not reused. A later hide, tombstone, or
+moderation action must not renumber the surrounding stream, because
+notifications, read jumps, exports, and copied scene links should keep pointing
+at the same beat.
+
 ## Character Roster
 
 When a user enters a community, that community resolves the user's membership

--- a/src/elbysodic/db/migrations.py
+++ b/src/elbysodic/db/migrations.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-CURRENT_SCHEMA_VERSION = 11
+CURRENT_SCHEMA_VERSION = 12
 BASELINE_MIGRATION_NAME = "baseline-current-schema"
 
 
@@ -418,6 +418,40 @@ def _add_user_session_identity_selection(connection: sqlite3.Connection) -> None
             connection.execute(f"ALTER TABLE user_sessions ADD COLUMN {name} {definition}")
 
 
+def _add_post_public_numbers(connection: sqlite3.Connection) -> None:
+    columns = {row["name"] for row in connection.execute("PRAGMA table_info(posts)").fetchall()}
+    if "post_number" not in columns:
+        connection.execute("ALTER TABLE posts ADD COLUMN post_number INTEGER")
+
+    rows = connection.execute(
+        """
+        SELECT id, community_id, thread_id
+        FROM posts
+        ORDER BY community_id, thread_id, created_at, id
+        """
+    ).fetchall()
+    next_numbers: dict[tuple[int, int], int] = {}
+    for row in rows:
+        key = (int(row["community_id"]), int(row["thread_id"]))
+        post_number = next_numbers.get(key, 1)
+        connection.execute(
+            """
+            UPDATE posts
+            SET post_number = ?
+            WHERE community_id = ? AND id = ?
+            """,
+            (post_number, row["community_id"], row["id"]),
+        )
+        next_numbers[key] = post_number + 1
+
+    connection.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_posts_thread_post_number
+        ON posts(community_id, thread_id, post_number)
+        """
+    )
+
+
 MIGRATIONS: tuple[Migration, ...] = (
     Migration(2, "plotting-room-planning-fields", _add_plotting_room_planning_fields),
     Migration(3, "plotting-room-messages", _add_plotting_room_messages),
@@ -429,6 +463,7 @@ MIGRATIONS: tuple[Migration, ...] = (
     Migration(9, "hero-treatments", _add_hero_treatments),
     Migration(10, "board-media-presentation", _add_board_media_presentation),
     Migration(11, "user-session-identity-selection", _add_user_session_identity_selection),
+    Migration(12, "post-public-numbers", _add_post_public_numbers),
 )
 
 

--- a/src/elbysodic/db/repositories/posts.py
+++ b/src/elbysodic/db/repositories/posts.py
@@ -26,20 +26,31 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
         self.get_thread(community_id, thread_id)
         character = self.get_character(community_id, author_character_id)
         now = _utc_now()
+        post_number = self._next_post_number(community_id, thread_id)
         cursor = self.connection.execute(
             """
             INSERT INTO posts (
                 community_id,
                 thread_id,
+                post_number,
                 author_membership_id,
                 author_character_id,
                 body,
                 created_at,
                 updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (community_id, thread_id, character.membership_id, author_character_id, body, now, now),
+            (
+                community_id,
+                thread_id,
+                post_number,
+                character.membership_id,
+                author_character_id,
+                body,
+                now,
+                now,
+            ),
         )
         self.connection.execute(
             """
@@ -68,6 +79,17 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
         )
         self.connection.commit()
         return self.get_post(community_id, _last_id(cursor))
+
+    def _next_post_number(self, community_id: int, thread_id: int) -> int:
+        row = self.connection.execute(
+            """
+            SELECT COALESCE(MAX(post_number), 0) + 1 AS next_post_number
+            FROM posts
+            WHERE community_id = ? AND thread_id = ?
+            """,
+            (community_id, thread_id),
+        ).fetchone()
+        return int(row["next_post_number"])
 
     def update_post_body(self, community_id: int, post_id: int, body: str) -> Post:
         post = self.get_post(community_id, post_id)
@@ -156,6 +178,7 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
                 id,
                 community_id,
                 thread_id,
+                post_number,
                 author_membership_id,
                 author_character_id,
                 body,
@@ -170,6 +193,31 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
             raise LookupError(f"post not found in community {community_id}: {post_id}")
         return _post_from_row(row)
 
+    def get_post_by_number(self, community_id: int, thread_id: int, post_number: int) -> Post:
+        row = self.connection.execute(
+            """
+            SELECT
+                id,
+                community_id,
+                thread_id,
+                post_number,
+                author_membership_id,
+                author_character_id,
+                body,
+                created_at,
+                updated_at
+            FROM posts
+            WHERE community_id = ? AND thread_id = ? AND post_number = ?
+            """,
+            (community_id, thread_id, post_number),
+        ).fetchone()
+        if row is None:
+            raise LookupError(
+                f"post number {post_number} not found in community {community_id} "
+                f"thread {thread_id}"
+            )
+        return _post_from_row(row)
+
     def list_posts(self, community_id: int, thread_id: int) -> list[Post]:
         rows = self.connection.execute(
             """
@@ -177,6 +225,7 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
                 id,
                 community_id,
                 thread_id,
+                post_number,
                 author_membership_id,
                 author_character_id,
                 body,
@@ -184,7 +233,7 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
                 updated_at
             FROM posts
             WHERE community_id = ? AND thread_id = ?
-            ORDER BY created_at, id
+            ORDER BY post_number
             """,
             (community_id, thread_id),
         ).fetchall()
@@ -198,6 +247,7 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
                 id,
                 community_id,
                 thread_id,
+                post_number,
                 author_membership_id,
                 author_character_id,
                 body,

--- a/src/elbysodic/db/repositories/rows.py
+++ b/src/elbysodic/db/repositories/rows.py
@@ -595,6 +595,7 @@ def _post_from_row(row: sqlite3.Row) -> Post:
         id=row["id"],
         community_id=row["community_id"],
         thread_id=row["thread_id"],
+        post_number=row["post_number"],
         author_membership_id=row["author_membership_id"],
         author_character_id=row["author_character_id"],
         body=row["body"],

--- a/src/elbysodic/db/schema.py
+++ b/src/elbysodic/db/schema.py
@@ -562,6 +562,7 @@ CREATE TABLE IF NOT EXISTS posts (
     id INTEGER PRIMARY KEY,
     community_id INTEGER NOT NULL REFERENCES communities(id) ON DELETE CASCADE,
     thread_id INTEGER NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+    post_number INTEGER NOT NULL,
     author_membership_id INTEGER NOT NULL REFERENCES community_memberships(id),
     author_character_id INTEGER NOT NULL REFERENCES characters(id),
     body TEXT NOT NULL,
@@ -901,11 +902,46 @@ def _migrate_schema(connection: sqlite3.Connection) -> None:
         GROUP BY community_id, thread_id, author_character_id
         """
     )
+    _migrate_posts_schema(connection)
     _migrate_wanted_ad_interests_schema(connection)
     _migrate_notifications_schema(connection)
     _migrate_plotting_rooms_schema(connection)
     _migrate_plotting_room_messages_schema(connection)
     _migrate_applications_schema(connection)
+
+
+def _migrate_posts_schema(connection: sqlite3.Connection) -> None:
+    columns = {row["name"] for row in connection.execute("PRAGMA table_info(posts)").fetchall()}
+    if "post_number" not in columns:
+        connection.execute("ALTER TABLE posts ADD COLUMN post_number INTEGER")
+
+    rows = connection.execute(
+        """
+        SELECT id, community_id, thread_id
+        FROM posts
+        ORDER BY community_id, thread_id, created_at, id
+        """
+    ).fetchall()
+    next_numbers: dict[tuple[int, int], int] = {}
+    for row in rows:
+        key = (int(row["community_id"]), int(row["thread_id"]))
+        post_number = next_numbers.get(key, 1)
+        connection.execute(
+            """
+            UPDATE posts
+            SET post_number = ?
+            WHERE community_id = ? AND id = ? AND post_number IS NULL
+            """,
+            (post_number, row["community_id"], row["id"]),
+        )
+        next_numbers[key] = post_number + 1
+
+    connection.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_posts_thread_post_number
+        ON posts(community_id, thread_id, post_number)
+        """
+    )
 
 
 def _migrate_applications_schema(connection: sqlite3.Connection) -> None:

--- a/src/elbysodic/domain/models.py
+++ b/src/elbysodic/domain/models.py
@@ -512,6 +512,7 @@ class Post:
     id: int
     community_id: int
     thread_id: int
+    post_number: int
     author_membership_id: int
     author_character_id: int
     body: str

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -1961,16 +1961,21 @@ class AppServices:
             interest_id,
         )
 
-    def read_post_editor(self, board_slug: str, thread_slug: str, post_id: int) -> EditablePostView:
-        return _read_post_editor(self.repo, self.viewer(), board_slug, thread_slug, post_id)
+    def read_post_editor(
+        self,
+        board_slug: str,
+        thread_slug: str,
+        post_number: int,
+    ) -> EditablePostView:
+        return _read_post_editor(self.repo, self.viewer(), board_slug, thread_slug, post_number)
 
     def read_post_revisions(
         self,
         board_slug: str,
         thread_slug: str,
-        post_id: int,
+        post_number: int,
     ) -> PostRevisionHistory:
-        return _read_post_revisions(self.repo, self.viewer(), board_slug, thread_slug, post_id)
+        return _read_post_revisions(self.repo, self.viewer(), board_slug, thread_slug, post_number)
 
     def create_character(
         self,
@@ -2212,8 +2217,8 @@ class AppServices:
             post_density=cleaned_post_density,
         )
 
-    def update_post(self, board_slug: str, thread_slug: str, post_id: int, body: str) -> Post:
-        return _update_post(self.repo, self.viewer(), board_slug, thread_slug, post_id, body)
+    def update_post(self, board_slug: str, thread_slug: str, post_number: int, body: str) -> Post:
+        return _update_post(self.repo, self.viewer(), board_slug, thread_slug, post_number, body)
 
     def update_thread_state(
         self,

--- a/src/elbysodic/services/posting.py
+++ b/src/elbysodic/services/posting.py
@@ -95,6 +95,8 @@ class PostingRepository(NotificationRepository, Protocol):
 
     def list_posts(self, community_id: int, thread_id: int) -> list[Post]: ...
 
+    def get_post_by_number(self, community_id: int, thread_id: int, post_number: int) -> Post: ...
+
     def create_post_revision(
         self,
         community_id: int,
@@ -176,9 +178,9 @@ def read_post_editor(
     viewer: ForumView,
     board_slug: str,
     thread_slug: str,
-    post_id: int,
+    post_number: int,
 ) -> EditablePostView:
-    board, thread, post = editable_post(repo, viewer, board_slug, thread_slug, post_id)
+    board, thread, post = editable_post(repo, viewer, board_slug, thread_slug, post_number)
     return EditablePostView(
         board=board,
         thread=thread,
@@ -197,9 +199,9 @@ def read_post_revisions(
     viewer: ForumView,
     board_slug: str,
     thread_slug: str,
-    post_id: int,
+    post_number: int,
 ) -> PostRevisionHistory:
-    board, thread, post = editable_post(repo, viewer, board_slug, thread_slug, post_id)
+    board, thread, post = editable_post(repo, viewer, board_slug, thread_slug, post_number)
     revisions = [
         post_revision_view(repo, viewer.community.id, revision)
         for revision in repo.list_post_revisions(viewer.community.id, post.id)
@@ -223,10 +225,10 @@ def update_post(
     viewer: ForumView,
     board_slug: str,
     thread_slug: str,
-    post_id: int,
+    post_number: int,
     body: str,
 ) -> Post:
-    _board, _thread, post = editable_post(repo, viewer, board_slug, thread_slug, post_id)
+    _board, _thread, post = editable_post(repo, viewer, board_slug, thread_slug, post_number)
     cleaned = body.strip()
     if not cleaned:
         raise ValueError("post body is required")
@@ -239,7 +241,7 @@ def update_post(
         post.body,
         cleaned,
     )
-    return repo.update_post_body(viewer.community.id, post_id, cleaned)
+    return repo.update_post_body(viewer.community.id, post.id, cleaned)
 
 
 def update_thread_scene(
@@ -425,12 +427,10 @@ def editable_post(
     viewer: ForumView,
     board_slug: str,
     thread_slug: str,
-    post_id: int,
+    post_number: int,
 ) -> tuple[Board, Thread, Post]:
     board, thread = visible_thread(repo, viewer, board_slug, thread_slug)
-    post = repo.get_post(viewer.community.id, post_id)
-    if post.thread_id != thread.id:
-        raise LookupError(f"post {post_id} does not belong to thread {thread.id}")
+    post = repo.get_post_by_number(viewer.community.id, thread.id, post_number)
     if not policies.can_edit_post(viewer.membership, post, viewer.role):
         raise PermissionError(f"membership {viewer.membership.id} cannot edit post {post.id}")
     return board, thread, post

--- a/src/elbysodic/services/posts.py
+++ b/src/elbysodic/services/posts.py
@@ -75,7 +75,7 @@ def post_view(
         created_at_relative_label=relative_timestamp_label(post.created_at),
         updated_at_label=timestamp_label(post.updated_at),
         updated_at_relative_label=relative_timestamp_label(post.updated_at),
-        anchor=f"post-{post.id}",
+        anchor=f"post-{post.post_number}",
     )
 
 

--- a/src/elbysodic/web/pages/_components/posts.html
+++ b/src/elbysodic/web/pages/_components/posts.html
@@ -65,18 +65,19 @@
 {% call surface(variant="elevated", cls=post_shell_cls, style=post_shell_style) %}
 <article id="{{ item.anchor }}"
          class="elbysodic-post elbysodic-post--{{ item.author.slug }}">
+  <span id="post-id-{{ item.post.id }}" class="chirpui-visually-hidden" aria-hidden="true"></span>
   {{ post_profile_rail(item) }}
   <div class="elbysodic-post__body">
     <header class="elbysodic-post__meta">
       <div class="elbysodic-post__meta-line">
-        <a class="chirpui-link" href="#{{ item.anchor }}" aria-label="Permalink to post {{ item.post.id }}">
-          #{{ item.post.id }}
+        <a class="chirpui-link" href="#{{ item.anchor }}" aria-label="Permalink to post {{ item.post.post_number }}">
+          #{{ item.post.post_number }}
         </a>
         <span>{{ item.created_at_label }}</span>
         {% if item.is_edited %}
         {% if item.can_edit %}
         <a class="chirpui-link"
-           href="/boards/{{ board.slug }}/threads/{{ thread.slug }}/posts/{{ item.post.id }}/revisions">
+           href="/boards/{{ board.slug }}/threads/{{ thread.slug }}/posts/{{ item.post.post_number }}/revisions">
           edited {{ item.updated_at_label }}
         </a>
         {% else %}
@@ -87,7 +88,7 @@
       <div class="elbysodic-post__meta-actions">
         {% if item.can_edit %}
         <a class="chirpui-link"
-           href="/boards/{{ board.slug }}/threads/{{ thread.slug }}/posts/{{ item.post.id }}/edit">
+           href="/boards/{{ board.slug }}/threads/{{ thread.slug }}/posts/{{ item.post.post_number }}/edit">
           Edit
         </a>
         {% end %}

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py
@@ -59,7 +59,9 @@ async def post(request: Request, board_slug: str) -> Page | Redirect:
             body=body,
         )
 
-    return Redirect(f"/boards/{board_slug}/threads/{created.thread.slug}#post-{created.post.id}")
+    return Redirect(
+        f"/boards/{board_slug}/threads/{created.thread.slug}#post-{created.post.post_number}"
+    )
 
 
 def _render_form(

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py
@@ -109,7 +109,7 @@ async def post(request: Request, board_slug: str, thread_slug: str) -> Page | Re
             selected_character_id=character_id,
         )
 
-    return Redirect(f"{request.path}#post-{post.id}")
+    return Redirect(f"{request.path}#post-{post.post_number}")
 
 
 def _render_thread(

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.html
@@ -18,7 +18,7 @@
 
   {% call section_header("Edit post") %}
   {{ badge(edit_view.board.name, variant="muted") }}
-  {{ badge("post #" ~ edit_view.post.post.id) }}
+  {{ badge("post #" ~ edit_view.post.post.post_number) }}
   {% end %}
 
   {% call surface(variant="elevated") %}

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.py
@@ -21,12 +21,17 @@ async def post(
     thread_slug: str,
     post_id: str,
 ) -> Page | Redirect:
-    parsed_post_id = _parse_post_id(post_id)
+    parsed_post_number = _parse_post_number(post_id)
     form = await request.form()
     body = str(form.get("body") or "")
 
     try:
-        post_view = get_services(request).update_post(board_slug, thread_slug, parsed_post_id, body)
+        post_view = get_services(request).update_post(
+            board_slug,
+            thread_slug,
+            parsed_post_number,
+            body,
+        )
     except ValueError as exc:
         return _render_form(
             request,
@@ -41,7 +46,7 @@ async def post(
     except PermissionError as exc:
         raise HTTPError(status=403, detail=str(exc)) from exc
 
-    return Redirect(f"/boards/{board_slug}/threads/{thread_slug}#post-{post_view.id}")
+    return Redirect(f"/boards/{board_slug}/threads/{thread_slug}#post-{post_view.post_number}")
 
 
 def _render_form(
@@ -53,11 +58,11 @@ def _render_form(
     error: str | None = None,
     body: str | None = None,
 ) -> Page:
-    parsed_post_id = _parse_post_id(post_id)
+    parsed_post_number = _parse_post_number(post_id)
     services = get_services(request)
     viewer = services.viewer()
     try:
-        edit_view = services.read_post_editor(board_slug, thread_slug, parsed_post_id)
+        edit_view = services.read_post_editor(board_slug, thread_slug, parsed_post_number)
     except LookupError as exc:
         raise HTTPError(status=404, detail=str(exc)) from exc
     except PermissionError as exc:
@@ -85,7 +90,7 @@ def _render_form(
     )
 
 
-def _parse_post_id(raw: object) -> int:
+def _parse_post_number(raw: object) -> int:
     try:
         return int(str(raw or ""))
     except ValueError as exc:

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/revisions/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/revisions/page.html
@@ -17,7 +17,7 @@
 
   {% call section_header("Post history") %}
   {{ badge(history.board.name, variant="muted") }}
-  {{ badge("post #" ~ history.post.post.id) }}
+  {{ badge("post #" ~ history.post.post.post_number) }}
   {% end %}
 
   {% call surface(variant="elevated") %}
@@ -31,7 +31,7 @@
         </p>
       </div>
       <a class="chirpui-link"
-         href="/boards/{{ history.board.slug }}/threads/{{ history.thread.slug }}/posts/{{ history.post.post.id }}/edit">
+         href="/boards/{{ history.board.slug }}/threads/{{ history.thread.slug }}/posts/{{ history.post.post.post_number }}/edit">
         Edit current post
       </a>
     </div>

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/revisions/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/revisions/page.py
@@ -10,11 +10,11 @@ from elbysodic.web.state import get_services
 
 
 def get(request: Request, board_slug: str, thread_slug: str, post_id: str) -> Page:
-    parsed_post_id = _parse_post_id(post_id)
+    parsed_post_number = _parse_post_number(post_id)
     services = get_services(request)
     viewer = services.viewer()
     try:
-        history = services.read_post_revisions(board_slug, thread_slug, parsed_post_id)
+        history = services.read_post_revisions(board_slug, thread_slug, parsed_post_number)
     except LookupError as exc:
         raise HTTPError(status=404, detail=str(exc)) from exc
     except PermissionError as exc:
@@ -29,7 +29,7 @@ def get(request: Request, board_slug: str, thread_slug: str, post_id: str) -> Pa
     )
 
 
-def _parse_post_id(raw: object) -> int:
+def _parse_post_number(raw: object) -> int:
     try:
         return int(str(raw or ""))
     except ValueError as exc:

--- a/src/elbysodic/web/pages/characters/{character_slug}/page.html
+++ b/src/elbysodic/web/pages/characters/{character_slug}/page.html
@@ -606,8 +606,8 @@
         </div>
         <a class="chirpui-link"
            href="/boards/{{ item.board.slug }}/threads/{{ item.thread.slug }}#{{ item.post.anchor }}"
-           aria-label="Jump to post {{ item.post.post.id }}">
-          #{{ item.post.post.id }}
+           aria-label="Jump to post {{ item.post.post.post_number }}">
+          #{{ item.post.post.post_number }}
         </a>
       </div>
       <div class="elbysodic-prose-body elbysodic-prose-body--compact elbysodic-post-content">

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -4206,11 +4206,11 @@ def test_thread_cards_jump_to_first_unread_then_latest() -> None:
             assert board_response.status == 200
             assert "First unread" in board_response.text
             assert (
-                f"/boards/plotting/threads/open-thread-roster#post-{first_unread.id}"
+                f"/boards/plotting/threads/open-thread-roster#post-{first_unread.post_number}"
                 in board_response.text
             )
             assert (
-                f"/boards/plotting/threads/open-thread-roster#post-{latest_unread.id}"
+                f"/boards/plotting/threads/open-thread-roster#post-{latest_unread.post_number}"
                 not in board_response.text
             )
 
@@ -4221,7 +4221,7 @@ def test_thread_cards_jump_to_first_unread_then_latest() -> None:
             assert board_after_read.status == 200
             assert "Jump to latest" in board_after_read.text
             assert (
-                f"/boards/plotting/threads/open-thread-roster#post-{latest_unread.id}"
+                f"/boards/plotting/threads/open-thread-roster#post-{latest_unread.post_number}"
                 in board_after_read.text
             )
 
@@ -4317,7 +4317,9 @@ def test_board_page_next_unread_jumps_to_first_unread_post() -> None:
             page = await client.get("/boards/board-next")
             assert page.status == 200
             assert "Next unread" in page.text
-            assert f"/boards/board-next/threads/board-next-thread#post-{post.id}" in page.text
+            assert (
+                f"/boards/board-next/threads/board-next-thread#post-{post.post_number}" in page.text
+            )
 
             thread_response = await client.get("/boards/board-next/threads/board-next-thread")
             assert thread_response.status == 200
@@ -4411,7 +4413,7 @@ def test_notifications_track_watched_thread_replies_and_open_read_state() -> Non
             )
             assert opened.status == 302
             assert dict(opened.headers)["location"] == (
-                f"/boards/plotting/threads/open-thread-roster#post-{post.id}"
+                f"/boards/plotting/threads/open-thread-roster#post-{post.post_number}"
             )
             assert services.viewer().unread_notification_count == 0
 
@@ -4652,7 +4654,7 @@ def test_thread_page_links_previous_next_and_next_unread_threads() -> None:
             assert "Next" in page.text
             assert "Older thread" in page.text
             assert "Next unread" in page.text
-            assert f"/boards/navigation/threads/older#post-{older_post.id}" in page.text
+            assert f"/boards/navigation/threads/older#post-{older_post.post_number}" in page.text
 
     asyncio.run(run())
 
@@ -4697,7 +4699,10 @@ def test_thread_page_bottom_next_unread_uses_visible_community_queue() -> None:
             page = await client.get("/boards/current-nav/threads/current-scene")
             assert page.status == 200
             assert "Next unread" in page.text
-            assert f"/boards/unread-nav/threads/elsewhere-scene#post-{unread_post.id}" in page.text
+            assert (
+                f"/boards/unread-nav/threads/elsewhere-scene#post-{unread_post.post_number}"
+                in page.text
+            )
 
     asyncio.run(run())
 
@@ -5551,10 +5556,10 @@ def test_writer_can_edit_own_post_with_safe_markup() -> None:
                 headers=_FORM,
             )
             assert created.status == 302
-            post_id = dict(created.headers)["location"].split("#post-")[1]
+            post_number = dict(created.headers)["location"].split("#post-")[1]
 
             edit_form = await client.get(
-                f"/boards/plotting/threads/open-thread-roster/posts/{post_id}/edit"
+                f"/boards/plotting/threads/open-thread-roster/posts/{post_number}/edit"
             )
             assert edit_form.status == 200
             assert "Edit post" in edit_form.text
@@ -5564,7 +5569,7 @@ def test_writer_can_edit_own_post_with_safe_markup() -> None:
             assert 'aria-label="Bold"' in edit_form.text
 
             edited = await client.post(
-                f"/boards/plotting/threads/open-thread-roster/posts/{post_id}/edit",
+                f"/boards/plotting/threads/open-thread-roster/posts/{post_number}/edit",
                 body=urlencode(
                     {
                         "body": (
@@ -5576,7 +5581,7 @@ def test_writer_can_edit_own_post_with_safe_markup() -> None:
             )
             assert edited.status == 302
             assert dict(edited.headers)["location"] == (
-                f"/boards/plotting/threads/open-thread-roster#post-{post_id}"
+                f"/boards/plotting/threads/open-thread-roster#post-{post_number}"
             )
 
             thread = await client.get("/boards/plotting/threads/open-thread-roster")
@@ -5586,11 +5591,11 @@ def test_writer_can_edit_own_post_with_safe_markup() -> None:
             assert '<script>alert("x")</script>' not in thread.text
             assert "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;" in thread.text
             assert "edited" in thread.text
-            assert f"/posts/{post_id}/revisions" in thread.text
-            assert f"/posts/{post_id}/edit" in thread.text
+            assert f"/posts/{post_number}/revisions" in thread.text
+            assert f"/posts/{post_number}/edit" in thread.text
 
             revisions = await client.get(
-                f"/boards/plotting/threads/open-thread-roster/posts/{post_id}/revisions"
+                f"/boards/plotting/threads/open-thread-roster/posts/{post_number}/revisions"
             )
             assert revisions.status == 200
             assert "Post history" in revisions.text
@@ -5618,19 +5623,29 @@ def test_noop_post_edit_does_not_create_revision() -> None:
                 headers=_FORM,
             )
             assert created.status == 302
-            post_id = int(dict(created.headers)["location"].split("#post-")[1])
-            original = repo.get_post(services.seed.community.id, post_id)
+            post_number = int(dict(created.headers)["location"].split("#post-")[1])
+            board = repo.get_board_by_slug(services.seed.community.id, "plotting")
+            thread = repo.get_thread_by_slug(
+                services.seed.community.id,
+                board.id,
+                "open-thread-roster",
+            )
+            original = repo.get_post_by_number(
+                services.seed.community.id,
+                thread.id,
+                post_number,
+            )
 
             edited = await client.post(
-                f"/boards/plotting/threads/open-thread-roster/posts/{post_id}/edit",
+                f"/boards/plotting/threads/open-thread-roster/posts/{post_number}/edit",
                 body=urlencode({"body": "Already polished."}).encode(),
                 headers=_FORM,
             )
             assert edited.status == 302
 
-            unchanged = repo.get_post(services.seed.community.id, post_id)
+            unchanged = repo.get_post(services.seed.community.id, original.id)
             assert unchanged.updated_at == original.updated_at
-            assert repo.list_post_revisions(services.seed.community.id, post_id) == []
+            assert repo.list_post_revisions(services.seed.community.id, original.id) == []
 
     asyncio.run(run())
 
@@ -5667,12 +5682,14 @@ def test_writer_cannot_edit_someone_elses_post() -> None:
 
         async with TestClient(app) as client:
             edit_form = await client.get(
-                f"/boards/plotting/threads/open-thread-roster/posts/{outsider_post.id}/edit"
+                "/boards/plotting/threads/open-thread-roster/posts/"
+                f"{outsider_post.post_number}/edit"
             )
             assert edit_form.status == 403
 
             edited = await client.post(
-                f"/boards/plotting/threads/open-thread-roster/posts/{outsider_post.id}/edit",
+                "/boards/plotting/threads/open-thread-roster/posts/"
+                f"{outsider_post.post_number}/edit",
                 body=urlencode({"body": "Trying to overwrite."}).encode(),
                 headers=_FORM,
             )
@@ -5697,7 +5714,8 @@ def test_locked_threads_still_allow_editing_own_existing_post() -> None:
 
         async with TestClient(app) as client:
             response = await client.post(
-                f"/boards/announcements/threads/welcome-to-the-rebuild/posts/{post.id}/edit",
+                "/boards/announcements/threads/welcome-to-the-rebuild/posts/"
+                f"{post.post_number}/edit",
                 body=urlencode({"body": "Updated staff note."}).encode(),
                 headers=_FORM,
             )

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -154,6 +154,7 @@ def test_staff_can_edit_posts_through_thread_management_capability(
         id=5,
         community_id=1,
         thread_id=2,
+        post_number=1,
         author_membership_id=99,
         author_character_id=100,
         body="A post from someone else.",

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -84,6 +84,75 @@ def test_schema_applies_ordered_migrations_from_historical_baseline() -> None:
     assert user_version == CURRENT_SCHEMA_VERSION
 
 
+def test_schema_migrates_existing_posts_for_thread_local_public_numbers() -> None:
+    connection = connect()
+    create_schema(connection)
+    repository = ForumRepository(connection)
+    repository.seed_default_community()
+    community = repository.get_community(1)
+    role = repository.create_role(community.id, "member", "Member")
+    user = repository.create_user("public-numbers@example.com", "hash")
+    membership = repository.create_membership(
+        community.id,
+        user.id,
+        role.id,
+        "numbers",
+        "Numbers",
+    )
+    character = repository.create_character(community.id, membership.id, "numbers", "Numbers")
+    board = repository.create_board(community.id, "numbered-scenes", "Numbered Scenes")
+    first_thread = repository.create_thread(
+        community.id,
+        board.id,
+        character.id,
+        "first-scene",
+        "First Scene",
+    )
+    second_thread = repository.create_thread(
+        community.id,
+        board.id,
+        character.id,
+        "second-scene",
+        "Second Scene",
+    )
+    first_post = repository.create_post(community.id, first_thread.id, character.id, "First beat.")
+    second_thread_post = repository.create_post(
+        community.id,
+        second_thread.id,
+        character.id,
+        "Other opener.",
+    )
+    reply = repository.create_post(community.id, first_thread.id, character.id, "Second beat.")
+
+    connection.execute("DROP INDEX idx_posts_thread_post_number")
+    connection.execute("ALTER TABLE posts DROP COLUMN post_number")
+    connection.execute("DELETE FROM schema_migrations")
+    connection.execute(
+        """
+        INSERT INTO schema_migrations (version, name, applied_at)
+        VALUES (11, 'user-session-identity-selection', '2026-01-01T00:00:00+00:00')
+        """
+    )
+    connection.execute("PRAGMA user_version = 11")
+    connection.commit()
+
+    create_schema(connection)
+
+    rows = connection.execute(
+        """
+        SELECT thread_id, id, post_number
+        FROM posts
+        ORDER BY thread_id, post_number
+        """
+    ).fetchall()
+
+    assert [tuple(row) for row in rows] == [
+        (first_thread.id, first_post.id, 1),
+        (first_thread.id, reply.id, 2),
+        (second_thread.id, second_thread_post.id, 1),
+    ]
+
+
 def test_user_sessions_can_be_created_touched_and_revoked(repo: ForumRepository) -> None:
     user = repo.create_user("session@example.com", "hash")
     session = repo.create_user_session(
@@ -1512,13 +1581,35 @@ def test_threads_and_posts_cannot_cross_community_boundaries(repo: ForumReposito
         "opening-scene",
         "Opening Scene Elsewhere",
     )
+    second_thread = repo.create_thread(
+        default.id,
+        default_board.id,
+        default_character.id,
+        "second-scene",
+        "Second Scene",
+    )
     post = repo.create_post(default.id, thread.id, default_character.id, "First post.")
+    reply = repo.create_post(default.id, thread.id, default_character.id, "Second post.")
+    second_thread_post = repo.create_post(
+        default.id,
+        second_thread.id,
+        default_character.id,
+        "Other scene opener.",
+    )
 
-    assert [item.title for item in repo.list_threads(default.id)] == ["Opening Scene"]
+    assert sorted(item.title for item in repo.list_threads(default.id)) == [
+        "Opening Scene",
+        "Second Scene",
+    ]
     assert repo.get_thread(default.id, thread.id).author_character_id == default_character.id
-    assert [item.body for item in repo.list_posts(default.id, thread.id)] == ["First post."]
+    assert [item.body for item in repo.list_posts(default.id, thread.id)] == [
+        "First post.",
+        "Second post.",
+    ]
     assert post.author_character_id == default_character.id
     assert post.author_membership_id == default_membership.id
+    assert (post.post_number, reply.post_number, second_thread_post.post_number) == (1, 2, 1)
+    assert repo.get_post_by_number(default.id, thread.id, 2) == reply
 
     with pytest.raises(LookupError):
         repo.create_thread(default.id, hosted_board.id, default_character.id, "bad", "Bad")


### PR DESCRIPTION
## Summary
- Add `post_number` as the public, thread-scoped identifier for posts while keeping `posts.id` as the internal persistence key.
- Update anchors, edit/revision routes, redirects, and thread links to resolve by `post_number` instead of database row id.
- Backfill existing posts in migration order and add coverage proving numbering resets per thread.
- Document the public-identifier rule so future iterable records follow the same pattern.

## Testing
- `uv run ruff format . --check`
- `uv run ruff check .`
- `uv run pytest -q --tb=short`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`