### PR TITLE
Fix brand navigation to swap only page content

### DIFF
--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -1,7 +1,8 @@
 {# target: body #}
 {% extends "chirpui/app_shell_layout.html" %}
 {% from "chirpui/drawer.html" import drawer, drawer_trigger %}
-{% from "chirpui/sidebar.html" import shell_brand_link, sidebar, sidebar_link, sidebar_section %}
+{% from "chirpui/sidebar.html" import sidebar, sidebar_link, sidebar_section %}
+{% from "chirpui/shell_frame.html" import shell_outlet_attrs %}
 {% from "chirpui/theme_toggle.html" import theme_toggle %}
 
 {% block title %}{{ viewer.community.name if viewer else "Elbysodic" }}{% end %}
@@ -50,14 +51,16 @@
 {% end %}
 
 {% block brand_link %}
-{% call shell_brand_link(href="/", cls="elbysodic-community-brand") %}
+<a href="/"
+   class="chirpui-app-shell__brand elbysodic-community-brand"
+   {{ shell_outlet_attrs() }}>
   {% if viewer and viewer.community.community_mark_url %}
   <img class="elbysodic-community-brand__mark"
        src="{{ viewer.community.community_mark_url }}"
        alt="{{ viewer.community.community_mark_alt }}">
   {% end %}
   <span class="elbysodic-community-brand__name">{{ viewer.community.name if viewer else "Elbysodic" }}</span>
-{% end %}
+</a>
 {% end %}
 
 {% def topnav_link(href, label, is_active=False) %}

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -417,6 +417,27 @@ def test_boosted_main_navigation_uses_chirp_shell_outlet() -> None:
     asyncio.run(run())
 
 
+def test_shell_brand_navigation_selects_page_content_for_boosted_swap() -> None:
+    async def run() -> None:
+        app = _app()
+
+        async with TestClient(app) as client:
+            response = await client.get("/boards/cerebro")
+
+        assert response.status == 200
+        brand_link = re.search(
+            r'<a href="/"[^>]*class="[^"]*elbysodic-community-brand[^"]*"[^>]*>',
+            response.text,
+        )
+        assert brand_link is not None
+        assert 'hx-boost="true"' in brand_link.group(0)
+        assert 'hx-target="#main"' in brand_link.group(0)
+        assert 'hx-swap="innerHTML"' in brand_link.group(0)
+        assert 'hx-select="#page-content"' in brand_link.group(0)
+
+    asyncio.run(run())
+
+
 def test_tenant_prefixed_boosted_main_navigation_keeps_links_in_chirp_shell_outlet() -> None:
     async def run() -> None:
         app = _app()


### PR DESCRIPTION
## Summary
- Made the shell brand link use Chirp’s shell outlet attrs so boosted navigation selects `#page-content` instead of re-nesting the full app shell.
- Added a regression test to verify the brand link carries the expected HTMX outlet contract.

## Testing
- `uv run pytest tests/test_forum_slice.py -q --tb=short`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run pytest -q --tb=short`