### PR TITLE
[codex] update agent steward system guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,249 +1,238 @@
-# Elbysodic Agent Guide
+# Elbysodic Agent Constitution
 
-This file is the handoff note for future coding agents. Read it before making
-product or architecture decisions.
+## North Star
 
-## Mission
+Elbysodic is a roleplay-native play-by-post studio layer. It exists to preserve
+character identity, thread continuity, community aesthetic control, and the
+emotional safety of pseudonymous writing spaces while making the board-running
+work of directors, writers, faces, scenes, locations, events, canon, casting,
+claims, reserves, and continuity native to the product.
 
-Elbysodic is a roleplay-native play-by-post forum platform. It is not a generic
-forum skin. The product should understand the culture of Jcink, InvisionFree,
-all things roleplay directories, Tumblr roleplay, and long-form collaborative
-fiction communities.
+## Non-Negotiables
 
-Elbysodic is becoming the studio layer for PBP. Treat a community as a small
-creative production with directors, writers, characters, scenes, locations,
-events, canon, casting needs, and continuity. The product should make those
-ideas native to the code instead of forcing communities to fake them with
-generic forums, templates, and manual lists.
-
-The north star is to give PBP a new lease on life: preserve character identity,
-thread continuity, community aesthetic control, and the emotional safety of
-pseudonymous writing spaces, while removing the repetitive manual work older
-platforms forced roleplayers to do.
-
-## Stack And Style
-
-- The app is built on Chirp and Chirp-UI.
-- Prefer server-rendered Chirp pages and small progressive-enhancement islands.
-- Chirp supports Alpine; use it for focused client-side interactions like the
-  composer, not for turning the app into an SPA.
-- Use Chirp-UI components, shell patterns, and token names first.
-- Elbysodic-specific design belongs in `src/elbysodic/web/static/elbysodic-theme.css`
-  as an app token layer on top of Chirp-UI, including light, dark, and system
-  theme behavior.
-- Repeated PBP UI concepts belong in the Elbysodic vocabulary components under
-  `src/elbysodic/web/pages/_components/` before they become page-local CSS.
-  Use `docs/product/information-hierarchy.md` for the meaning of counters,
-  facets, state badges, latest lines, cast faces, and metadata.
-- Use `docs/product/control-topology.md` before adding, hiding, combining, or
-  changing controls. It is the decision guide for visible actions, disclosure,
-  overflow menus, icon-only buttons, inline editing, and input component choice.
-- Use `docs/product/navigation-menus.md` before changing topbar realms,
-  sidebar grouping, route pathing, breadcrumbs, tabs, dropdowns, active states,
-  or mobile navigation behavior.
-- Use `docs/product/paragraph-rhythm.md` before adding or changing `<p>` output
-  or paragraph styling. Posts, hero leads, card summaries, helper copy,
-  metadata, and empty states need distinct text roles.
-- Use `docs/product/notices-admonitions.md` before adding current-event bridges,
-  warnings, staff notices, toasts, or other page-local alerts.
-- Keep frontend controls complete and ergonomic for roleplayers doing real
-  writing: stable composer dimensions, previews, drafts, toolbar affordances,
-  and clear character context.
-
-## Product Decisions
-
-- MVP experience is one community per install.
-- Architecture is tenant-aware from day one; forum-domain rows and service
-  operations stay scoped by `community_id`.
-- Users are global login accounts.
-- `CommunityMembership` is the user's identity inside one community.
-- Permissions, roles, usernames, display names, and default character settings
-  belong to membership, not user.
-- There are no global characters. A character belongs to exactly one membership
-  in exactly one community.
-- Characters are public posting identities, aliases, and roster faces. They are
-  core product primitives, not profile decoration.
-- The active/default face is a product lens, not just a composer default. When
-  a writer is browsing as a character, discovery, queues, joins, and future
-  filters should reduce cognitive load by assuming that face where safe.
-- Facets are director-defined world lenses. They can describe species,
-  factions, locations, plot lanes, application categories, or any other
-  community-specific dimension the board uses to make its world playable.
-- Pillar content does not have to be a thread. World materials, events,
-  application guides, claims, reserves, and wanted hooks can be first-class
-  objects when that better fits the PBP ritual.
-
-## Current Product Spine
-
-The current prototype already has:
-
-- Seeded SQLite development forum with one default community.
-- Boards, threads, posts, and character-authored posting.
-- Community-local character roster and active/default face switching.
-- Board, thread, home, character, and "My threads" views.
-- Safe post markup rendering, composer toolbar, preview toggle, and local draft
-  restore.
-- Thread read state, first-unread jumps, next-unread navigation, sidebar board
-  counts, and "caught up" status.
-- Queue language for "needs reply" and "waiting on others" rather than generic
-  unread-only forum language.
-- Post editing and revision history.
-- Staff thread lifecycle controls: pin, lock, unlock, unpin, and move.
-- Thread watches, character and writer mention detection, notification inbox,
-  and shell notification counts.
-- Director-defined facets for characters, boards, threads, materials, discovery,
-  and wanted hooks.
-- World materials for premise, rules, factions, application guidance, and
-  events outside the forum/thread format.
-- Wanted hooks as first-class plot and casting invitations linked to characters,
-  world materials, and facets.
-- Character plot hooks as writer-authored invitations attached to a face,
-  membership, and community, with lightweight interest from active faces.
-- Wanted interest supports both active-face interest and prospective concepts
-  from writers willing to create a new character for the hook.
-- Plotting rooms collect accepted plot-hook and wanted interest into shared
-  planning spaces without forcing that work into ordinary threads.
-- Character profiles are becoming hubs: profile identity, plotter hooks,
-  writing tracker, and recent posts.
-
-## Product Shape To Preserve
-
-- The world should be the default emotional surface. Writer/admin tooling should
-  support the fiction without visually outshouting the community's atmosphere.
-- Character pages should continue moving toward a hub model: identity at the
-  top, plotter and wanted material near the character, tracker/queue below it,
-  and world/facet context where it helps.
-- Wanted hooks should stay more structured than ordinary plotter threads. They
-  can become claimable/reservable, notify creators, spawn applications, or spawn
-  plotting threads, but they should remain a first-class object.
-- Character plot hooks are lighter than wanted hooks: they are invitations to
-  connect with an existing face, not a full casting workflow. Keep prospective
-  "I would make someone new" behavior in wanted/casting unless a future design
-  deliberately expands plot hooks.
-- Plotting rooms are private planning surfaces for turning interest into play.
-  Keep them compact and action-oriented, with clear links back to the character,
-  wanted hook, plot hook, and eventual scene.
-- Applications, claims, reserves, canons, face claims, and wanted ads belong near
-  the "materials of running a board." They may integrate with threads, but they
-  should not be forced to be threads by default.
-- Plot discovery should use facets and the active face to help writers find
-  compatible people, open scenes, event roles, and faction pressure.
-- Keep visual and cognitive load low by using the current face, current lens,
-  and director-authored structure to choose sensible defaults.
-- When a feature feels like board production material, consider whether it
-  belongs in the studio layer: world materials, events, applications, claims,
-  reserves, casting, wanted hooks, and future director tools.
-
-## Architecture Rules
-
-- Keep tenant boundaries explicit in schema, repository, services, permissions,
+- This is not a generic forum skin. Use PBP language: face, roster, thread,
+  scene, plotter, wanted, claims, reserves, needs reply, waiting, caught up,
+  and watching.
+- The MVP is one community per install, but the architecture is tenant-aware
+  from day one.
+- Keep `community_id` explicit in schema, repositories, services, permissions,
   cache keys, exports, and tests.
-- Add service-layer methods that accept or resolve community/membership context
-  rather than reaching around it in page handlers.
-- Prefer repository methods over ad hoc SQL in web pages.
-- New structured content should be community-scoped from the first schema, even
-  when the MVP only exposes one community.
-- If a feature can involve a writer identity and a character identity, store both
-  intentionally: membership for ownership/permissions, character for public
-  authorship or story context.
-- When adding a new forum primitive, ask:
-  - Is it community-scoped?
-  - Is it membership-scoped or character-scoped?
-  - Is it director-authored, writer-authored, or both?
-  - Should it be a thread, or does it deserve a structured primitive?
-  - Does the active face provide a safe default?
-  - Does it need export support later?
-  - Can it leak staff/private data across communities or roles?
-- Tests should cover behavior through both repository boundaries and rendered
-  pages when the feature affects user workflow.
+- Users are global login accounts. `CommunityMembership` is the user's identity
+  inside one community. Permissions, roles, names, and default face settings
+  belong to membership, not user.
+- Characters are public posting identities owned by exactly one membership in
+  exactly one community. There are no global characters.
+- Store membership for ownership and permissions, and character for public
+  authorship or story context when a flow has both.
+- Prefer server-rendered Chirp pages and small progressive-enhancement islands.
+  Do not turn the app into an SPA.
+- Use Chirp-UI patterns and token names first. Put Elbysodic theme tokens in
+  `src/elbysodic/web/static/elbysodic-theme.css`.
+- Repeated PBP UI concepts belong in
+  `src/elbysodic/web/pages/_components/` before they become page-local CSS.
+- Prefer repository and service methods over ad hoc SQL in page handlers.
 
-## Scoped Agent Guides
+## Architecture Boundaries
 
-Root `AGENTS.md` is the product constitution. Nested `AGENTS.md` files are
-scoped steward files: short local domain guides for package boundaries, docs,
-domain primitives, services, storage, web/UI, blueprints, and tests.
+- `src/elbysodic/domain/` owns typed product primitives and vocabulary.
+- `src/elbysodic/db/` owns SQLite schema, migrations, repositories, and seed
+  data. Repository APIs stay tenant-aware.
+- `src/elbysodic/services/` owns workflows, policy checks, read models,
+  identity resolution, and orchestration.
+- `src/elbysodic/web/` owns Chirp app setup, routes/pages/templates/static
+  assets, navigation, composer behavior, security wrappers, and rendered
+  privacy.
+- `src/elbysodic/blueprints/` owns the director-authored Program Blueprint
+  import/validation contract.
+- `docs/` owns product and architecture decision guides.
+- `tests/` owns regression proof for repository boundaries, services, policies,
+  rendered pages, markup, CLI behavior, and security.
+- `plans/` owns durable roadmap and steward rollup snapshots, not scratch notes.
+- `changelog.d/` owns user-visible release fragments.
 
-When editing a subtree, read this root guide and the nearest nested
-`AGENTS.md` before making product or architecture decisions. The nested guide
-may add local checks, contracts, and safety boundaries, but it must refine this
-constitution rather than contradicting the mission, tenant model, product voice,
-or PBP-native shape.
+## Stakes
 
-Cross-cutting PRs should include brief **Steward Notes** in the summary:
-which steward files were consulted, which boundary decisions were made, and
-which risks or follow-up gaps remain. Keep the notes small and practical.
+When this repo regresses, writers can post as the wrong face, private/staff data
+can leak across communities, directors can lose structured board-running
+material, seeded demos can misrepresent the product, rendered pages can break
+long-form writing flow, and future agents can drift into generic forum or SaaS
+decisions that erase the culture the platform is meant to protect.
 
-### Ask Stewards Workflow
+## Stop And Ask
 
-The trigger phrase **"ask stewards"** means run this consultation workflow and
-produce a short prioritization rollup.
+Check in with a human before:
 
-1. Verify the checkout/ref is current enough for the question. Run `git status
-   --short --branch`; fetch or compare with upstream when prioritization depends
-   on current remote state.
-2. Enumerate scoped steward files with `find . -name AGENTS.md -print | sort`.
-3. For implementation work, consult the stewards nearest the affected paths.
-   For backlog, roadmap, or product sequencing work, consult all stewards.
-4. Ask each consulted steward for:
-   - top priority
-   - confidence
-   - evidence from code, docs, tests, or product spine
-   - dependencies and ordering constraints
-   - risks and blast radius
-   - tempting "not now" items
-   - upstream or downstream service opportunities
-5. Synthesize with weighted voting. Favor convergence, dependency order,
-   blast-radius reduction, public-contract risk, user-visible correctness, risk
-   reduction, and reversibility.
-6. Preserve minority reports when a steward sees a real risk the majority
-   downweights.
-7. Return a short rollup: recommendation, why now, consulted stewards,
-   confidence, dependencies, risks, not-now items, and suggested next checks.
+- public API, CLI, route, import path, blueprint, or release-protocol changes
+- new runtime dependencies or dependency-source changes
+- config, build, deployment, Railway, or release-surface changes
+- data model, schema, migration, seed, or irreversible data changes
+- irreversible operations or destructive filesystem/git actions
+- security, auth, CSRF, session, role, permission, or privacy-boundary changes
+- concurrency, lifecycle, startup, request-context, or persistence changes
+- test/code disagreement where the intended product behavior is unclear
+- unreproduced bugs or fixes based only on speculation
 
-The workflow is a thinking aid, not a committee. Use it to surface domain-aware
-tradeoffs quickly, then keep moving.
+## Anti-Patterns
 
-### Plan Snapshots
+- Global characters, user-level staff power, or role checks detached from
+  membership.
+- Page handlers with one-off SQL for product rows.
+- Structured board-running material forced into threads when it deserves its
+  own primitive.
+- Generic tags replacing director-defined facets.
+- UI that hides writing context, active face, preview, drafts, or control
+  affordances roleplayers need during long sessions.
+- Theme or Blueprint inputs that accept raw CSS, script tags, external font
+  URLs, or layout-breaking controls.
+- Docs or tests that describe a different tenant, identity, navigation, or
+  product vocabulary contract than the code implements.
 
-Save durable steward rollups, roadmap sequences, and multi-step implementation
-plans under `plans/`. Active plans live in `plans/in-progress/` and must be
-listed in `plans/README.md` with a review-by date and closure criteria.
+## Steward System
 
-Do not use plan files as scratch notes. If a plan has gone stale, refresh it,
-split it into concrete work, or move it to `plans/archive/YYYY/` as completed,
-superseded, or abandoned.
+Agents read this root constitution plus the closest scoped `AGENTS.md` before
+making product or architecture decisions. Root is the constitution and routing
+guide. Scoped files are domain stewards: they own local invariants, refusal
+patterns, docs, tests, examples, fixtures, and checks.
 
-## Development Commands
+Each steward uses this operating model:
 
-Use the project tools before handing work back:
+- Point of View: who or what the domain represents
+- Protect: invariants, contracts, quality bars, and failure modes
+- Contract Checklist: concrete surfaces to inspect when this domain changes
+- Advocate: features, fixes, and investments the domain should push for
+- Serve Peers: upstream/downstream domains that need clearer contracts,
+  diagnostics, docs, tests, or ergonomics
+- Do Not: local anti-patterns
+- Own: tests, docs, examples, fixtures, maintenance checks
 
-```bash
-uv run ruff check .
-uv run ruff format . --check
-uv run pytest -q --tb=short
-uv run ty check src/elbysodic/ tests/
-uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
-```
+Cross-boundary PRs should include short **Steward Notes** naming consulted
+stewards, accepted/deferred findings, proof, collateral updates, and remaining
+risks.
 
-For local browser QA, run the app on port 8001:
+## Contract Checklist
 
-```bash
-elbysodic serve --port 8001
-```
+For cross-surface changes:
 
-or, in this workspace, the known direct form:
+- Identify every surface that should agree: CLI/API, programmatic use,
+  protocol, schema/types, UI, docs, examples, scaffold/templates, tests,
+  benchmarks, and changelog.
+- Every accepted finding must name required proof and collateral updates, or
+  explicitly say `no collateral: <reason>`.
+- Docs, examples, and scaffold/templates move in the same PR as user-facing
+  behavior unless synthesis records why they are unaffected.
+- Contract-affecting PRs include a parity matrix when behavior spans multiple
+  entrypoints.
 
-```bash
-.venv/bin/python -c "from elbysodic.web import create_app; create_app(debug=False).run(port=8001)"
-```
+## Steward Signal Format
 
-## Product Voice
+Steward findings should be contract-oriented, evidence-backed, and
+collateral-aware.
 
-Use language that fits roleplayers. Prefer "face", "roster", "thread",
-"scene", "plotter", "wanted", "claims", "reserves", "needs reply", "waiting",
-"caught up", and "watching" over generic forum jargon when the PBP concept is
-more precise.
+Use this format:
 
-The interface should feel like a calm, capable writing room: dense enough for
-regular players, gentle enough for long sessions, and expressive enough to let
-communities feel like themselves.
+- Steward:
+- Area:
+- Severity: P0/P1/P2/P3
+- Invariant:
+- Evidence:
+- User Impact:
+- Required Fix:
+- Required Proof:
+- Collateral:
+- Confidence:
+
+## Steward Swarms
+
+When the user asks for `ask stewards`, `bugbash`, `review swarm`, or
+`steward synthesis`, and delegation is available:
+
+- spawn independent steward agents for affected domains
+- each steward reads root plus its closest scoped `AGENTS.md`
+- each steward advocates only for that domain's interests
+- each steward returns findings in the Steward Signal Format
+- implementing agent owns synthesis and final decisions
+- stewards advise and create useful tension; they do not own the integrated
+  implementation
+- keep PR scope bounded to accepted findings and their proof/collateral
+- defer unrelated steward suggestions to not-now/follow-up
+
+For backlog, roadmap, or prioritization work, consult all scoped stewards and
+produce raw steward signals, confidence, dependencies, risks, convergence,
+minority reports, ranked backlog, and not-now items.
+
+## Steward Feedback Loop
+
+- Steward miss: when a bug escapes an applicable steward, update the checklist,
+  a regression test, a docs/snippet check, a routing rule, or record why the
+  miss should not become policy.
+- Steward overreach: when a steward repeatedly pulls unrelated work into PRs,
+  narrow the checklist, split the steward, or move the concern to follow-up.
+- Repeated high-quality findings should become checklist items.
+- Repeated noisy findings should be pruned or clarified.
+- Steward guidance evolves from evidence: escaped bugs, late collateral
+  updates, CI/review misses, and recurring review comments.
+
+## When To Consult
+
+- Proactively consult stewards for cross-boundary, public-facing,
+  hard-to-reverse, performance-sensitive, concurrency-sensitive,
+  security-sensitive, or contract-affecting work.
+- Use the nearest steward for local work.
+- Use multiple stewards when ownership lines cross.
+- Parallelize steward consultation only when questions are independent.
+- Keep final synthesis and implementation accountability with the implementing
+  agent.
+
+## Ask Stewards
+
+Trigger phrase: `ask stewards`.
+
+For implementation work, consult affected stewards and return synthesis before
+or during the change. Include accepted/deferred findings, merged duplicates,
+minority reports, required proof, collateral updates, and not-now items.
+
+For multi-surface work, include a parity matrix like:
+
+| Contract | API/CLI | Programmatic | Protocol | Schema/Types | Docs | Examples | Tests |
+|---|---|---|---|---|---|---|---|
+
+For backlog, roadmap, or product sequencing work, consult all scoped stewards.
+Favor convergence, dependency order, blast-radius reduction, public-contract
+risk, user-visible correctness, risk reduction, and reversibility. Preserve
+minority reports when a steward sees a real risk the majority downweights.
+
+## Extension Routing
+
+Elbysodic does not currently expose a general plugin system. The extension-like
+contract is Program Blueprints:
+
+- Blueprint parser and validation: `src/elbysodic/blueprints/`
+- Blueprint hydration and workflow logic: `src/elbysodic/services/blueprints.py`
+- Blueprint product contract: `docs/product/program-blueprints.md`
+- Blueprint tests: `tests/test_program_blueprints.py`
+
+## Done Criteria
+
+- Run the relevant local gate: `uv run ruff check .`,
+  `uv run ruff format . --check`, `uv run pytest -q --tb=short`,
+  `uv run ty check src/elbysodic/ tests/`, and
+  `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`.
+- For doc-only changes, run the lightest relevant checks and say what was not
+  run.
+- Update docs, changelog fragments, migration notes, examples, scaffold, or
+  templates when user-facing behavior or public contracts change.
+- Add performance, concurrency, security, or privacy notes when relevant.
+- Every accepted steward finding has test/docs/example/benchmark proof or an
+  explicit no-impact note.
+
+## Review Notes
+
+Flag these in commits, PRs, or final handoff when they appear:
+
+- weird tests or brittle assertions
+- unused public names or dead code
+- suppressions and why they remain justified
+- benchmark gaps for performance-sensitive changes
+- free-threading, request-lifecycle, or SQLite persistence assumptions
+- steward disagreement, minority reports, and deferred/not-now findings
+- product-code/docs/tests/changelog drift

--- a/changelog.d/AGENTS.md
+++ b/changelog.d/AGENTS.md
@@ -1,0 +1,71 @@
+# Changelog Steward
+
+This domain represents user-visible release fragments and Towncrier release
+categories.
+
+Related docs:
+
+- root `AGENTS.md`
+- `changelog.d/README.md`
+- `pyproject.toml`
+- `README.md`
+
+## Point Of View
+
+Represent users, deployers, and future maintainers reading release notes to
+understand what changed and whether behavior, setup, data, or security needs
+attention.
+
+## Protect
+
+- Every user-visible change gets one clear fragment unless synthesis records
+  `no collateral: <reason>`.
+- Fragment categories match configured Towncrier directories: `added`,
+  `changed`, `deprecated`, `removed`, `fixed`, and `security`.
+- Fragment text is a complete sentence without a leading dash.
+- Release notes describe product behavior in roleplay-native language when the
+  change affects writers or directors.
+- Security, migration, deployment, and data-shape changes are not hidden under
+  vague "changed" wording.
+
+## Contract Checklist
+
+- File path: `changelog.d/+short-description.<category>.md`.
+- Category: matches `pyproject.toml` Towncrier config and the change type.
+- Content: complete sentence, user-facing impact, no implementation-only noise.
+- Docs: README or architecture docs update when release notes mention setup,
+  deployment, migration, security, or public contracts.
+- Checks: `make changelog-draft` or `make changelog-check` when validating
+  release-note behavior matters.
+
+## Advocate
+
+- Prefer specific fragments that help users scan what changed.
+- Use `security` for auth, privacy, CSRF, session, tenant leakage, or role
+  boundary fixes.
+- Keep release notes connected to actual behavior, not internal churn.
+
+## Serve Peers
+
+- Remind package, docs, storage, service, web, blueprint, and test stewards when
+  their accepted findings need release collateral.
+- Coordinate with package steward when Towncrier config or release commands
+  change.
+
+## Do Not
+
+- Add fragments for purely internal doc-only steward wording unless it changes
+  user-facing guidance.
+- Combine unrelated user-visible changes into one vague fragment.
+- Rename release categories without updating `pyproject.toml`, docs, and
+  release checks.
+- Treat changelog fragments as a substitute for docs or migration notes.
+
+## Own
+
+- `changelog.d/README.md`
+- `changelog.d/*.md` fragments
+- Towncrier category expectations in `pyproject.toml` with package steward
+  coordination
+- optional checks: `make changelog-draft`, `make changelog-check`, and
+  `scripts/check_changelog_fragments.py`

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,44 +1,77 @@
-# Product And Architecture Steward
+# Product And Architecture Docs Steward
 
-## Steward
+This domain represents the product and architecture decision guides that keep
+Elbysodic PBP-native, tenant-safe, and understandable across agent sessions.
 
-Product and architecture steward for `docs/architecture/`, `docs/product/`, and
-the README/AGENTS narrative when it explains Elbysodic's direction.
+Related docs:
 
-## Protects
+- root `AGENTS.md`
+- `README.md`
+- `docs/architecture/*.md`
+- `docs/product/*.md`
+- `plans/README.md`
+
+## Point Of View
+
+Represent future contributors and agents who need docs to explain current
+contracts, product language, and decision rules without drifting away from code
+and tests.
+
+## Protect
 
 - The PBP-native mission: faces, rosters, scenes, plotters, wanted hooks,
   claims, reserves, director materials, and writing flow stay first-class.
 - Architecture docs preserve tenant boundaries, membership-vs-character
-  identity, repository/service layering, and migration discipline.
-- Product docs remain decision guides for agents, not aspirational clutter.
+  identity, repository/service layering, migration discipline, rendered
+  privacy, and security assumptions.
+- Product docs remain decision guides for implementation, not speculative
+  manifesto or backlog landfill.
 - UI vocabulary docs stay consistent with promoted components and current
   route surfaces.
+- Docs distinguish current behavior, planned work, and deliberately deferred
+  ideas.
 
-## Must Not Become
+## Contract Checklist
 
-- A backlog landfill or speculative manifesto detached from code.
-- Generic SaaS language that erases roleplay culture.
-- A duplicate of implementation details better expressed in tests or code.
+- Architecture: primitives, multi-tenancy, migrations, security, rendered
+  privacy, and seed personas agree with code and tests.
+- Product: mission, information hierarchy, controls, navigation, paragraph
+  rhythm, notices, appearance, and blueprints agree with UI/service behavior.
+- README: setup, development, deployment, current slice, and public commands
+  remain accurate.
+- Plans: durable roadmaps link to active contracts without becoming docs.
+- Tests/checks: run relevant tests when docs make behavioral claims; run Ruff
+  if Python snippets change.
+- Changelog: product-guide or architecture-guide changes that affect users get
+  a fragment.
 
-## Documentation Ownership
+## Advocate
 
-Owns `docs/architecture/*.md`, `docs/product/*.md`, README architecture/product
-sections, and root `AGENTS.md` product doctrine. When code changes alter a
-primitive, control pattern, navigation rule, or migration boundary, update the
-relevant doc in the same PR.
+- Convert recurring review comments and escaped bugs into clearer docs or
+  steward checklist items.
+- Replace generic SaaS/forum language with roleplay-native language.
+- Keep docs concise enough that agents will actually read them.
 
-## Local Checks
+## Serve Peers
 
-- `rg` for conflicting terms before changing product vocabulary.
-- `uv run ruff check .` when doc examples include Python snippets.
-- `uv run pytest -q --tb=short` when documentation claims are backed by tests.
+- Give domain, service, storage, web, blueprint, tests, and plans stewards
+  canonical language for contracts.
+- Ask code stewards to update docs when behavior changes first.
+- Ask tests steward for proof when docs claim a behavior is enforced.
 
-## Public Contracts And Safety
+## Do Not
 
-- Do not weaken `community_id`, membership, character, or staff-role
+- Weaken `community_id`, membership, character, staff-role, or privacy
   boundaries in prose.
-- Keep examples in PBP language and make clear whether a feature is current,
-  planned, or deliberately deferred.
-- Cross-cutting docs changes should include Steward Notes naming affected code
-  domains and tests that prove the claim.
+- Document aspirational features as implemented behavior.
+- Duplicate implementation details better expressed in code or tests.
+- Let plan snapshots become permanent product doctrine.
+
+## Own
+
+- `docs/architecture/`
+- `docs/product/`
+- product and architecture portions of `README.md`
+- root `AGENTS.md` product doctrine in coordination with scoped stewards
+- terminology checks with `rg` before broad vocabulary changes
+- docs collateral for contract-affecting PRs

--- a/plans/AGENTS.md
+++ b/plans/AGENTS.md
@@ -1,0 +1,67 @@
+# Planning Steward
+
+This domain represents durable roadmap, steward rollup, and multi-step
+implementation snapshots that need continuity across agent sessions.
+
+Related docs:
+
+- root `AGENTS.md`
+- `plans/README.md`
+- `docs/product/mission.md`
+- `docs/architecture/primitives.md`
+
+## Point Of View
+
+Represent future agents and maintainers who need active plans to be current,
+bounded, reviewable, and connected to product/code/test contracts.
+
+## Protect
+
+- Plans are working snapshots, not scratchpads, permanent specs, or a second
+  issue tracker.
+- Active plans live in `plans/in-progress/` and appear in `plans/README.md`.
+- Every active plan has status, owner, created/updated context when present,
+  review-by date, and closure criteria.
+- Stale plans are refreshed, split into concrete work, or moved to
+  `plans/archive/YYYY/` as completed, superseded, or abandoned.
+- Steward rollups preserve dependencies, risks, minority reports, and not-now
+  items without turning them into immediate scope creep.
+
+## Contract Checklist
+
+- Index: `plans/README.md` lists active plans with accurate status, owner,
+  review-by date, and closure criteria.
+- File placement: active plans stay in `plans/in-progress/`; inactive plans move
+  to archive paths.
+- Cross-links: plan claims point to relevant docs, code domains, or tests.
+- Steward synthesis: accepted/deferred findings, proof, collateral, and
+  dependencies are visible.
+- Docs/changelog: update docs or changelog only when a plan changes a public
+  contract or records delivered user-facing behavior.
+
+## Advocate
+
+- Split durable plans into PR-sized work before they become stale.
+- Keep product sequencing tied to tenant safety, user-visible correctness,
+  reversibility, and proof.
+- Capture steward disagreement as minority reports when it affects risk.
+
+## Serve Peers
+
+- Give product/docs stewards roadmap context without rewriting doctrine.
+- Give implementation stewards dependencies and not-now boundaries.
+- Give tests steward early warning for proof gaps that plans must close.
+
+## Do Not
+
+- Use plan files for scratch notes or raw transcripts.
+- Let stale in-progress plans accumulate past review dates.
+- Treat a plan as implemented behavior.
+- Add new plan categories without updating `plans/README.md`.
+
+## Own
+
+- `plans/README.md`
+- `plans/in-progress/`
+- future `plans/archive/YYYY/` lifecycle hygiene
+- durable steward rollups and roadmap sequencing snapshots

--- a/src/elbysodic/AGENTS.md
+++ b/src/elbysodic/AGENTS.md
@@ -1,47 +1,76 @@
 # Package And Tooling Steward
 
-## Steward
+This domain represents the installable `elbysodic` Python distribution, CLI
+entrypoint, application factory import surface, typing marker, and local
+development orchestration.
 
-Package steward for the installable `elbysodic` distribution, CLI entrypoint,
-application factory import surface, and local development orchestration.
+Related docs:
 
-## Protects
+- root `AGENTS.md`
+- `README.md`
+- `changelog.d/README.md`
+- `pyproject.toml`
 
-- The package remains a typed Python 3.14 project with `src/` layout and the
+## Point Of View
+
+Represent contributors, deployers, tests, and agents who need the package to be
+boring to install, import, type-check, run, and release.
+
+## Protect
+
+- `src/` layout, Python 3.14 typing, `src/elbysodic/py.typed`, and the
   `elbysodic` console script.
-- `elbysodic.cli:main`, `elbysodic.web:create_app`, and `elbysodic.services`
-  exports stay boring, importable, and friendly to tests.
-- Root tools stay aligned: `pyproject.toml`, `Makefile`, `uv.lock`,
-  `changelog.d/`, and README command examples should tell the same story.
-- Local dependency overrides keep pointing at the owned Chirp stack described
-  in README.
-
-## Must Not Become
-
-- A dumping ground for product logic that belongs in services or repositories.
-- A second configuration system beside Chirp, `pyproject.toml`, and the CLI.
-- A packaging experiment that makes local setup harder than `make setup`,
-  `make install`, and `make ci`.
-
-## Documentation Ownership
-
-Owns README sections for dependency layout, local commands, running the app,
-and package-level public imports. Coordinate with `docs/AGENTS.md` when command
-or architecture descriptions change.
-
-## Local Checks
-
-- `uv run ruff check .`
-- `uv run ruff format . --check`
-- `uv run ty check src/elbysodic/ tests/`
-- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
-- For CLI changes, run a focused smoke such as `uv run elbysodic --help`.
-
-## Public Contracts And Safety
-
-- Do not rename the console script, package, or `create_app` import path without
-  updating README, tests, and downstream usage.
-- Keep CLI commands side-effect explicit: `serve` runs the app, `init-db`
+- Stable public imports such as `elbysodic.cli:main`,
+  `elbysodic.web:create_app`, and service package exports.
+- Alignment among `pyproject.toml`, `Makefile`, `uv.lock`, README commands,
+  Towncrier config, and local development docs.
+- Local Chirp stack overrides stay in ignored `uv.toml`, not committed project
+  metadata.
+- CLI commands make side effects explicit: `serve` runs the app, `init-db`
   creates schema, and `seed-demo` creates seeded demo state.
-- Do not hide dependency downloads, destructive cleanup, or database writes
-  behind innocuous commands.
+
+## Contract Checklist
+
+- CLI behavior: `uv run elbysodic --help` for CLI changes.
+- Programmatic imports: app factory import and package exports still import.
+- Tooling: `pyproject.toml`, `Makefile`, `uv.lock`, and README command examples
+  agree.
+- Release notes: user-visible behavior has a `changelog.d/` fragment unless
+  synthesis records `no collateral`.
+- Checks: Ruff, Ruff format check, ty, app check, and focused tests relevant to
+  the changed command or import surface.
+
+## Advocate
+
+- Keep local setup and CI commands short, documented, and reproducible.
+- Improve diagnostics for CLI failures before adding new knobs.
+- Keep dependency changes rare, deliberate, and paired with docs and lockfile
+  updates.
+
+## Serve Peers
+
+- Give web, service, storage, and blueprint stewards stable imports and
+  command entrypoints.
+- Coordinate with docs and changelog stewards when commands, dependencies,
+  release fragments, or deployment instructions change.
+- Coordinate with tests steward on fixtures that depend on package setup.
+
+## Do Not
+
+- Put product workflow logic in package-level files.
+- Add a second configuration system beside Chirp, `pyproject.toml`, and CLI
+  options.
+- Hide dependency downloads, destructive cleanup, or database writes behind
+  innocent-looking commands.
+- Rename the console script, package, or `create_app` import path without
+  same-PR docs and tests.
+
+## Own
+
+- `src/elbysodic/__init__.py`
+- `src/elbysodic/cli.py`
+- `src/elbysodic/py.typed`
+- package metadata and task-runner config in `pyproject.toml`
+- README sections for local dependency layout, development, running locally,
+  deployment commands, and package-level public imports
+- package/CLI smoke tests in `tests/test_cli.py`

--- a/src/elbysodic/blueprints/AGENTS.md
+++ b/src/elbysodic/blueprints/AGENTS.md
@@ -1,40 +1,76 @@
 # Blueprint Contract Steward
 
-## Steward
+This domain represents Program Blueprints: the director-authored starter packet
+contract for creating a PBP hub from validated structured input.
 
-Blueprint steward for `src/elbysodic/blueprints/` and the director-authored
-program starter packet contract.
+Related docs:
 
-## Protects
+- root `AGENTS.md`
+- `docs/product/program-blueprints.md`
+- `docs/architecture/primitives.md`
+- `docs/architecture/multi-tenancy.md`
 
-- Program Blueprints describe PBP hubs in director language: program, roster
-  faces, playable boards, materials, wanted hooks, and safe theme tokens.
+## Point Of View
+
+Represent directors importing a community concept and the services/storage that
+must hydrate it safely into one tenant without treating the input as trusted
+runtime code.
+
+## Protect
+
+- Blueprints use director language: program, roster faces, playable boards,
+  materials, wanted hooks, facets, and safe theme tokens.
 - Validation errors stay human-readable for directors and import previews.
-- Hydration paths go through repository/service boundaries, not ad hoc writes.
-- Seed data and future YAML imports remain aligned to one shared shape.
+- Hydration routes through service and repository boundaries.
+- Seed data, future YAML imports, docs, and tests stay aligned to one shared
+  shape.
+- Input cannot smuggle raw CSS, script tags, external font URLs, or
+  layout-breaking theme controls.
+- Duplicate slugs, missing starter content, unknown board/wanted types, invalid
+  theme tokens, and broken material references are caught before hydration.
 
-## Must Not Become
+## Contract Checklist
 
-- A live state store or replacement for normal staff tools.
-- A free-form CSS/theme engine.
-- A generic CMS import format without roleplay-specific shape.
+- Protocol: parser, validation output, and hydration expectations agree.
+- Schema/types: Blueprint data structures align with domain records and service
+  hydration needs.
+- Storage/services: created objects are scoped to one community and intentional
+  owners.
+- Docs: `docs/product/program-blueprints.md` updates with any contract,
+  validation, hydration, or allowed-token change.
+- Tests: `tests/test_program_blueprints.py` covers parsing/validation; tenant
+  repository tests cover hydration boundary changes.
+- Changelog: add a fragment for user-visible Blueprint behavior.
 
-## Documentation Ownership
+## Advocate
 
-Owns `docs/product/program-blueprints.md` and should update it with any
-contract, validation, hydration, or allowed-token change.
+- Add dry-run diffs and clearer validation diagnostics before expanding import
+  power.
+- Keep Blueprint shape roleplay-specific instead of turning it into a generic
+  CMS format.
+- Promote safe reusable starter content when seed data and Blueprint imports
+  need the same examples.
 
-## Local Checks
+## Serve Peers
 
-- `uv run pytest tests/test_program_blueprints.py -q --tb=short`
-- `uv run pytest tests/test_tenant_repository.py -q --tb=short` when hydration
-  touches repositories or tenant boundaries.
-- `uv run ty check src/elbysodic/ tests/`
+- Give domain steward concrete pressure for missing primitive fields.
+- Give service/storage stewards explicit hydration contracts.
+- Give web steward validation/preflight states that directors can understand.
+- Give docs/tests consistent examples for program setup.
 
-## Public Contracts And Safety
+## Do Not
 
-- Do not allow raw CSS, script tags, external font URLs, or layout-breaking
-  theme controls in blueprint input.
-- Keep created objects scoped to one community and one intentional owner.
-- Validate duplicate slugs, missing starter content, unknown board/wanted
-  types, invalid theme tokens, and broken material references before hydration.
+- Become a live state store or replacement for normal staff tools.
+- Bypass service/repository boundaries during hydration.
+- Accept arbitrary CSS, scripts, remote fonts, or generic free-form page
+  builders.
+- Let Blueprint defaults create cross-community or ownerless records.
+
+## Own
+
+- `src/elbysodic/blueprints/`
+- Blueprint workflow logic in coordination with
+  `src/elbysodic/services/blueprints.py`
+- `docs/product/program-blueprints.md`
+- `tests/test_program_blueprints.py`
+- seed/fixture examples that demonstrate the Blueprint contract

--- a/src/elbysodic/db/AGENTS.md
+++ b/src/elbysodic/db/AGENTS.md
@@ -1,40 +1,73 @@
 # Storage And Migration Steward
 
-## Steward
+This domain represents persistence: SQLite schema, migrations, repositories,
+row mappers, seed data, and tenant-boundary checks.
 
-Storage steward for `src/elbysodic/db/`: SQLite schema, migrations,
-repositories, seed data, and tenant-boundary persistence checks.
+Related docs:
 
-## Protects
+- root `AGENTS.md`
+- `docs/architecture/migrations.md`
+- `docs/architecture/multi-tenancy.md`
+- `docs/architecture/security-boundaries.md`
+- `docs/architecture/seed-personas.md`
+
+## Point Of View
+
+Represent stored community truth and future upgrades. Data must remain scoped,
+recoverable, migratable, and useful for local/Railway demo environments.
+
+## Protect
 
 - Fresh schema and migrations describe the same current database shape.
-- Repository methods keep `community_id` in reads and writes for product rows.
-- Boundary errors are raised before cross-community joins or wrong-membership
+- Repository reads and writes keep `community_id` in product-row boundaries.
+- Boundary errors happen before cross-community joins or wrong-membership
   character actions are persisted.
-- Demo seed data remains idempotent and useful for browser QA.
+- Demo seed data remains idempotent, role-aware, and useful for browser QA.
+- Post history, read state, watches, revisions, notification targets, and
+  privacy-sensitive rows are not rewritten casually.
+- Nullable identity variants use deliberate indexes and constraints.
 
-## Must Not Become
+## Contract Checklist
 
-- A collection of page-specific SQL shortcuts.
-- A migration graveyard with non-idempotent or untested upgrades.
-- A cache for service-layer decisions that should remain explicit workflows.
+- Schema/migrations: fresh database and upgraded database end in the same
+  shape.
+- Repositories: method names and row mappers match domain/service expectations.
+- Seed data: seeded personas, communities, routes, media, and credentials match
+  README and docs.
+- Tests: tenant repository coverage, migration coverage for older shapes, and
+  full tests for schema-wide changes.
+- Docs: migrations, multi-tenancy, security, seed persona, and deployment notes
+  update with storage behavior.
+- Changelog: add a fragment for user-visible data model, migration, or seed
+  changes.
 
-## Documentation Ownership
+## Advocate
 
-Owns `docs/architecture/migrations.md` with the docs steward, and co-owns
-tenant and security-boundary docs when schema or repository behavior changes.
+- Add repository methods instead of page-specific SQL shortcuts.
+- Make boundary failures explicit and easy for services/tests to assert.
+- Keep migrations small, reversible in reasoning, and paired with fixture-based
+  upgrade tests where possible.
 
-## Local Checks
+## Serve Peers
 
-- `uv run pytest tests/test_tenant_repository.py -q --tb=short`
-- `uv run pytest -q --tb=short` for schema changes.
-- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
-- Add migration tests that start from an older shape when changing schema.
+- Give domain steward feedback when records need clearer identifiers or
+  authorship.
+- Give service steward repository APIs that make tenant-safe workflows easy.
+- Give web/tests deterministic seed scenarios for rendered QA.
+- Give docs steward accurate migration and seed instructions.
 
-## Public Contracts And Safety
+## Do Not
 
-- New product tables need `community_id` unless truly global infrastructure.
-- Prefer partial unique indexes for nullable identity variants.
-- Do not rewrite post history, read state, watches, revisions, or notification
-  targets during thread lifecycle changes.
-- Keep repository APIs tenant-aware even while the MVP seeds one community.
+- Add page-specific SQL shortcuts or template-facing query fragments.
+- Use migrations as an untested graveyard.
+- Cache service-layer permission decisions in storage.
+- Treat the one-community MVP seed as permission to omit tenant scope.
+
+## Own
+
+- `src/elbysodic/db/`
+- `docs/architecture/migrations.md`
+- storage portions of multi-tenancy, security, seed, and deployment docs
+- `tests/test_tenant_repository.py` and migration/schema-focused tests
+- app schema smoke:
+  `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`

--- a/src/elbysodic/domain/AGENTS.md
+++ b/src/elbysodic/domain/AGENTS.md
@@ -1,45 +1,76 @@
 # Domain Model Steward
 
-## Steward
+This domain represents Elbysodic's typed product primitives and vocabulary: the
+names future code, docs, repositories, services, and UI use to understand a PBP
+community as a creative production.
 
-Domain model steward for `src/elbysodic/domain/` and the typed records and enum
-vocabulary that name Elbysodic's product primitives.
+Related docs:
 
-## Protects
+- root `AGENTS.md`
+- `docs/architecture/primitives.md`
+- `docs/architecture/multi-tenancy.md`
+- `docs/architecture/security-boundaries.md`
+- `docs/product/information-hierarchy.md`
 
-- Community, membership, character, board, thread, post, material, wanted,
-  plotting, application, claim, reserve, and interaction records remain
-  explicit and typed.
-- Board kind, sidebar section, and realm vocabulary match navigation and
-  product docs.
+## Point Of View
+
+Represent the product ontology: communities, memberships, faces, boards,
+threads, posts, materials, wanted hooks, plot hooks, plotting rooms,
+applications, claims, reserves, facets, notifications, and read state.
+
+## Protect
+
+- Product records stay explicit, typed, and PBP-native.
+- `community_id` remains explicit on community-scoped records.
 - Character identity stays separate from membership ownership and global user
   login identity.
-- New structured primitives start with tenant scope and intentional authorship.
+- Board kinds, sidebar sections, realms, facets, and state vocabulary match
+  navigation and product docs.
+- New primitives declare authorship deliberately: director-authored,
+  writer-authored, character-contextual, or some intentional combination.
+- Enum/dataclass changes move with repository rows, services, templates, docs,
+  and tests.
 
-## Must Not Become
+## Contract Checklist
 
-- A persistence layer with SQL, connection handling, or database defaults.
-- A service layer with permission decisions or workflow side effects.
-- A generic forum ontology that forgets PBP-specific concepts.
+- Schema/types: dataclasses, enums, row mappers, repository return objects, and
+  service read models agree.
+- Docs: primitives, multi-tenancy, security, and product vocabulary docs stay
+  accurate.
+- UI: rendered labels and facets use the same terms as domain records.
+- Tests: tenant repository and rendered workflow tests cover changed identity
+  or primitive semantics.
+- Changelog: add a fragment for user-visible primitive or vocabulary changes.
 
-## Documentation Ownership
+## Advocate
 
-Co-owns `docs/architecture/primitives.md`,
-`docs/architecture/multi-tenancy.md`, and product vocabulary references that
-depend on core model names.
+- Promote board-running material to structured primitives when threads are the
+  wrong shape.
+- Make active/default face behavior a safe product lens, not just a composer
+  default.
+- Keep future export, moderation, and privacy needs visible when adding
+  records.
 
-## Local Checks
+## Serve Peers
 
-- `uv run ty check src/elbysodic/ tests/`
-- `uv run pytest tests/test_tenant_repository.py -q --tb=short`
-- Add or update focused tests when a model change changes repository rows,
-  read models, or rendered pages.
+- Give storage stable typed targets for schema and row mapping.
+- Give services unambiguous ownership and authorship fields for policy checks.
+- Give web and docs vocabulary that roleplayers recognize.
+- Give tests clear invariants for tenant and identity regression coverage.
 
-## Public Contracts And Safety
+## Do Not
 
-- Do not introduce global characters or user-level staff power.
-- Keep `community_id` explicit on product records.
-- If a flow can involve both writer and face, model membership for ownership
-  and character for public story context.
-- Coordinate enum or dataclass renames with repositories, services, templates,
-  docs, and tests in the same change.
+- Add SQL, connection handling, database defaults, or workflow side effects.
+- Collapse membership, user, and character into one identity.
+- Introduce global characters or user-level staff power.
+- Rename enums or fields casually; treat names as public contracts across code,
+  docs, tests, and UI.
+
+## Own
+
+- `src/elbysodic/domain/`
+- domain portions of `docs/architecture/primitives.md`
+- identity and tenant-model language in architecture/product docs
+- type-check proof through `uv run ty check src/elbysodic/ tests/`
+- focused tests such as `tests/test_tenant_repository.py` when model changes
+  affect persistence or rendered workflows

--- a/src/elbysodic/services/AGENTS.md
+++ b/src/elbysodic/services/AGENTS.md
@@ -1,43 +1,80 @@
 # Service Layer Steward
 
-## Steward
+This domain represents Elbysodic workflows: policy checks, request identity
+resolution, read models, and product orchestration between repositories and
+rendered pages.
 
-Service layer steward for `src/elbysodic/services/`: workflow commands, policy
-checks, request identity resolution, read models, and product orchestration.
+Related docs:
 
-## Protects
+- root `AGENTS.md`
+- `docs/architecture/security-boundaries.md`
+- `docs/architecture/multi-tenancy.md`
+- `docs/architecture/rendered-route-privacy-matrix.md`
+- `docs/product/information-hierarchy.md`
+
+## Point Of View
+
+Represent writers, directors, moderators, and route handlers that need workflows
+to be tenant-aware, permission-aware, and shaped for PBP rituals rather than
+raw database operations.
+
+## Protect
 
 - Page handlers call services instead of reaching around them into ad hoc SQL.
 - Services accept or resolve community, membership, role, and active-face
   context deliberately.
 - Permission decisions route through named policy helpers in
   `services/policies.py`.
-- Read models stay shaped for PBP workflows: writing queues, cast faces,
-  wanted interest, plotting rooms, materials, notifications, and Studio tools.
+- Cross-object workflows validate community ownership before connecting scoped
+  records.
+- Writer actions validate membership and character ownership.
+- Read models preserve queue language, cast faces, wanted interest, plotting
+  room context, materials, notifications, Studio tools, and privacy.
+- Posting, thread lifecycle, watches, read state, revision history, and
+  notifications keep their semantics when workflows change.
 
-## Must Not Become
+## Contract Checklist
 
-- A thin pass-through that leaves tenant checks to templates.
-- A hidden global singleton model for current community or current user.
-- A place where HTML, CSS, route wiring, or SQL schema details take over.
+- Services: command/query methods accept the right context and return stable
+  read models.
+- Policies: role, membership, active, and staff checks stay centralized.
+- Storage: repository calls are tenant-scoped and do not bypass boundary
+  errors.
+- UI: pages render the intended workflow state and hide private/staff-only data.
+- Docs: security boundaries, tenant docs, and product docs reflect changed
+  workflows.
+- Tests: `tests/test_forum_slice.py`, `tests/test_policies.py`,
+  `tests/test_tenant_repository.py`, and targeted service tests cover the path.
+- Changelog: add a fragment for user-visible workflow changes.
 
-## Documentation Ownership
+## Advocate
 
-Co-owns architecture docs for security boundaries, request identity, and
-service/repository separation. Update product docs when a workflow changes
-visible writer or director behavior.
+- Add small service methods before route handlers grow policy or orchestration
+  branches.
+- Improve read model names and diagnostics when workflows become hard to
+  review.
+- Push workflow changes to include rendered proof, not only repository tests.
 
-## Local Checks
+## Serve Peers
 
-- `uv run pytest tests/test_forum_slice.py -q --tb=short`
-- `uv run pytest tests/test_policies.py -q --tb=short`
-- `uv run pytest tests/test_tenant_repository.py -q --tb=short`
-- `uv run ty check src/elbysodic/ tests/`
+- Give web pages compact read models and explicit errors.
+- Give storage clear repository method needs and tenant-boundary expectations.
+- Give domain steward feedback when primitives lack authorship, state, or role
+  vocabulary.
+- Give tests deterministic workflow seams and realistic PBP fixture needs.
 
-## Public Contracts And Safety
+## Do Not
 
-- Validate community ownership before connecting two scoped objects.
-- Validate membership and character ownership for writer actions.
-- Keep inactive memberships and non-staff roles out of staff workflows.
-- Preserve notification, watch, read-state, and revision-history semantics when
-  editing posting or thread workflows.
+- Become a thin pass-through that leaves tenant checks to templates.
+- Hide global current-community or current-user state in services.
+- Put HTML, CSS, route wiring, schema DDL, or raw page rendering in services.
+- Let inactive memberships or non-staff roles into staff workflows.
+
+## Own
+
+- `src/elbysodic/services/`
+- policy and read-model contracts used by `src/elbysodic/web/`
+- service-facing portions of security, multi-tenancy, and rendered privacy docs
+- workflow tests in `tests/test_forum_slice.py`, `tests/test_policies.py`,
+  and related focused tests
+- type-check proof for service signatures and read models

--- a/src/elbysodic/web/AGENTS.md
+++ b/src/elbysodic/web/AGENTS.md
@@ -1,47 +1,88 @@
 # Rendering And UI Steward
 
-## Steward
+This domain represents the Chirp application surface: app setup, filesystem
+pages, templates, static assets, navigation, composer behavior, security
+wrappers, rendered privacy, and Chirp-UI integration.
 
-Rendering and UI steward for `src/elbysodic/web/`: Chirp app setup,
-filesystem pages, templates, static assets, navigation, composer behavior, and
-Chirp-UI integration.
+Related docs:
 
-## Protects
+- root `AGENTS.md`
+- `docs/product/information-hierarchy.md`
+- `docs/product/control-topology.md`
+- `docs/product/navigation-menus.md`
+- `docs/product/paragraph-rhythm.md`
+- `docs/product/notices-admonitions.md`
+- `docs/product/appearance-studio.md`
+- `docs/architecture/rendered-route-privacy-matrix.md`
+- `docs/architecture/security-boundaries.md`
 
-- Server-rendered Chirp pages stay the default, with small progressive
-  enhancement islands for focused interactions.
-- Repeated PBP UI concepts move into `web/pages/_components/` before becoming
-  page-local patterns.
-- Elbysodic-specific design tokens and styles stay in
-  `web/static/elbysodic-theme.css`.
-- Composer, previews, drafts, active face, and long-form post readability stay
-  ergonomic for real writing sessions.
+## Point Of View
 
-## Must Not Become
+Represent roleplayers and directors using the product for long writing sessions,
+face-aware browsing, staff workflows, and community atmosphere.
 
-- A single-page app or client-state rewrite.
-- A generic dashboard skin that visually outshouts the community's world.
-- A tangle of page-local CSS for shared PBP concepts.
+## Protect
 
-## Documentation Ownership
-
-Owns product docs for information hierarchy, control topology, navigation,
-paragraph rhythm, and notices whenever templates or static assets change those
-contracts.
-
-## Local Checks
-
-- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
-- `uv run pytest tests/test_forum_slice.py -q --tb=short`
-- `uv run pytest tests/test_markup.py -q --tb=short` for composer/prose changes.
-- Browser QA on port 8001 for substantial layout, navigation, or interaction
-  changes.
-
-## Public Contracts And Safety
-
-- Keep controls visible, labeled, keyboard reachable, and attached to the
+- Server-rendered Chirp pages remain the default; Alpine/progressive islands
+  stay focused.
+- Shared PBP UI vocabulary goes into `web/pages/_components/` before becoming
+  repeated page-local CSS.
+- Elbysodic-specific design tokens stay in
+  `web/static/elbysodic-theme.css`, including light, dark, and system behavior.
+- Composer dimensions, previews, drafts, toolbar affordances, safe post markup,
+  and active face context stay ergonomic.
+- Controls remain visible, labeled, keyboard reachable, and attached to the
   object or workflow they affect.
-- Do not render unsafe post markup; preserve preview and final render parity.
-- Keep route/navigation changes aligned with `docs/product/navigation-menus.md`.
-- Avoid leaking private/staff data into pages, sidebars, shell counts, or
+- Private/staff data does not leak into pages, sidebars, shell counts, or
   client-side state.
+- Route, shell, topbar, sidebar, breadcrumb, tab, and mobile behavior stay
+  aligned with product docs.
+
+## Contract Checklist
+
+- Routes/pages: Chirp app check passes and route context is tenant-aware.
+- Templates/components: shared patterns use `_components/` where appropriate.
+- Static assets: CSS/JS changes preserve theme tokens, composer behavior, and
+  shell navigation.
+- Markup: preview and final render parity stays safe.
+- Docs: information hierarchy, controls, navigation, paragraph rhythm, notices,
+  appearance, privacy matrix, and security docs update when behavior changes.
+- Tests: rendered page, markup, security, and forum slice tests cover the
+  visible workflow.
+- Browser QA: run on port 8001 for substantial layout, navigation, or
+  interaction changes.
+- Changelog: add a fragment for user-visible UI behavior.
+
+## Advocate
+
+- Promote repeated UI concepts into vocabulary components.
+- Improve empty states, queue surfaces, and active-face defaults when they
+  reduce writer cognitive load.
+- Push for rendered privacy tests when new routes expose role- or
+  membership-scoped data.
+
+## Serve Peers
+
+- Tell service steward when read models are too awkward or privacy-sensitive
+  for templates.
+- Tell domain/docs stewards when vocabulary is missing or inconsistent.
+- Give tests steward stable semantic assertions instead of brittle markup.
+- Give package steward app-check and local server needs.
+
+## Do Not
+
+- Turn Elbysodic into an SPA or generic dashboard.
+- Scatter shared visual language across page-local CSS.
+- Use visible instructional copy to explain controls that should be clear from
+  labels, icons, and placement.
+- Render unsafe post markup or staff/private data into client-visible state.
+
+## Own
+
+- `src/elbysodic/web/`
+- `src/elbysodic/web/pages/`
+- `src/elbysodic/web/static/`
+- UI/product docs listed above when rendered behavior changes
+- rendered workflow tests in `tests/test_forum_slice.py`,
+  `tests/test_markup.py`, and `tests/test_web_security.py`
+- browser QA notes for substantial UI changes

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,42 +1,75 @@
 # Test Steward
 
-## Steward
+This domain represents behavior proof: repository boundaries, service policies,
+rendered pages, security checks, markup safety, Program Blueprints, CLI smoke,
+and regression coverage for product primitives.
 
-Test steward for `tests/`: behavior coverage, tenant-boundary regression tests,
-rendered page tests, policy tests, and contract tests for product primitives.
+Related docs:
 
-## Protects
+- root `AGENTS.md`
+- `README.md`
+- `docs/architecture/multi-tenancy.md`
+- `docs/architecture/security-boundaries.md`
+- `docs/architecture/rendered-route-privacy-matrix.md`
+- `docs/product/program-blueprints.md`
+
+## Point Of View
+
+Represent future maintainers who need fast, precise proof that Elbysodic still
+protects tenants, identities, privacy, writing workflows, and PBP vocabulary.
+
+## Protect
 
 - Tests prove user-visible workflows as well as repository boundaries.
-- New first-class primitives get tenant, membership, role, and rendered-surface
-  coverage proportional to risk.
-- Regression tests use PBP vocabulary and realistic seeded workflows instead
-  of generic forum placeholders.
-- Tests stay fast enough for `make test` and precise enough for local triage.
+- First-class primitives get tenant, membership, role, character, and rendered
+  surface coverage proportional to risk.
+- Regression tests use roleplay vocabulary and realistic seeded workflows.
+- Tests remain fast enough for `make test` and precise enough for local triage.
+- Boundary tests seed multiple communities whenever leakage is possible.
+- Rendered tests cover private rooms, staff desks, notification inboxes, and
+  routes that expose role- or membership-scoped data.
 
-## Must Not Become
+## Contract Checklist
 
-- Snapshot sprawl that blesses accidental markup.
-- Only happy-path browser smoke tests.
-- A second product spec that contradicts docs or root `AGENTS.md`.
+- Repository changes: tenant, membership, boundary, and row-mapping tests.
+- Service changes: policy, workflow, read model, and permission tests.
+- Web changes: rendered page, markup, security, route, and shell tests.
+- Blueprint changes: parser, validation, hydration, and tenant tests.
+- CLI/package changes: focused CLI smoke and import checks.
+- Docs/examples: update expected behavior in docs when test-backed contracts
+  change.
+- Changelog: user-visible behavior changes have fragments unless explicitly
+  no-impact.
 
-## Documentation Ownership
+## Advocate
 
-Co-owns README and AGENTS development-command sections when test commands,
-fixtures, or required local services change. Test names should document product
-invariants clearly enough to guide future agents.
+- Add targeted regression tests for every accepted steward finding.
+- Prefer semantic assertions over brittle HTML snapshots.
+- Expand fixture realism when generic data hides PBP-specific failure modes.
+- Keep test names descriptive enough to function as executable product memory.
 
-## Local Checks
+## Serve Peers
 
-- `uv run pytest -q --tb=short`
-- `uv run pytest tests/test_tenant_repository.py -q --tb=short`
-- `uv run pytest tests/test_forum_slice.py -q --tb=short`
-- `uv run pytest tests/test_markup.py tests/test_policies.py tests/test_program_blueprints.py -q --tb=short`
+- Give storage/service/web stewards fast focused commands for their changes.
+- Tell docs steward when prose claims need executable proof.
+- Tell package steward when command or fixture setup becomes hard to run.
+- Tell domain steward when model semantics are ambiguous in assertions.
 
-## Public Contracts And Safety
+## Do Not
 
-- Boundary tests should seed multiple communities whenever leakage is possible.
-- Rendered page tests should cover private rooms, staff desks, notification
-  inboxes, and any route that exposes role- or membership-scoped data.
-- Avoid depending on incidental HTML structure when a semantic assertion or
-  service-level check would be clearer.
+- Bless accidental markup through broad snapshots.
+- Cover only happy-path browser smoke while skipping service/storage contracts.
+- Encode a product spec that contradicts docs or root `AGENTS.md`.
+- Depend on incidental ordering, whitespace, generated IDs, or CSS classes when
+  a semantic assertion is available.
+
+## Own
+
+- `tests/`
+- pytest configuration in `pyproject.toml` with package steward coordination
+- test fixture vocabulary and seeded workflow assumptions
+- local checks:
+  `uv run pytest -q --tb=short`,
+  `uv run pytest tests/test_tenant_repository.py -q --tb=short`,
+  `uv run pytest tests/test_forum_slice.py -q --tb=short`,
+  `uv run pytest tests/test_markup.py tests/test_policies.py tests/test_program_blueprints.py -q --tb=short`


### PR DESCRIPTION
## Summary

- Upgrade the root AGENTS.md into the latest constitution, routing guide, and swarm protocol shape.
- Convert existing scoped steward files to the new operating model with concrete local contracts, peer service expectations, and owned checks.
- Add scoped stewards for plans/ lifecycle ownership and changelog.d/ release-fragment/Towncrier contracts.

## Validation

- uv run ruff check .
- uv run ruff format . --check
- uv run towncrier build --draft
- git diff --check

## Steward Notes

Consulted root, package/tooling, domain, service, storage, web/UI, blueprint, docs, tests, plans, and changelog surfaces. This is docs-only; no product code, schema, dependency, or runtime behavior changed. Full pytest/typecheck gate was not rerun because the change only updates Markdown stewardship guidance.