### PR TITLE
[codex] Adopt Chirp UI 0.7.0 network hub patterns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "bengal-chirp[config,forms,sessions,ui]>=0.6.0",
-    "chirp-ui>=0.6.0",
+    "chirp-ui>=0.7.0",
     "pyyaml>=6.0",
 ]
 

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -1373,6 +1373,17 @@ class StudioNetworkProgramView:
         return _program_href(self, "/")
 
     @property
+    def monogram(self) -> str:
+        parts = [
+            part for part in self.community.name.replace("-", " ").replace("_", " ").split() if part
+        ]
+        if not parts:
+            return "EB"
+        if len(parts) == 1:
+            return parts[0][:2].upper()
+        return "".join(part[:1] for part in parts[:3]).upper()
+
+    @property
     def application_href(self) -> str:
         return _program_href(self, "/applications/new")
 

--- a/src/elbysodic/web/app.py
+++ b/src/elbysodic/web/app.py
@@ -65,6 +65,20 @@ def create_app(
         web_security_config=security,
     )
     use_chirp_ui(app)
+    app.register_oob_region(
+        "program_theme_oob",
+        target_id="elbysodic-program-theme",
+        swap="innerHTML",
+        wrap=True,
+        optional=True,
+    )
+    app.register_oob_region(
+        "product_shell_oob",
+        target_id="elbysodic-product-shell",
+        swap="innerHTML",
+        wrap=True,
+        optional=True,
+    )
     app.template_global()(location_nav_tree_items)
     app.template_global()(dev_tools_enabled)
     app.template_global()(sidebar_is_hidden)

--- a/src/elbysodic/web/pages/_components/boards.html
+++ b/src/elbysodic/web/pages/_components/boards.html
@@ -50,7 +50,10 @@ elbysodic-board-media--{{ board.slug }} elbysodic-board-media-treatment--{{ boar
   {{ latest_line("Latest", summary.latest_href, summary.latest_thread.title) }}
   {% end %}
 {% else %}
-<p class="elbysodic-empty-state">No scenes have opened here yet.</p>
+<div class="elbysodic-empty-cta">
+  <p>No scenes have opened here yet.</p>
+  <a class="chirpui-btn chirpui-btn--secondary" href="{{ summary.href }}/threads/new">Start scene</a>
+</div>
 {% end %}
 {% end %}
 

--- a/src/elbysodic/web/pages/_components/facets.html
+++ b/src/elbysodic/web/pages/_components/facets.html
@@ -1,13 +1,17 @@
+{% imports %}
+  {% from "chirpui/facet_chip.html" import facet_chip %}
+{% end %}
+
 {% def facet_pills(tags) %}
 {% if tags %}
 <div class="elbysodic-facet-pills">
   {% for tag in tags %}
-  <span class="elbysodic-facet-pill"
-        title="{{ tag.group_label }}"
-        {% if tag.facet.accent_color %}style="--elbysodic-facet-accent: {{ tag.facet.accent_color }}"{% end %}>
-    {{ tag.label }}
-  </span>
+  {{ facet_chip(tag.label, color=tag.facet.accent_color, cls="elbysodic-facet-pill") }}
   {% end %}
 </div>
 {% end %}
+{% end %}
+
+{% def facet_filter_link(label, href, selected=false, color=none) %}
+{{ facet_chip(label, href=href, selected=selected, color=color, cls="elbysodic-facet-filter") }}
 {% end %}

--- a/src/elbysodic/web/pages/_components/sidebar.html
+++ b/src/elbysodic/web/pages/_components/sidebar.html
@@ -1,4 +1,5 @@
 {% from "chirpui/sidebar.html" import sidebar_section %}
+{% from "chirpui/scope_switcher.html" import scope_switcher %}
 
 {% def sidebar_count(count) %}
   {% if count %}
@@ -74,7 +75,7 @@
 {% def sidebar_active_face(viewer) %}
 {% if viewer and viewer.current_character %}
 {% call sidebar_section("Active Face") %}
-  {{ sidebar_plain_link("/characters/" ~ viewer.current_character.slug, viewer.current_character.name) }}
+  {{ scope_switcher("Playing as " ~ viewer.current_character.name, [{"label": "Profile", "href": "/characters/" ~ viewer.current_character.slug, "icon": "⊙"}, {"label": "Face queue", "href": "/my/threads?character=" ~ viewer.current_character.slug, "icon": "✎"}, {"label": "Roster", "href": "/characters", "icon": "≡"}], id="elbysodic-active-face-scope", aria_label="Active face shortcuts", icon="user", cls="elbysodic-active-face-scope") }}
 {% end %}
 {% end %}
 {% end %}

--- a/src/elbysodic/web/pages/_components/ui.html
+++ b/src/elbysodic/web/pages/_components/ui.html
@@ -15,13 +15,13 @@
 {% end %}
 
 {% def inline_nav(label, cls="") %}
-<nav class="elbysodic-filter-bar{{ " " ~ cls if cls else "" }}" aria-label="{{ label }}">
+<nav class="chirpui-saved-view-strip elbysodic-filter-bar{{ " " ~ cls if cls else "" }}" aria-label="{{ label }}">
   {% slot %}
 </nav>
 {% end %}
 
 {% def inline_nav_link(label, href, active=false, hx_target=none, hx_select=none, hx_swap="innerHTML show:none", hx_push_url=false) %}
-<a class="elbysodic-filter-link{{ " elbysodic-filter-link--active" if active else "" }}"
+<a class="chirpui-chip{{ " chirpui-chip--selected" if active else "" }} elbysodic-filter-link{{ " elbysodic-filter-link--active" if active else "" }}"
    href="{{ href }}"
    {% if active %}aria-current="page"{% end %}
    {% if hx_target %}

--- a/src/elbysodic/web/pages/_components/vocabulary.html
+++ b/src/elbysodic/web/pages/_components/vocabulary.html
@@ -26,11 +26,18 @@
 </a>
 {% end %}
 
-{% def metric_item(value, label, cls="") %}
+{% def metric_item(value, label, cls="", href="") %}
+{% if href %}
+<a class="elbysodic-metric{{ " " ~ cls if cls else "" }}" href="{{ href }}" aria-label="{{ value }} {{ label }}">
+  <strong>{{ value }}</strong>
+  <span>{{ label }}</span>
+</a>
+{% else %}
 <span class="elbysodic-metric{{ " " ~ cls if cls else "" }}">
   <strong>{{ value }}</strong>
   <span>{{ label }}</span>
 </span>
+{% end %}
 {% end %}
 
 {% def command_action(action, cls="") %}

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -11,6 +11,53 @@
 
 {% block title %}{{ page_title if page_title is defined else (viewer.community.name if shell_has_community and viewer else "Elbysodic") }}{% end %}
 
+{% def program_theme_css(has_community, current_viewer) %}
+{% if has_community and current_viewer and current_viewer.program_theme %}
+      :root {
+        {% for variable, value in current_viewer.program_theme.base_variables %}
+        {{ variable }}: {{ value }};
+        {% end %}
+        {% for variable, value in current_viewer.program_theme.dark_variables %}
+        {{ variable }}: {{ value }};
+        {% end %}
+      }
+
+      [data-theme="light"] {
+        {% for variable, value in current_viewer.program_theme.light_variables %}
+        {{ variable }}: {{ value }};
+        {% end %}
+      }
+
+      @media (prefers-color-scheme: light) {
+        [data-theme="system"] {
+          {% for variable, value in current_viewer.program_theme.light_variables %}
+          {{ variable }}: {{ value }};
+          {% end %}
+        }
+      }
+
+      @media (prefers-color-scheme: dark) {
+        [data-theme="system"] {
+          {% for variable, value in current_viewer.program_theme.dark_variables %}
+          {{ variable }}: {{ value }};
+          {% end %}
+        }
+      }
+{% end %}
+{% end %}
+
+{% def product_shell_css(has_community) %}
+{% if not has_community %}
+      .chirpui-app-shell {
+        --chirpui-sidebar-width: 0rem;
+      }
+
+      .chirpui-app-shell__sidebar {
+        display: none;
+      }
+{% end %}
+{% end %}
+
 {% block head_extra %}
     <script>
     (function () {
@@ -36,51 +83,12 @@
     })();
     </script>
     <link rel="stylesheet" href="/elbysodic-static/elbysodic-theme.css?v=sidebar-cookie-1">
-    {% if viewer and viewer.program_theme %}
     <style id="elbysodic-program-theme">
-      :root {
-        {% for variable, value in viewer.program_theme.base_variables %}
-        {{ variable }}: {{ value }};
-        {% end %}
-        {% for variable, value in viewer.program_theme.dark_variables %}
-        {{ variable }}: {{ value }};
-        {% end %}
-      }
-
-      [data-theme="light"] {
-        {% for variable, value in viewer.program_theme.light_variables %}
-        {{ variable }}: {{ value }};
-        {% end %}
-      }
-
-      @media (prefers-color-scheme: light) {
-        [data-theme="system"] {
-          {% for variable, value in viewer.program_theme.light_variables %}
-          {{ variable }}: {{ value }};
-          {% end %}
-        }
-      }
-
-      @media (prefers-color-scheme: dark) {
-        [data-theme="system"] {
-          {% for variable, value in viewer.program_theme.dark_variables %}
-          {{ variable }}: {{ value }};
-          {% end %}
-        }
-      }
+{{ program_theme_css(shell_has_community, viewer) }}
     </style>
-    {% end %}
-    {% if not shell_has_community %}
     <style id="elbysodic-product-shell">
-      .chirpui-app-shell {
-        --chirpui-sidebar-width: 0rem;
-      }
-
-      .chirpui-app-shell__sidebar {
-        display: none;
-      }
+{{ product_shell_css(shell_has_community) }}
     </style>
-    {% end %}
     {% if shell_sidebar_hidden %}
     <style id="elbysodic-sidebar-cookie-state">
       @media (min-width: 48.001rem) {
@@ -115,10 +123,18 @@
 <title id="chirpui-document-title">{{ page_title if page_title is defined else (viewer.community.name if shell_has_community and viewer else "Elbysodic") }}</title>
 {% end %}
 
+{% block program_theme_oob %}
+{{ program_theme_css(show_community_shell | default(true), viewer) }}
+{% end %}
+
+{% block product_shell_oob %}
+{{ product_shell_css(show_community_shell | default(true)) }}
+{% end %}
+
 {% block brand_link %}
 <a href="/"
    class="chirpui-app-shell__brand elbysodic-community-brand"
-   {{ shell_outlet_attrs() }}>
+   hx-boost="false">
   {% if shell_has_community and viewer and viewer.community.community_mark_url %}
   <img class="elbysodic-community-brand__mark"
        src="{{ viewer.community.community_mark_url }}"
@@ -184,7 +200,7 @@
 <div class="elbysodic-shell-identity">
   <details class="elbysodic-identity-menu">
     <summary class="elbysodic-identity-menu__summary"
-             aria-label="Identity menu: {{ viewer.membership.username }}{% if viewer.current_character %} wearing {{ viewer.current_character.name }}{% end %}">
+             aria-label="Identity menu: {{ viewer.membership.username }}{% if viewer.current_character %} playing as {{ viewer.current_character.name }}{% end %}">
       <span class="elbysodic-identity-menu__avatar-stack" aria-hidden="true">
         <span class="elbysodic-identity-menu__writer-avatar">{{ (viewer.membership.display_name or viewer.membership.username)[:1] }}</span>
         {% if viewer.current_character %}
@@ -203,7 +219,7 @@
       <span class="elbysodic-identity-menu__copy">
         <span class="elbysodic-identity-menu__label">{{ viewer.membership.username }}</span>
         {% if viewer.current_character %}
-        <span class="elbysodic-identity-menu__face">wearing {{ viewer.current_character.name }}</span>
+        <span class="elbysodic-identity-menu__face">playing as {{ viewer.current_character.name }}</span>
         {% else %}
         <span class="elbysodic-identity-menu__face">no face selected</span>
         {% end %}
@@ -230,7 +246,7 @@
                     {{ "disabled" if option.is_current else "" }}>
               <span>
                 <strong>{{ option.community.name }}</strong>
-                <small>{{ option.membership.display_name or option.membership.username }} · {{ option.role.name }}{% if option.current_character %} · wearing {{ option.current_character.name }}{% endif %}</small>
+                <small>{{ option.membership.display_name or option.membership.username }} · {{ option.role.name }}{% if option.current_character %} · playing as {{ option.current_character.name }}{% endif %}</small>
               </span>
               {% if option.unread_notification_count %}
               <b>{{ option.unread_notification_count }}</b>
@@ -287,7 +303,7 @@
       <form action="/identity" method="post" hx-boost="false" class="elbysodic-identity-menu__face-form">
         <input type="hidden" name="intent" value="set_default_character">
         <input type="hidden" name="next" value="{{ current_path or "/" }}">
-        <label class="elbysodic-identity-menu__kicker" for="active-character">Wearing</label>
+        <label class="elbysodic-identity-menu__kicker" for="active-character">Playing as</label>
         <select id="active-character"
                 name="character_id"
                 class="chirpui-field__input"

--- a/src/elbysodic/web/pages/boards/{board_slug}/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/page.html
@@ -1,4 +1,5 @@
 {% imports %}
+  {% from "chirpui/breadcrumbs.html" import breadcrumbs %}
   {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
   {% from "chirpui/surface.html" import surface %}
   {% from "_components/boards.html" import board_media_classes, board_media_image, board_stat_row, subboard_card %}
@@ -21,19 +22,20 @@
 {% call container(max_width="76rem") %}
 {% call stack(gap="lg") %}
   <div class="elbysodic-place-toolbar">
-    <nav class="elbysodic-place-path" aria-label="Place path">
-      {% if is_community_board %}
-      <a href="/community">Community</a>
-      {% else %}
-      <a href="/">World</a>
-      {% end %}
+    <div class="elbysodic-place-toolbar__breadcrumbs" role="group" aria-label="Place path">
       {% if parent_board %}
-      <span class="elbysodic-place-path__separator" aria-hidden="true">/</span>
-      <a href="/boards/{{ parent_board.slug }}">{{ parent_board.name }}</a>
+      {{ breadcrumbs([
+        {"label": "Community", "href": "/community"} if is_community_board else {"label": "World", "href": "/"},
+        {"label": parent_board.name, "href": "/boards/" ~ parent_board.slug},
+        {"label": board.name},
+      ], cls="elbysodic-place-path", overflow="collapse", max_items=4) }}
+      {% else %}
+      {{ breadcrumbs([
+        {"label": "Community", "href": "/community"} if is_community_board else {"label": "World", "href": "/"},
+        {"label": board.name},
+      ], cls="elbysodic-place-path", overflow="collapse", max_items=4) }}
       {% end %}
-      <span class="elbysodic-place-path__separator" aria-hidden="true">/</span>
-      <span aria-current="page">{{ board.name }}</span>
-    </nav>
+    </div>
     <div class="chirpui-cluster chirpui-cluster--sm">
       {% if next_unread_thread %}
       {{ next_unread_link(next_unread_thread) }}

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
@@ -1,7 +1,9 @@
 {% imports %}
   {% from "chirpui/badge.html" import badge %}
+  {% from "chirpui/breadcrumbs.html" import breadcrumbs %}
   {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
   {% from "chirpui/surface.html" import surface %}
+  {% from "chirpui/thread_reader_layout.html" import thread_reader_layout %}
   {% from "_components/composer.html" import composer_toolbar, composer_view_toggle %}
   {% from "_components/facets.html" import facet_pills %}
   {% from "_components/posts.html" import post_frame %}
@@ -40,17 +42,22 @@
 {% call container(max_width="72rem") %}
 {% call stack(gap="lg") %}
   <div class="elbysodic-thread-toolbar">
-    <nav class="elbysodic-place-path" aria-label="Scene path">
-      <a href="/">World</a>
+    <div class="elbysodic-place-toolbar__breadcrumbs" role="group" aria-label="Scene path">
       {% if parent_board %}
-      <span class="elbysodic-place-path__separator" aria-hidden="true">/</span>
-      <a href="/boards/{{ parent_board.slug }}">{{ parent_board.name }}</a>
+      {{ breadcrumbs([
+        {"label": "World", "href": "/"},
+        {"label": parent_board.name, "href": "/boards/" ~ parent_board.slug},
+        {"label": thread_view.board.name, "href": "/boards/" ~ thread_view.board.slug},
+        {"label": thread_view.thread.title},
+      ], cls="elbysodic-place-path", overflow="collapse", max_items=4) }}
+      {% else %}
+      {{ breadcrumbs([
+        {"label": "World", "href": "/"},
+        {"label": thread_view.board.name, "href": "/boards/" ~ thread_view.board.slug},
+        {"label": thread_view.thread.title},
+      ], cls="elbysodic-place-path", overflow="collapse", max_items=4) }}
       {% end %}
-      <span class="elbysodic-place-path__separator" aria-hidden="true">/</span>
-      <a href="/boards/{{ thread_view.board.slug }}">{{ thread_view.board.name }}</a>
-      <span class="elbysodic-place-path__separator" aria-hidden="true">/</span>
-      <span aria-current="page">{{ thread_view.thread.title }}</span>
-    </nav>
+    </div>
   </div>
 
   <section class="elbysodic-thread-stage elbysodic-board-media--{{ thread_view.board.slug }}" aria-labelledby="scene-title">
@@ -143,11 +150,13 @@
         <form method="post" hx-boost="false">
           <input type="hidden" name="intent" value="join_scene">
           <button type="submit" class="chirpui-btn chirpui-btn--primary">
+            <span class="chirpui-btn__icon" aria-hidden="true">{{ "add" | icon }}</span>
             Join as {{ viewer.current_character.name }}
           </button>
         </form>
         {% elif thread_view.can_reply and selected_character %}
         <a class="chirpui-btn chirpui-btn--primary" href="#reply-composer">
+          <span class="chirpui-btn__icon" aria-hidden="true">{{ "reply" | icon }}</span>
           Reply as {{ selected_character.name }}
         </a>
         {% end %}
@@ -158,13 +167,14 @@
                     class="chirpui-btn chirpui-btn--secondary elbysodic-thread-watch-toggle"
                     title="{{ "Unwatch thread" if thread_view.is_watched else "Watch thread" }}"
                     aria-label="{{ "Unwatch thread" if thread_view.is_watched else "Watch thread" }}">
-              <span aria-hidden="true">{{ "◉" if thread_view.is_watched else "○" }}</span>
+              <span aria-hidden="true">{{ "watch" | icon }}</span>
               <span class="chirpui-visually-hidden">{{ "Unwatch thread" if thread_view.is_watched else "Watch thread" }}</span>
             </button>
           </form>
           {% if thread_view.latest_post %}
           <a class="chirpui-btn chirpui-btn--secondary"
              href="#{{ thread_view.latest_post.anchor }}">
+            <span class="chirpui-btn__icon" aria-hidden="true">{{ "arrow-down" | icon }}</span>
             Read latest
           </a>
           {% end %}
@@ -332,6 +342,8 @@
   {% end %}
   {% end %}
 
+  {% call thread_reader_layout(label="Scene transcript", cls="elbysodic-thread-reader-layout") %}
+  {% slot header %}
   <section class="elbysodic-scene-transcript" aria-labelledby="scene-transcript-title">
     <div class="elbysodic-scene-transcript__copy">
       <p class="elbysodic-kicker">Transcript</p>
@@ -348,13 +360,29 @@
       {{ thread_nav_link(thread_view.next_thread, "Next") }}
     </nav>
   </section>
+  {% end %}
 
+  {% slot local_nav %}
+    {% if thread_view.posts %}
+    <a class="chirpui-thread-reader-layout__nav-link" href="#{{ thread_view.posts[0].anchor }}">First post</a>
+    {% end %}
+    {% if thread_view.latest_post %}
+    <a class="chirpui-thread-reader-layout__nav-link" href="#{{ thread_view.latest_post.anchor }}">Latest beat</a>
+    {% end %}
+    {% if thread_view.can_reply %}
+    <a class="chirpui-thread-reader-layout__nav-link" href="#reply-composer">Reply composer</a>
+    {% end %}
+  {% end %}
+
+  {% slot posts %}
   <div class="elbysodic-post-list" aria-label="Scene posts">
     {% for item in thread_view.posts %}
     {{ post_frame(item, thread_view.board, thread_view.thread) }}
     {% end %}
   </div>
+  {% end %}
 
+  {% slot attention_nav %}
   {% if thread_view.previous_unreplied_thread or thread_view.next_unread_thread %}
   <nav class="elbysodic-thread-attention-nav" aria-label="Attention thread navigation">
     {% if not thread_view.previous_unreplied_thread and thread_view.next_unread_thread %}
@@ -364,7 +392,9 @@
     {{ thread_attention_link(thread_view.next_unread_thread, "Next unread", "next") }}
   </nav>
   {% end %}
+  {% end %}
 
+  {% slot composer %}
   {% if thread_view.can_reply %}
     {% call surface(variant="elevated") %}
     {% if not selected_character %}
@@ -488,6 +518,8 @@
       <p class="chirpui-field__error">{{ error }}</p>
       {% end %}
     </aside>
+  {% end %}
+  {% end %}
   {% end %}
 {% end %}
 {% end %}

--- a/src/elbysodic/web/pages/casting/page.html
+++ b/src/elbysodic/web/pages/casting/page.html
@@ -60,7 +60,7 @@
         </h2>
         <p class="elbysodic-copy-section">
           {% if desk.active_face %}
-          Casting views are weighted toward the face you are currently wearing.
+          Casting views are weighted toward the face you are playing as.
           {% else %}
           Pick a character to make casting filters and claims feel more personal.
           {% end %}

--- a/src/elbysodic/web/pages/desk/page.html
+++ b/src/elbysodic/web/pages/desk/page.html
@@ -28,7 +28,7 @@
     <div class="elbysodic-desk-hero__lens">
       <span>{{ viewer.membership.username }}</span>
       {% if viewer.current_character %}
-      <strong>wearing {{ viewer.current_character.name }}</strong>
+      <strong>playing as {{ viewer.current_character.name }}</strong>
       {% else %}
       <strong>whole roster</strong>
       {% end %}

--- a/src/elbysodic/web/pages/dev/personas/page.html
+++ b/src/elbysodic/web/pages/dev/personas/page.html
@@ -74,7 +74,7 @@
     <p class="elbysodic-copy-section">
       {{ viewer.role.name }}
       {% if viewer.current_character %}
-      · wearing {{ viewer.current_character.name }}
+      · playing as {{ viewer.current_character.name }}
       {% else %}
       · no active face
       {% end %}

--- a/src/elbysodic/web/pages/discover/page.html
+++ b/src/elbysodic/web/pages/discover/page.html
@@ -2,7 +2,7 @@
   {% from "chirpui/badge.html" import badge %}
   {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
   {% from "chirpui/surface.html" import surface %}
-  {% from "_components/facets.html" import facet_pills %}
+  {% from "_components/facets.html" import facet_filter_link, facet_pills %}
   {% from "_components/ui.html" import counter %}
 {% end %}
 
@@ -40,11 +40,7 @@
         <h2>{{ group.group.name }}</h2>
         <div class="elbysodic-facet-filter-row">
           {% for option in group.options %}
-          <a class="elbysodic-facet-filter {{ "elbysodic-facet-filter--selected" if option.is_selected else "" }}"
-             href="{{ option.href }}"
-             {% if option.tag.facet.accent_color %}style="--elbysodic-facet-accent: {{ option.tag.facet.accent_color }}"{% end %}>
-            {{ option.tag.label }}
-          </a>
+          {{ facet_filter_link(option.tag.label, option.href, option.is_selected, option.tag.facet.accent_color) }}
           {% end %}
         </div>
       </section>

--- a/src/elbysodic/web/pages/locations/page.html
+++ b/src/elbysodic/web/pages/locations/page.html
@@ -22,7 +22,7 @@
       </p>
       {% if viewer.current_character %}
       <p class="elbysodic-copy-helper">
-        Wearing {{ viewer.current_character.name }}. Location signals are tuned to that face.
+        Playing as {{ viewer.current_character.name }}. Location signals are tuned to that face.
       </p>
       {% end %}
     </div>

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -2,6 +2,7 @@
   {% from "chirpui/badge.html" import badge %}
   {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "chirpui/surface.html" import surface %}
+  {% from "chirpui/tooltip.html" import tooltip %}
   {% from "_components/vocabulary.html" import metric_item %}
 {% end %}
 
@@ -31,6 +32,23 @@ A studio program ready for scenes, casting, and writer movement.
 {% else %}
 {{ switch_form(program, href, label, variant) }}
 {% end %}
+{% end %}
+
+{% def compact_link_action(href, label, icon) %}
+{% if href %}
+{% call tooltip(label, position="left", cls="elbysodic-network-card__tooltip") %}
+  <a class="elbysodic-network-card__icon-action" href="{{ href }}" aria-label="{{ label }}">
+    <span aria-hidden="true">{{ icon | icon }}</span>
+    <span class="chirpui-visually-hidden">{{ label }}</span>
+  </a>
+{% end %}
+{% end %}
+{% end %}
+
+{% def program_metric_links(program) %}
+{{ metric_item(program.roster_count, "faces", href=program.entry_href ~ "/characters") }}
+{{ metric_item(program.open_wanted_count, "wanted", href=program.entry_href ~ "/wanted") }}
+{{ metric_item(program.plotting_room_count, "rooms", href=program.entry_href ~ "/plotting") }}
 {% end %}
 
 {% def network_billboard(program) %}
@@ -70,7 +88,9 @@ A studio program ready for scenes, casting, and writer movement.
       {% elif program.premise %}
       <a class="chirpui-btn chirpui-btn--secondary" href="{{ program.premise_href }}">Premise</a>
       {% end %}
-      {{ program_action(program, program.application_href, "Start application", "secondary") }}
+      {% if program.open_wanted_count %}
+      <a class="chirpui-btn chirpui-btn--secondary" href="{{ program.entry_href }}/wanted">Wanted hooks</a>
+      {% end %}
     </div>
   </div>
 </section>
@@ -84,8 +104,6 @@ A studio program ready for scenes, casting, and writer movement.
     {{ program.unread_notification_count }} unread
     {% elif program.plotting_room_count %}
     {{ program.plotting_room_count }} plotting
-    {% elif program.application_count %}
-    {{ program.application_count }} applications
     {% else %}
     {{ program.open_wanted_count }} wanted
     {% end %}
@@ -93,7 +111,7 @@ A studio program ready for scenes, casting, and writer movement.
   <h2>{{ program.community.name }}</h2>
   <p>
     {% if program.current_character %}
-    Wearing {{ program.current_character.name }}.
+    Playing as {{ program.current_character.name }}.
     {% else %}
     No active face selected.
     {% end %}
@@ -101,31 +119,32 @@ A studio program ready for scenes, casting, and writer movement.
     Check what needs you.
     {% elif program.plotting_room_count %}
     Return to rooms forming scenes.
-    {% elif program.application_count %}
-    Review application movement.
     {% else %}
     Browse open casting hooks.
     {% end %}
   </p>
   <div class="elbysodic-network-continue-card__actions">
     {{ program_action(program, program.entry_href, "Enter realm", "secondary") }}
-    {{ program_action(program, program.application_href, "Application", "secondary") }}
+    {% if program.open_wanted_count %}
+    <a class="chirpui-btn chirpui-btn--secondary" href="{{ program.entry_href }}/wanted">Wanted</a>
+    {% end %}
   </div>
 </article>
 {% end %}
 
 {% def program_card(program) %}
-<article class="elbysodic-network-card{{ " elbysodic-network-card--current" if program.is_current else "" }}"
+<article class="elbysodic-network-card{{ " elbysodic-network-card--current" if program.is_current else "" }}{{ " elbysodic-network-card--no-hero" if not program.community.world_hero_image_url else "" }}"
          style="--elbysodic-network-accent: {{ program.theme_preview.accent }}; --elbysodic-network-surface: {{ program.theme_preview.surface }}; --elbysodic-network-text: {{ program.theme_preview.text }}; --elbysodic-network-display-font: {{ program.theme_preview.display_font }};">
+  <a class="elbysodic-network-card__realm-link" href="{{ program.entry_href }}" aria-label="Enter {{ program.community.name }}">
+    <span class="chirpui-visually-hidden">Enter {{ program.community.name }}</span>
+  </a>
   <a class="elbysodic-network-card__poster" href="{{ program.entry_href }}">
     {% if program.community.world_hero_image_url %}
     <img src="{{ program.community.world_hero_image_url }}" alt="{{ program.community.world_hero_image_alt }}">
     {% else %}
-    <span aria-hidden="true"></span>
+    <span class="elbysodic-network-card__poster-fallback" aria-hidden="true">{{ program.monogram }}</span>
     {% end %}
-    {% if program.community.community_mark_url %}
-    <em><img src="{{ program.community.community_mark_url }}" alt=""></em>
-    {% end %}
+    <em class="elbysodic-network-card__mark" aria-hidden="true">{{ program.monogram }}</em>
   </a>
   <div class="elbysodic-network-card__main">
     <header class="elbysodic-network-card__header">
@@ -154,32 +173,30 @@ A studio program ready for scenes, casting, and writer movement.
     <p class="elbysodic-copy-meta">
       {{ program.membership.display_name or program.membership.username }}
       {% if program.current_character %}
-      · wearing {{ program.current_character.name }}
+      · playing as {{ program.current_character.name }}
       {% else %}
       · no active face
       {% end %}
     </p>
     <div class="elbysodic-network-card__metrics" aria-label="{{ program.community.name }} signals">
-      {{ metric_item(program.roster_count, "faces") }}
-      {{ metric_item(program.open_wanted_count, "wanted") }}
-      {{ metric_item(program.application_count, "apps") }}
-      {{ metric_item(program.plotting_room_count, "rooms") }}
+      {{ program_metric_links(program) }}
     </div>
   </div>
   <div class="elbysodic-network-card__actions">
     {% if program.current_event %}
-    <a class="chirpui-btn chirpui-btn--secondary" href="{{ program.current_event_href }}">Current event</a>
+    {{ compact_link_action(program.current_event_href, "Current event", "bolt") }}
     {% elif program.premise %}
-    <a class="chirpui-btn chirpui-btn--secondary" href="{{ program.premise_href }}">Premise</a>
+    {{ compact_link_action(program.premise_href, "Premise", "list") }}
     {% end %}
-    {{ program_action(program, program.entry_href, "Enter realm") }}
-    {{ program_action(program, program.application_href, "Start application", "secondary") }}
+    {% if program.open_wanted_count %}
+    {{ compact_link_action(program.entry_href ~ "/wanted", "Wanted hooks", "star") }}
+    {% end %}
   </div>
 </article>
 {% end %}
 
 {% block page_root %}
-<div id="page-root">
+<div id="page-root" hx-boost="false">
 {% block page_root_inner %}
 {% block page_content %}
 {% call container(max_width="84rem") %}
@@ -191,17 +208,18 @@ A studio program ready for scenes, casting, and writer movement.
     <div>
       <p class="elbysodic-section-kicker">Explore Elbysodic</p>
       <h1 id="network-heading">Search worlds, wanted hooks, and writing lanes.</h1>
-      <p>Move by genre, mood, open roles, current events, or the face you want to wear next.</p>
+      <p>Move by genre, mood, open roles, current events, or the face you want to play next.</p>
     </div>
     <form class="elbysodic-network-search" action="/network" method="get" role="search">
       <label for="network-search">Search the studio network</label>
-      <div>
+      <div class="elbysodic-network-search__control">
+        <span class="elbysodic-network-search__scope">Realms</span>
         <input id="network-search"
                name="q"
                type="search"
                value="{{ network_search_query }}"
                placeholder="magic school, survival, wanted, Rogue">
-        <button class="chirpui-btn chirpui-btn--primary" type="submit">Search</button>
+        <button class="elbysodic-network-search__submit" type="submit">Search</button>
       </div>
     </form>
   </section>
@@ -213,7 +231,6 @@ A studio program ready for scenes, casting, and writer movement.
     <a href="/network?q=town">small town</a>
     <a href="/network?q=wanted">wanted hooks</a>
     <a href="/network?q=event">current events</a>
-    <a href="/network?q=application">applications</a>
     <a href="/network?q=plotting">plotting rooms</a>
   </section>
 
@@ -283,7 +300,7 @@ A studio program ready for scenes, casting, and writer movement.
           <strong>{{ program.community.name }}</strong>
           <span>
             {% if program.current_character %}
-            wearing {{ program.current_character.name }}
+            playing as {{ program.current_character.name }}
             {% else %}
             no active face
             {% end %}
@@ -320,7 +337,7 @@ A studio program ready for scenes, casting, and writer movement.
     </div>
     <div class="elbysodic-network-continue-grid">
       {% for program in network.programs %}
-      {% if program.is_current or program.unread_notification_count or program.plotting_room_count or program.application_count %}
+      {% if program.is_current or program.unread_notification_count or program.plotting_room_count or program.open_wanted_count %}
       {{ continue_card(program) }}
       {% end %}
       {% end %}

--- a/src/elbysodic/web/pages/page.html
+++ b/src/elbysodic/web/pages/page.html
@@ -1,10 +1,17 @@
 {% imports %}
-  {% from "chirpui/badge.html" import badge %}
-  {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
+  {% from "chirpui/layout.html" import container, stack %}
   {% from "chirpui/stat.html" import stat %}
-  {% from "chirpui/surface.html" import surface %}
   {% from "_components/boards.html" import board_signal, community_board_row %}
   {% from "_components/thread_summary.html" import activity_item, activity_log_item %}
+{% end %}
+
+{% def home_section_header(title, summary="") %}
+<header class="elbysodic-home-section-header">
+  <h2>{{ title }}</h2>
+  {% if summary %}
+  <p>{{ summary }}</p>
+  {% end %}
+</header>
 {% end %}
 
 {% block page_root %}
@@ -12,7 +19,7 @@
 {% block page_root_inner %}
 {% block page_content %}
 {% call container(max_width="76rem") %}
-{% call stack(gap="xl") %}
+{% call stack(gap="lg") %}
   {% set hero_treatment = viewer.community.world_hero_treatment or "split" %}
   {% set hero_uses_media = viewer.community.world_hero_image_url and hero_treatment != "text" %}
   <section class="elbysodic-world-hero elbysodic-world-hero--{{ hero_treatment }} elbysodic-world-hero--height-{{ viewer.community.world_hero_height or "standard" }} elbysodic-world-hero--overlay-{{ viewer.community.world_hero_overlay or "medium" }} elbysodic-world-hero--focal-{{ viewer.community.world_hero_focal_point or "center" }}{{ " elbysodic-world-hero--with-media" if hero_uses_media else "" }}">
@@ -44,9 +51,7 @@
     {% end %}
   </section>
 
-  {% call section_header("Locations") %}
-  In-character doors into the board's world, conflicts, and current event pressure.
-  {% end %}
+  {{ home_section_header("Locations", "In-character doors into the board's world, conflicts, and current event pressure.") }}
 
   <div class="elbysodic-location-grid">
     {% for summary in location_boards %}
@@ -54,41 +59,38 @@
     {% end %}
   </div>
 
-  {% call section_header("Community Table") %}
-  The director notes, plotting boards, OOC room, and continuity shelves behind the story.
-  {% end %}
+  {% if community_boards %}
+  {{ home_section_header("Community Table", "Director notes, plotting boards, OOC rooms, and continuity shelves behind the story.") }}
 
   <div class="elbysodic-community-table">
     {% for summary in community_boards %}
     {{ community_board_row(summary, viewer) }}
     {% end %}
   </div>
-
-  {% call section_header("Needs reply") %}
-  Threads where someone else posted last.
   {% end %}
 
+  {% if attention %}
+  {{ home_section_header("Needs reply", "Threads where someone else posted last.") }}
   <div class="chirpui-stack chirpui-stack--sm elbysodic-activity-list">
-    {% if attention %}
     {% for item in attention %}
     {{ activity_item(item.board, item.thread, item.latest_post, item.snippet, "needs reply", "warning") }}
     {% end %}
-    {% else %}
-    {% call surface(variant="elevated") %}
-    <p class="elbysodic-empty-state">Your roster is caught up for now.</p>
-    {% end %}
-    {% end %}
   </div>
-
-  {% call section_header("Recent activity") %}
-  Latest visible posts across the forum.
+  {% else %}
+  <div class="elbysodic-quiet-empty" role="status">
+    Your roster is caught up for now.
+  </div>
   {% end %}
+
+  {% if activity %}
+  {{ home_section_header("Recent activity", "Latest visible posts across the forum.") }}
 
   <div class="elbysodic-activity-log">
     {% for item in activity %}
     {{ activity_log_item(item.board, item.thread, item.post, item.snippet, "new" if item.is_unread else "", "info") }}
     {% end %}
   </div>
+  {% end %}
 {% end %}
 {% end %}
 {% end %}

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/page.html
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/page.html
@@ -1,5 +1,6 @@
 {% imports %}
   {% from "chirpui/badge.html" import badge %}
+  {% from "chirpui/detail_header.html" import detail_header %}
   {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "chirpui/surface.html" import surface %}
   {% from "_components/facets.html" import facet_pills %}
@@ -16,42 +17,28 @@
 
   {% call surface(variant="elevated") %}
   <article class="chirpui-stack chirpui-stack--md elbysodic-wanted-detail">
-    <div>
-      <p class="elbysodic-wanted-card__type">{{ wanted.type_label }}</p>
-      <div class="chirpui-cluster chirpui-cluster--between">
-        <h2>{{ wanted.wanted_ad.title }}</h2>
+    {% call detail_header(title=wanted.wanted_ad.title, summary=wanted.wanted_ad.summary, eyebrow=wanted.type_label, cls="elbysodic-wanted-detail__header") %}
+      {% slot badges %}
         {{ badge(wanted.wanted_ad.status, variant="success" if wanted.wanted_ad.status == "open" else "muted") }}
-      </div>
-      {% if wanted.wanted_ad.summary %}
-      <p class="elbysodic-copy-lead">{{ wanted.wanted_ad.summary }}</p>
+        {{ facet_pills(wanted.facets) }}
       {% end %}
-    </div>
-
-    <div class="elbysodic-wanted-card__meta">
-      {% if wanted.creator_character %}
-      <span>
-        wanted by
-        <a class="chirpui-link" href="/characters/{{ wanted.creator_character.slug }}">
-          {{ wanted.creator_character.name }}
-        </a>
-      </span>
-      {% else %}
-      <span>
-        wanted by
-        <a class="chirpui-link" href="/members/{{ wanted.creator_membership.username }}">
-          {{ wanted.creator_membership.username }}
-        </a>
-      </span>
+      {% slot meta %}
+        <span>
+          wanted by
+          {% if wanted.creator_character %}
+          <a class="chirpui-link" href="/characters/{{ wanted.creator_character.slug }}">{{ wanted.creator_character.name }}</a>
+          {% else %}
+          <a class="chirpui-link" href="/members/{{ wanted.creator_membership.username }}">{{ wanted.creator_membership.username }}</a>
+          {% end %}
+        </span>
+        {% if wanted.related_material %}
+        <span>
+          tied to
+          <a class="chirpui-link" href="/world/{{ wanted.related_material.slug }}">{{ wanted.related_material.title }}</a>
+        </span>
+        {% end %}
       {% end %}
-      {% if wanted.related_material %}
-      <span>
-        tied to
-        <a class="chirpui-link" href="/world/{{ wanted.related_material.slug }}">
-          {{ wanted.related_material.title }}
-        </a>
-      </span>
-      {% end %}
-    </div>
+    {% end %}
 
     {% if wanted.related_characters %}
     <div>
@@ -73,7 +60,6 @@
     </div>
     {% end %}
 
-    {{ facet_pills(wanted.facets) }}
     <div class="elbysodic-prose-body elbysodic-prose-body--hook elbysodic-hook-body">
       {{ wanted.rendered_body }}
     </div>

--- a/src/elbysodic/web/pages/world/{material_slug}/page.html
+++ b/src/elbysodic/web/pages/world/{material_slug}/page.html
@@ -1,4 +1,5 @@
 {% imports %}
+  {% from "chirpui/detail_header.html" import detail_header %}
   {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "chirpui/surface.html" import surface %}
   {% from "_components/boards.html" import board_signal %}
@@ -48,19 +49,16 @@
 {% call stack(gap="lg") %}
   <a class="chirpui-link" href="/world">← Guidebook</a>
 
-  <article class="elbysodic-material-hero elbysodic-material-hero--{{ material.material.material_type }}">
-    <div class="elbysodic-material-hero__copy">
-      <p class="elbysodic-material-card__type">{{ material.type_label }}</p>
-      <h1>{{ material.material.title }}</h1>
-      {% if material.material.summary %}
-      <p class="elbysodic-copy-lead">{{ material.material.summary }}</p>
-      {% end %}
+  {% call detail_header(title=material.material.title, summary=material.material.summary, eyebrow=material.type_label, cls="elbysodic-material-hero elbysodic-material-hero--" ~ material.material.material_type) %}
+    {% slot badges %}
       {{ facet_pills(material.facets) }}
-    </div>
-    <aside class="elbysodic-material-hero__pulse">
+    {% end %}
+    {% slot aside %}
+    <div class="elbysodic-material-hero__pulse">
       {{ studio_facts(material) }}
-    </aside>
-  </article>
+    </div>
+    {% end %}
+  {% end %}
 
   {% call inline_nav("Material sections", cls="elbysodic-section-jump") %}
     {% if material.event_actions %}

--- a/src/elbysodic/web/static/elbysodic-theme.css
+++ b/src/elbysodic/web/static/elbysodic-theme.css
@@ -2643,6 +2643,43 @@ body {
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
 }
 
+.elbysodic-home-section-header {
+    align-items: baseline;
+    border-block-start: 1px solid color-mix(in srgb, var(--chirpui-border) 54%, transparent);
+    display: flex;
+    gap: 0.75rem 1rem;
+    justify-content: space-between;
+    padding-block-start: 1.1rem;
+}
+
+.elbysodic-home-section-header h2,
+.elbysodic-home-section-header p {
+    margin: 0;
+}
+
+.elbysodic-home-section-header h2 {
+    color: var(--chirpui-text);
+    font-size: var(--chirpui-font-lg);
+    letter-spacing: 0;
+    line-height: 1.2;
+}
+
+.elbysodic-home-section-header p {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-sm);
+    line-height: 1.38;
+    max-inline-size: 48rem;
+    text-align: end;
+}
+
+.elbysodic-quiet-empty {
+    background: color-mix(in srgb, var(--chirpui-surface) 52%, transparent);
+    border: 1px solid color-mix(in srgb, var(--chirpui-border) 58%, transparent);
+    border-radius: var(--chirpui-radius-sm);
+    color: var(--chirpui-text-muted);
+    padding: 1rem;
+}
+
 .elbysodic-community-grid {
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
 }
@@ -2732,6 +2769,27 @@ body {
 
 .elbysodic-location-card {
     height: 100%;
+}
+
+.elbysodic-empty-cta {
+    align-items: center;
+    border-block-start: 1px solid color-mix(in srgb, var(--chirpui-border) 54%, transparent);
+    display: flex;
+    gap: 0.75rem;
+    justify-content: space-between;
+    margin-block-start: auto;
+    padding-block-start: 0.75rem;
+}
+
+.elbysodic-empty-cta p {
+    color: var(--chirpui-text-muted);
+    margin: 0;
+}
+
+.elbysodic-empty-cta .chirpui-btn {
+    min-block-size: 2rem;
+    padding: 0.35rem 0.65rem;
+    white-space: nowrap;
 }
 
 .elbysodic-board-card__body {
@@ -3480,6 +3538,15 @@ body {
     margin-left: 0.55rem;
 }
 
+.elbysodic-filter-link.chirpui-chip {
+    border-bottom-width: 1px;
+    padding: var(--chirpui-spacing-xs) var(--chirpui-spacing-sm);
+}
+
+.elbysodic-filter-link.chirpui-chip + .elbysodic-filter-link.chirpui-chip {
+    margin-left: 0;
+}
+
 .elbysodic-filter-link:hover,
 .elbysodic-filter-link:focus-visible,
 .elbysodic-filter-link--active {
@@ -4194,6 +4261,19 @@ body {
     gap: 0.35rem;
     min-height: 2rem;
     padding: 0.35rem 0.55rem;
+    text-decoration: none;
+}
+
+a.elbysodic-metric {
+    position: relative;
+    z-index: 2;
+}
+
+a.elbysodic-metric:hover,
+a.elbysodic-metric:focus-visible {
+    background: color-mix(in srgb, var(--chirpui-accent) 14%, var(--chirpui-bg-subtle));
+    border-color: color-mix(in srgb, var(--chirpui-accent) 44%, var(--chirpui-border));
+    color: var(--chirpui-text);
 }
 
 .elbysodic-metric strong,
@@ -6583,7 +6663,7 @@ body {
 
 .elbysodic-facet-pill,
 .elbysodic-facet-filter {
-    --elbysodic-facet-accent: var(--chirpui-accent);
+    --elbysodic-facet-accent: var(--chirpui-facet-chip-color, var(--chirpui-accent));
     align-items: center;
     border: 1px solid color-mix(in srgb, var(--elbysodic-facet-accent) 42%, var(--chirpui-border));
     border-radius: 999px;
@@ -6628,7 +6708,8 @@ body {
 }
 
 .elbysodic-facet-filter:hover,
-.elbysodic-facet-filter--selected {
+.elbysodic-facet-filter--selected,
+.elbysodic-facet-filter.chirpui-facet-chip--selected {
     background: color-mix(in srgb, var(--elbysodic-facet-accent) 14%, var(--chirpui-bg-subtle));
     border-color: color-mix(in srgb, var(--elbysodic-facet-accent) 70%, var(--chirpui-border));
 }
@@ -7167,6 +7248,38 @@ body {
     gap: 0.45rem;
 }
 
+.elbysodic-network-card__metrics {
+    align-items: stretch;
+    align-self: end;
+    background: color-mix(in srgb, var(--elbysodic-network-accent) 8%, var(--chirpui-bg-subtle));
+    border: 1px solid color-mix(in srgb, var(--elbysodic-network-accent) 18%, var(--chirpui-border-subtle));
+    border-radius: var(--chirpui-radius-sm);
+    display: inline-flex;
+    flex-wrap: nowrap;
+    gap: 0;
+    inline-size: max-content;
+    max-inline-size: 100%;
+    overflow: hidden;
+}
+
+.elbysodic-network-card__metrics .elbysodic-metric {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    flex: 0 0 auto;
+    min-block-size: 2rem;
+    padding: 0.35rem 0.55rem;
+    white-space: nowrap;
+}
+
+.elbysodic-network-card__metrics .elbysodic-metric + .elbysodic-metric {
+    border-inline-start: 1px solid color-mix(in srgb, var(--elbysodic-network-accent) 18%, var(--chirpui-border-subtle));
+}
+
+.elbysodic-network-card__metrics .elbysodic-metric strong {
+    font-size: var(--chirpui-font-base);
+}
+
 .elbysodic-network-billboard__signals .elbysodic-metric {
     background: rgba(255, 255, 255, 0.12);
     border-color: rgba(255, 255, 255, 0.22);
@@ -7181,8 +7294,7 @@ body {
 }
 
 .elbysodic-network-billboard__actions form,
-.elbysodic-network-continue-card__actions form,
-.elbysodic-network-card__actions form {
+.elbysodic-network-continue-card__actions form {
     margin: 0;
 }
 
@@ -7227,12 +7339,12 @@ body {
 }
 
 .elbysodic-network-search {
-    background: var(--chirpui-bg);
+    background: color-mix(in srgb, var(--chirpui-bg) 86%, transparent);
     border: 1px solid var(--chirpui-border);
     border-radius: var(--chirpui-radius-sm);
     display: grid;
-    gap: 0.55rem;
-    padding: 0.75rem;
+    gap: 0.45rem;
+    padding: 0.65rem;
 }
 
 .elbysodic-network-search label {
@@ -7241,20 +7353,53 @@ body {
     font-weight: 700;
 }
 
-.elbysodic-network-search div {
-    display: flex;
-    gap: 0.5rem;
-}
-
-.elbysodic-network-search input {
+.elbysodic-network-search__control {
+    align-items: stretch;
     background: var(--chirpui-surface);
     border: 1px solid var(--chirpui-border);
     border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    overflow: hidden;
+}
+
+.elbysodic-network-search__scope {
+    align-items: center;
+    border-inline-end: 1px solid var(--chirpui-border);
+    color: var(--chirpui-text-muted);
+    display: inline-flex;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 800;
+    padding: 0 0.75rem;
+    text-transform: uppercase;
+}
+
+.elbysodic-network-search input {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
     color: var(--chirpui-text);
     flex: 1 1 auto;
     font: inherit;
+    min-block-size: 2.85rem;
     min-inline-size: 0;
-    padding: 0.7rem 0.75rem;
+    padding: 0.7rem 0.85rem;
+}
+
+.elbysodic-network-search__submit {
+    background: var(--chirpui-accent);
+    border: 0;
+    border-inline-start: 1px solid color-mix(in srgb, var(--chirpui-accent) 68%, var(--chirpui-border));
+    color: var(--chirpui-on-accent);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 800;
+    padding: 0 1rem;
+}
+
+.elbysodic-network-search__submit:hover,
+.elbysodic-network-search__submit:focus-visible {
+    background: color-mix(in srgb, var(--chirpui-accent) 88%, var(--chirpui-text));
 }
 
 .elbysodic-network-discovery-band {
@@ -7367,9 +7512,10 @@ body {
     border-radius: var(--chirpui-radius-sm);
     display: grid;
     gap: 1rem;
-    grid-template-rows: auto 1fr auto;
+    grid-template-rows: auto 1fr;
     min-block-size: 100%;
     overflow: hidden;
+    position: relative;
 }
 
 .elbysodic-network-card--current {
@@ -7384,6 +7530,19 @@ body {
     min-block-size: 12rem;
     overflow: hidden;
     position: relative;
+    z-index: 2;
+}
+
+.elbysodic-network-card__realm-link {
+    border-radius: inherit;
+    inset: 0;
+    position: absolute;
+    z-index: 1;
+}
+
+.elbysodic-network-card__realm-link:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--elbysodic-network-accent) 72%, white);
+    outline-offset: -3px;
 }
 
 .elbysodic-network-card__poster > img {
@@ -7400,8 +7559,21 @@ body {
 }
 
 .elbysodic-network-card__poster > span {
-    display: block;
+    display: grid;
     min-block-size: 12rem;
+    place-items: end start;
+}
+
+.elbysodic-network-card__poster-fallback {
+    color: color-mix(in srgb, var(--elbysodic-network-accent) 58%, var(--chirpui-text));
+    font-family: var(--elbysodic-network-display-font);
+    font-size: clamp(3rem, 9vw, 5.5rem);
+    line-height: 0.85;
+    padding: 1rem;
+}
+
+.elbysodic-network-card--no-hero .elbysodic-network-card__poster {
+    min-block-size: 10rem;
 }
 
 .elbysodic-network-card__poster em {
@@ -7411,23 +7583,22 @@ body {
     bottom: 0.75rem;
     display: grid;
     font-style: normal;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
     inline-size: 2.75rem;
     left: 0.75rem;
+    line-height: 1;
+    min-block-size: 2.75rem;
     place-items: center;
     position: absolute;
 }
 
-.elbysodic-network-card__poster em img {
-    block-size: 2.25rem;
-    inline-size: 2.25rem;
-    object-fit: cover;
-}
-
 .elbysodic-network-card__main {
+    align-content: start;
     display: grid;
     gap: 0.65rem;
     min-inline-size: 0;
-    padding: 0 1rem;
+    padding: 0 1rem 1rem;
 }
 
 .elbysodic-network-card__header {
@@ -7454,12 +7625,50 @@ body {
 }
 
 .elbysodic-network-card__actions {
-    align-content: end;
+    align-items: center;
     display: flex;
     flex-wrap: wrap;
-    gap: 0.45rem;
-    padding: 0 1rem 1rem;
+    gap: 0.35rem;
+    justify-content: flex-end;
+    padding: 0;
+    position: absolute;
+    right: 0.75rem;
+    top: 0.75rem;
+    z-index: 3;
 }
+
+.elbysodic-network-card__icon-action {
+    align-items: center;
+    backdrop-filter: blur(10px);
+    background: color-mix(in srgb, var(--chirpui-surface) 76%, transparent);
+    border: 1px solid color-mix(in srgb, var(--elbysodic-network-accent) 30%, var(--chirpui-border));
+    border-radius: var(--chirpui-radius-sm);
+    color: var(--chirpui-text-muted);
+    display: inline-flex;
+    font: inherit;
+    font-weight: 800;
+    inline-size: 2.35rem;
+    justify-content: center;
+    min-block-size: 2.25rem;
+    padding: 0;
+    text-decoration: none;
+}
+
+.elbysodic-network-card__tooltip {
+    z-index: 3;
+}
+
+.elbysodic-network-card__tooltip .chirpui-tooltip__bubble {
+    white-space: nowrap;
+}
+
+.elbysodic-network-card__icon-action:hover,
+.elbysodic-network-card__icon-action:focus-visible {
+    background: color-mix(in srgb, var(--elbysodic-network-accent) 14%, var(--chirpui-surface));
+    border-color: color-mix(in srgb, var(--elbysodic-network-accent) 56%, var(--chirpui-border));
+    color: var(--chirpui-text);
+}
+
 
 .elbysodic-network-editorial-panel {
     display: grid;
@@ -8704,8 +8913,12 @@ body {
         display: grid;
     }
 
-    .elbysodic-network-search div {
-        display: grid;
+    .elbysodic-network-search__control {
+        grid-template-columns: 1fr auto;
+    }
+
+    .elbysodic-network-search__scope {
+        display: none;
     }
 
     .elbysodic-network-card__poster {

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -60,6 +60,33 @@ def _response_headers(response: Any, name: str) -> list[str]:
     return values
 
 
+def _style_block(html: str, style_id: str) -> str:
+    match = re.search(
+        rf'<style id="{re.escape(style_id)}">(?P<body>.*?)</style>',
+        html,
+        re.DOTALL,
+    )
+    assert match is not None
+    return match.group("body")
+
+
+def _oob_block(html: str, target_id: str) -> str:
+    match = re.search(
+        rf'<div id="{re.escape(target_id)}" hx-swap-oob="innerHTML">(?P<body>.*?)</div>',
+        html,
+        re.DOTALL,
+    )
+    assert match is not None
+    return match.group("body")
+
+
+def _page_content(html: str) -> str:
+    marker = '<div id="page-content">'
+    start = html.find(marker)
+    assert start >= 0
+    return html[start:]
+
+
 def _app():
     return create_app(debug=False, services=create_services(path=":memory:"))
 
@@ -435,7 +462,7 @@ def test_boosted_main_navigation_uses_chirp_shell_outlet() -> None:
     asyncio.run(run())
 
 
-def test_shell_brand_navigation_selects_page_content_for_boosted_swap() -> None:
+def test_shell_brand_navigation_uses_full_boundary_navigation() -> None:
     async def run() -> None:
         app = _app()
 
@@ -448,10 +475,7 @@ def test_shell_brand_navigation_selects_page_content_for_boosted_swap() -> None:
             response.text,
         )
         assert brand_link is not None
-        assert 'hx-boost="true"' in brand_link.group(0)
-        assert 'hx-target="#main"' in brand_link.group(0)
-        assert 'hx-swap="innerHTML"' in brand_link.group(0)
-        assert 'hx-select="#page-content"' in brand_link.group(0)
+        assert 'hx-boost="false"' in brand_link.group(0)
 
     asyncio.run(run())
 
@@ -602,7 +626,7 @@ def test_identity_switcher_persists_dev_membership_cookie() -> None:
         assert after.status == 200
         assert '<span class="elbysodic-community-brand__name">HP Universe</span>' in after.text
         assert "Director in HP Universe" in after.text
-        assert "wearing Rowan Ash" in after.text
+        assert "playing as Rowan Ash" in after.text
         assert '<style id="elbysodic-program-theme">' in after.text
         assert "--chirpui-accent: #c8a6ff;" in after.text
         assert "--chirpui-ui-font-family: Georgia, serif;" in after.text
@@ -694,7 +718,7 @@ def test_dev_persona_switcher_can_change_seeded_user_and_membership() -> None:
         assert "SameSite=lax" in set_cookie
         assert studio.status == 200
         assert "Staff in X-Men Apocalypse" in studio.text
-        assert "wearing Moira MacTaggert" in studio.text
+        assert "playing as Moira MacTaggert" in studio.text
         assert "Save theme tokens" in studio.text
         assert "Director Studio is visible as a preview" not in studio.text
 
@@ -863,6 +887,79 @@ def test_stale_dev_identity_cookie_falls_back_to_membership_for_program() -> Non
         )
         assert '<style id="elbysodic-program-theme">' in response.text
         assert "--chirpui-accent: #6bbf7a;" in response.text
+
+    asyncio.run(run())
+
+
+def test_product_shell_does_not_inherit_current_program_theme() -> None:
+    async def run() -> None:
+        app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=True,
+        )
+        services = get_services()
+        hp = services.repo.get_community_by_slug("hp-universe")
+        hp_membership = services.repo.get_membership_for_user(hp.id, 1)
+        cookie = f"elbysodic_dev_identity={hp.id}:1:{hp_membership.id}"
+
+        async with TestClient(app) as client:
+            network = await client.get("/network", headers={"Cookie": cookie})
+            community = await client.get("/notifications", headers={"Cookie": cookie})
+
+        assert network.status == 200
+        assert community.status == 200
+        assert "--chirpui-accent: #c8a6ff;" not in _style_block(
+            network.text, "elbysodic-program-theme"
+        )
+        assert "--chirpui-sidebar-width: 0rem;" in _style_block(
+            network.text, "elbysodic-product-shell"
+        )
+        assert "--chirpui-accent: #c8a6ff;" in _style_block(
+            community.text, "elbysodic-program-theme"
+        )
+        assert "--chirpui-sidebar-width: 0rem;" not in _style_block(
+            community.text, "elbysodic-product-shell"
+        )
+
+    asyncio.run(run())
+
+
+def test_boosted_shell_navigation_carries_theme_boundary_oob() -> None:
+    async def run() -> None:
+        app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=True,
+        )
+        services = get_services()
+        hp = services.repo.get_community_by_slug("hp-universe")
+        hp_membership = services.repo.get_membership_for_user(hp.id, 1)
+        cookie = f"elbysodic_dev_identity={hp.id}:1:{hp_membership.id}"
+        hx_headers = {
+            "Cookie": cookie,
+            "HX-Request": "true",
+            "HX-Boosted": "true",
+            "HX-Target": "main",
+        }
+
+        async with TestClient(app) as client:
+            network = await client.get("/network", headers=hx_headers)
+            community = await client.get("/notifications", headers=hx_headers)
+
+        assert network.status == 200
+        assert community.status == 200
+        assert "--chirpui-accent: #c8a6ff;" not in _oob_block(
+            network.text, "elbysodic-program-theme"
+        )
+        assert "--chirpui-sidebar-width: 0rem;" in _oob_block(
+            network.text, "elbysodic-product-shell"
+        )
+        assert 'id="page-root" hx-boost="false"' in network.text
+        assert "--chirpui-accent: #c8a6ff;" in _oob_block(community.text, "elbysodic-program-theme")
+        assert "--chirpui-sidebar-width: 0rem;" not in _oob_block(
+            community.text, "elbysodic-product-shell"
+        )
 
     asyncio.run(run())
 
@@ -1053,11 +1150,27 @@ def test_network_directory_lists_programs_and_realm_entry_actions() -> None:
         assert "RL NYC" in response.text
         assert "RL Small Town" in response.text
         assert "current realm" in response.text
-        assert "wearing Rogue" in response.text
+        assert "playing as Rogue" in response.text
         assert response.text.count('name="intent" value="switch_membership"') >= 4
         assert 'name="next" value="/c/hp-universe"' in response.text
-        assert 'name="next" value="/c/hp-universe/applications/new"' in response.text
+        assert "/applications/new" not in response.text
+        assert "Start application" not in response.text
         assert 'name="next" value="/c/jurassic-park-universe"' in response.text
+        assert 'class="elbysodic-network-card__realm-link"' in response.text
+        assert 'aria-label="Enter Jurassic Park Universe"' in response.text
+        assert 'class="elbysodic-network-card__icon-action' in response.text
+        assert 'aria-label="Current event"' in response.text
+        assert 'aria-label="Wanted hooks"' in response.text
+        assert "elbysodic-network-card__tooltip" in response.text
+        assert 'title="Wanted hooks"' not in response.text
+        assert "elbysodic-network-search__control" in response.text
+        assert "face you want to play next" in response.text
+        assert "face you want to wear next" not in response.text
+        assert "elbysodic-network-card__mark" in response.text
+        assert "XMA" in response.text
+        assert 'href="/c/jurassic-park-universe/characters" aria-label="3 faces"' in response.text
+        assert 'href="/c/jurassic-park-universe/wanted" aria-label="2 wanted"' in response.text
+        assert 'href="/c/jurassic-park-universe/plotting" aria-label="0 rooms"' in response.text
         assert 'href="/c/jurassic-park-universe/world/paddock-twelve-incident"' in response.text
 
     asyncio.run(run())
@@ -1142,7 +1255,7 @@ def test_forum_pages_render_seeded_boards_and_thread() -> None:
             assert "elbysodic-identity-menu" in index.text
             assert "elbysodic-identity-menu__notification-link" in index.text
             assert "elbysodic-identity-menu__theme-row" in index.text
-            assert "wearing Rogue" in index.text
+            assert "playing as Rogue" in index.text
             assert "elbysodic-community-table" in index.text
             assert "elbysodic-community-row" in index.text
             assert "✉" in index.text
@@ -1169,6 +1282,9 @@ def test_forum_pages_render_seeded_boards_and_thread() -> None:
             assert 'id="board-thread-region"' in board.text
             assert 'hx-target="#board-thread-region"' in board.text
             assert 'hx-swap="outerHTML show:none"' in board.text
+            assert "chirpui-breadcrumbs" in board.text
+            assert "chirpui-saved-view-strip" in board.text
+            assert "chirpui-facet-chip" in board.text
             assert "First unread" in board.text
             assert "#post-" in board.text
             assert "new replies" in board.text
@@ -1180,6 +1296,8 @@ def test_forum_pages_render_seeded_boards_and_thread() -> None:
             thread = await client.get("/boards/plotting/threads/open-thread-roster")
             assert thread.status == 200
             assert 'id="post-' in thread.text
+            assert "chirpui-thread-reader-layout" in thread.text
+            assert "chirpui-breadcrumbs" in thread.text
             assert "Runtime" in thread.text
             assert "Credits" in thread.text
             assert "min read" in thread.text
@@ -1328,6 +1446,27 @@ def test_seeded_program_homepage_uses_community_media_and_world_status() -> None
     asyncio.run(run())
 
 
+def test_new_realm_homepage_uses_quiet_sections_and_actionable_empty_states() -> None:
+    async def run() -> None:
+        app = _app()
+        async with TestClient(app) as client:
+            response = await client.get("/c/rl-nyc")
+
+        assert response.status == 200
+        content = _page_content(response.text)
+        assert "elbysodic-home-section-header" in content
+        assert "chirpui-section-header" not in content
+        assert "elbysodic-quiet-empty" in content
+        assert "Your roster is caught up for now." in content
+        assert "No scenes have opened here yet." in content
+        assert 'href="/c/rl-nyc/boards/brooklyn/threads/new"' in content
+        assert 'href="/c/rl-nyc/boards/queens-night-market/threads/new"' in content
+        assert "Community Table" not in content
+        assert "Recent activity" not in content
+
+    asyncio.run(run())
+
+
 def test_seeded_location_boards_have_media_throughlines() -> None:
     async def run() -> None:
         app = _app()
@@ -1463,7 +1602,7 @@ def test_writer_desk_hub_keeps_meta_tools_reachable() -> None:
             assert "Unread watched" in desk.text
             assert "Waiting on others" in desk.text
             assert "Plotting rooms" in desk.text
-            assert "wearing Rogue" in desk.text
+            assert "playing as Rogue" in desk.text
             assert "Queue" in desk.text
             assert "Inbox" in desk.text
             assert "Roster" in desk.text
@@ -2641,6 +2780,7 @@ def test_discovery_defaults_to_active_face_lens_and_filters_facets() -> None:
             discover = await client.get("/discover")
             assert discover.status == 200
             assert "Plot discovery" in discover.text
+            assert "chirpui-facet-chip" in discover.text
             assert "For Rogue" in discover.text
             assert "Mutant" in discover.text
             assert "X-Men" in discover.text
@@ -2678,6 +2818,8 @@ def test_world_materials_render_pillars_events_and_application_guides() -> None:
             event = await client.get("/world/b-24-winter")
             assert event.status == 200
             assert "elbysodic-material-hero--event" in event.text
+            assert "chirpui-detail-header" in event.text
+            assert "chirpui-saved-view-strip" in event.text
             assert "elbysodic-material-detail-shell--event" in event.text
             assert "Iceman is infected with B-24" in event.text
             assert "Evil Lab" in event.text
@@ -3108,6 +3250,9 @@ def test_wanted_ads_render_board_detail_and_character_hub() -> None:
 
             detail = await client.get("/wanted/brotherhood-rival-for-rogue")
             assert detail.status == 200
+            assert "chirpui-detail-header" in detail.text
+            assert "chirpui-facet-chip" in detail.text
+            assert "chirpui-scope-switcher" in detail.text
             assert "Rogue needs someone who remembers" in detail.text
             assert 'href="/characters/rogue"' in detail.text
             assert 'href="/world/factions"' in detail.text
@@ -3667,7 +3812,7 @@ def test_application_start_form_preserves_validation_errors_and_unique_slugs() -
     asyncio.run(run())
 
 
-def test_network_start_application_switches_to_realm_form() -> None:
+def test_direct_application_path_switches_to_realm_form() -> None:
     async def run() -> None:
         app = _app()
         services = get_services()
@@ -3694,7 +3839,8 @@ def test_network_start_application_switches_to_realm_form() -> None:
             )
 
         assert network.status == 200
-        assert 'name="next" value="/c/hp-universe/applications/new"' in network.text
+        assert "/applications/new" not in network.text
+        assert "Start application" not in network.text
         assert response.status == 302
         assert _response_header(response, "location") == "/c/hp-universe/applications/new"
         assert form.status == 200
@@ -4768,6 +4914,7 @@ def test_thread_watch_toggle_controls_thread_notifications() -> None:
         async with TestClient(app) as client:
             thread = await client.get("/boards/plotting/threads/open-thread-roster")
             assert thread.status == 200
+            assert "chirpui-thread-reader-layout" in thread.text
             assert "Watch thread" in thread.text
 
             watched = await client.post(

--- a/uv.lock
+++ b/uv.lock
@@ -93,14 +93,14 @@ wheels = [
 
 [[package]]
 name = "chirp-ui"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "kida-templates" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/d8/164178298a6e606b2f9602766e8e62a72170fb9be8ca1ab6bc790f2cca7a/chirp_ui-0.6.0.tar.gz", hash = "sha256:67404f1ef0bd4691ac45e643de8ad3592bbc5cf0500407ebfea459c2cbfde655", size = 1814331, upload-time = "2026-04-26T19:45:15.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/20/a1e1c4e175f9d11fed2955bb84608e22b8f5f14fb05e3a4ae6a5978b9964/chirp_ui-0.7.0.tar.gz", hash = "sha256:d46d2ffddccdb6f8d0e2265b11a365676d562be286618675e0f063c035f7d2aa", size = 1853443, upload-time = "2026-05-05T21:35:06.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/f5/d4ecf4db9677bcfb52c7aee539b6946c5fff1a1e82f6fc8d561f11e6376f/chirp_ui-0.6.0-py3-none-any.whl", hash = "sha256:8c4f4c038e44c59a10ddcc5f49f11a589cb46a19617f8adb56ef0373af929849", size = 2043367, upload-time = "2026-04-26T19:45:13.679Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a4/803b8137f6bc605b6a2cdfe5797821b03dafb314018187c083fe2df916ed/chirp_ui-0.7.0-py3-none-any.whl", hash = "sha256:44b61833c808b3a3c80b5f8aefa7354b507c60f85c964b0e2a4eee3fae57241b", size = 2081478, upload-time = "2026-05-05T21:35:04.164Z" },
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "bengal-chirp", extras = ["config", "forms", "sessions", "ui"], specifier = ">=0.6.0" },
-    { name = "chirp-ui", specifier = ">=0.6.0" },
+    { name = "chirp-ui", specifier = ">=0.7.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
## Summary
- bump Chirp UI to 0.7.0 and wire in new documented recipes across dense navigation, facets, breadcrumbs, detail headers, saved view strips, thread layout, and scope switcher surfaces
- harden product/community theme boundaries so the network hub does not retain a community theme outside that realm
- redesign the multi-tenant network hub with clickable realm cards, compact icon actions, linked signal metrics, monogram marks, fused search, and less application-forward language
- quiet empty community home sections and add actionable scene CTAs where an empty state should lead to writing

## Validation
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
- git diff --check