### PR TITLE
[codex] Public network shell gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,11 @@ Set these Railway variables before sharing the app:
 
 - `ELBYSODIC_ENV=production`
 - `ELBYSODIC_SECRET_KEY` to a random value of at least 32 characters
-- `ELBYSODIC_ALLOWED_HOSTS` to the Railway/custom host list, comma-separated
 - `ELBYSODIC_DEMO_MODE=1` only when seeded demo credentials should work
+
+`ELBYSODIC_ALLOWED_HOSTS` is optional for Railway because production defaults
+allow Railway domains. Set it only after confirming the exact public or custom
+host list; values are comma-separated hostnames without `https://`.
 
 When demo mode is enabled, seed users can log in with password `password`,
 including `writer@example.com`, `moira@example.com`, and `alex@example.com`.
@@ -221,6 +224,8 @@ Without `ELBYSODIC_DEMO_MODE=1`, production rejects those seed password hashes.
 Post-deploy smoke for the shared Railway host:
 
 - confirm `/health` returns `200`
+- confirm logged-out `/` and `/network?q=magic` render the public realm catalog
+- confirm logged-out `/studio` redirects to `/login?next=/studio`
 - log in with the intended demo account policy
 - open `/c/x-men-apocalypse/world/b-24-winter`
 - open `/c/jurassic-park-universe/boards/paddock-twelve`
@@ -229,6 +234,8 @@ Post-deploy smoke for the shared Railway host:
   confirm the shell never swaps to an empty main area
 - submit one low-risk write path, such as a membership or face switch, to prove
   session cookies and CSRF work together
+- log out, then confirm replaying the old `elbysodic_session` cannot open
+  `/studio`
 - confirm seed media under `/elbysodic-static/seed-media/...` returns `200`
 - keep the Railway service at one replica while SQLite is volume-backed
 

--- a/changelog.d/+public-network-auth-shell.security.md
+++ b/changelog.d/+public-network-auth-shell.security.md
@@ -1,0 +1,1 @@
+Production mode now allows logged-out visitors to browse the public realm catalog while keeping community, Studio, Desk, writing, and identity actions session-gated.

--- a/changelog.d/+sidebar-default-open.fixed.md
+++ b/changelog.d/+sidebar-default-open.fixed.md
@@ -1,0 +1,1 @@
+The community sidebar now defaults open for fresh sessions instead of inheriting older collapsed browser preferences.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -63,10 +63,16 @@ Production mode is enabled with `ELBYSODIC_ENV=production` or `staging`.
 Production request identity is session-backed:
 
 - normal app routes require a valid `elbysodic_session`
-- `/health`, `/login`, `/logout`, and static assets are public
+- `/health`, `/login`, `/logout`, `/`, `/network`, and static assets are public
 - dev identity headers are ignored
 - unsigned `elbysodic_dev_identity` cookies are ignored and are not issued
 - `/dev/personas` is unavailable even when `ELBYSODIC_DEV_TOOLS` is set
+
+The logged-out `/` and `/network` surfaces use public catalog read models.
+They can show realm names, public premise or current-event summaries, public
+media, roster counts, and wanted-hook counts. They must not render membership
+names, active faces, unread counts, staff signals, identity switch forms, or
+private writer queues.
 
 Current community and membership selection is stored on `user_sessions` as
 `selected_community_id` and `selected_membership_id`. Switching membership

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -167,6 +167,37 @@ class IdentityRepositoryMixin(RepositoryBase):
             raise LookupError(f"community not found for host: {host}")
         return _community_from_row(row)
 
+    def list_communities(self) -> list[Community]:
+        rows = self.connection.execute(
+            """
+            SELECT
+                id,
+                name,
+                slug,
+                host,
+                default_theme_id,
+                identity_accent_facet_group_id,
+                community_mark_url,
+                community_mark_alt,
+                world_hero_image_url,
+                world_hero_image_alt,
+                world_hero_treatment,
+                world_hero_focal_point,
+                world_hero_overlay,
+                world_hero_height,
+                enabled_post_profile_variants,
+                enabled_post_accent_styles,
+                enabled_post_border_styles,
+                enabled_post_title_styles,
+                enabled_post_densities,
+                created_at,
+                updated_at
+            FROM communities
+            ORDER BY name, id
+            """
+        ).fetchall()
+        return [_community_from_row(row) for row in rows]
+
     def update_community_identity_accent_group(
         self,
         community_id: int,

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -607,6 +607,39 @@ class AppServices:
             )
         )
 
+    def public_studio_network(self) -> StudioNetworkDirectory:
+        programs: list[StudioNetworkProgramView] = []
+        for community in self.repo.list_communities():
+            materials = self.repo.list_materials(community.id)
+            wanted_ads = self.repo.list_wanted_ads(community.id)
+            community_characters = self.repo.list_community_characters(community.id)
+            theme = community_theme_view(self.repo.get_default_theme(community.id))
+            programs.append(
+                StudioNetworkProgramView(
+                    community=community,
+                    membership=None,
+                    role=None,
+                    current_character=None,
+                    premise=_first_material_summary(materials, "premise", self.repo, community.id),
+                    current_event=_first_material_summary(
+                        materials,
+                        "event",
+                        self.repo,
+                        community.id,
+                    ),
+                    roster_count=len(community_characters),
+                    open_wanted_count=sum(
+                        1 for wanted_ad in wanted_ads if wanted_ad.status == "open"
+                    ),
+                    application_count=0,
+                    plotting_room_count=0,
+                    unread_notification_count=0,
+                    theme_preview=_network_theme_preview(theme),
+                    is_current=False,
+                )
+            )
+        return StudioNetworkDirectory(programs=programs)
+
     def list_boards(self) -> list[BoardSummary]:
         viewer = self.viewer()
         current_facet_ids = _current_character_facet_ids(self.repo, viewer)

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -1355,8 +1355,8 @@ class StudioNetworkThemePreview:
 @dataclass(frozen=True, slots=True)
 class StudioNetworkProgramView:
     community: Community
-    membership: CommunityMembership
-    role: Role
+    membership: CommunityMembership | None
+    role: Role | None
     current_character: Character | None
     premise: MaterialSummary | None
     current_event: MaterialSummary | None
@@ -1367,6 +1367,10 @@ class StudioNetworkProgramView:
     unread_notification_count: int
     theme_preview: StudioNetworkThemePreview
     is_current: bool
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self.membership is not None and self.role is not None
 
     @property
     def entry_href(self) -> str:

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -61,22 +61,15 @@
 {% block head_extra %}
     <script>
     (function () {
-      var cookieName = "elbysodic_sidebar_hidden";
+      var cookieName = "elbysodic_sidebar_hidden_v2";
       var cookieMatch = document.cookie.match(new RegExp("(^|; )" + cookieName + "=([^;]*)"));
       if (cookieMatch) {
         return;
       }
-      var legacyKeys = ["chirpui-sidebar-collapsed", "elbysodic:sidebar-collapsed"];
       var hiddenClass = "elbysodic-app-shell--sidebar-hidden";
       try {
-        var value = null;
-        for (var index = 0; value === null && index < legacyKeys.length; index += 1) {
-          value = window.localStorage.getItem(legacyKeys[index]);
-        }
-        if (value === "true") {
-          document.documentElement.classList.add(hiddenClass);
-          document.cookie = cookieName + "=true; Max-Age=31536000; Path=/; SameSite=Lax" + (location.protocol === "https:" ? "; Secure" : "");
-        }
+        window.localStorage.removeItem("chirpui-sidebar-collapsed");
+        window.localStorage.removeItem("elbysodic:sidebar-collapsed");
       } catch (_error) {
         document.documentElement.classList.remove(hiddenClass);
       }

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -27,7 +27,9 @@ A studio program ready for scenes, casting, and writer movement.
 {% end %}
 
 {% def program_action(program, href, label, variant="primary") %}
-{% if program.is_current %}
+{% if not program.is_authenticated %}
+<a class="chirpui-btn chirpui-btn--{{ variant }}" href="{{ href }}">{{ label }}</a>
+{% elif program.is_current %}
 <a class="chirpui-btn chirpui-btn--{{ variant }}" href="{{ href }}">{{ label }}</a>
 {% else %}
 {{ switch_form(program, href, label, variant) }}
@@ -48,7 +50,9 @@ A studio program ready for scenes, casting, and writer movement.
 {% def program_metric_links(program) %}
 {{ metric_item(program.roster_count, "faces", href=program.entry_href ~ "/characters") }}
 {{ metric_item(program.open_wanted_count, "wanted", href=program.entry_href ~ "/wanted") }}
+{% if program.is_authenticated %}
 {{ metric_item(program.plotting_room_count, "rooms", href=program.entry_href ~ "/plotting") }}
+{% end %}
 {% end %}
 
 {% def network_billboard(program) %}
@@ -69,16 +73,18 @@ A studio program ready for scenes, casting, and writer movement.
       {% if program.community.community_mark_url %}
       <img src="{{ program.community.community_mark_url }}" alt="{{ program.community.community_mark_alt }}">
       {% end %}
-      <span>{{ program.role.name }} realm</span>
+      <span>{{ program.role.name if program.role else "Public realm" }}</span>
     </div>
     <h1 id="network-heading">{{ program.community.name }}</h1>
     <p class="elbysodic-network-billboard__summary">{{ program_summary(program) }}</p>
     <div class="elbysodic-network-billboard__signals" aria-label="{{ program.community.name }} network signals">
       {{ metric_item(program.roster_count, "faces") }}
       {{ metric_item(program.open_wanted_count, "wanted") }}
+      {% if program.is_authenticated %}
       {{ metric_item(program.plotting_room_count, "rooms") }}
       {% if program.unread_notification_count %}
       {{ metric_item(program.unread_notification_count, "unread") }}
+      {% end %}
       {% end %}
     </div>
     <div class="elbysodic-network-billboard__actions">
@@ -155,7 +161,7 @@ A studio program ready for scenes, casting, and writer movement.
           {% elif program.premise %}
           World premise
           {% else %}
-          {{ program.role.name }} realm
+          {{ program.role.name if program.role else "Public realm" }}
           {% end %}
         </p>
         <h2>{{ program.community.name }}</h2>
@@ -164,12 +170,13 @@ A studio program ready for scenes, casting, and writer movement.
         {% if program.is_current %}
         {{ badge("current realm", variant="success") }}
         {% end %}
-        {% if program.unread_notification_count %}
+        {% if program.is_authenticated and program.unread_notification_count %}
         {{ badge(program.unread_notification_count ~ " unread", variant="info") }}
         {% end %}
       </div>
     </header>
     <p class="elbysodic-copy-summary">{{ program_summary(program) }}</p>
+    {% if program.is_authenticated %}
     <p class="elbysodic-copy-meta">
       {{ program.membership.display_name or program.membership.username }}
       {% if program.current_character %}
@@ -178,6 +185,9 @@ A studio program ready for scenes, casting, and writer movement.
       · no active face
       {% end %}
     </p>
+    {% else %}
+    <p class="elbysodic-copy-meta">Public preview · log in to enter queues, claims, and face controls.</p>
+    {% end %}
     <div class="elbysodic-network-card__metrics" aria-label="{{ program.community.name }} signals">
       {{ program_metric_links(program) }}
     </div>
@@ -292,17 +302,25 @@ A studio program ready for scenes, casting, and writer movement.
 
     {% call surface(variant="elevated") %}
     <div class="elbysodic-network-editorial-panel">
-      <p class="elbysodic-section-kicker">Your lanes</p>
+      <p class="elbysodic-section-kicker">{{ "Your lanes" if viewer else "Ways in" }}</p>
+      {% if viewer %}
       <h2>Memberships and face defaults that can shape discovery.</h2>
+      {% else %}
+      <h2>Public previews before you choose an account.</h2>
+      {% end %}
       <div class="elbysodic-network-casting-list">
         {% for program in network.programs %}
         <a href="{{ program.entry_href }}">
           <strong>{{ program.community.name }}</strong>
           <span>
+            {% if viewer %}
             {% if program.current_character %}
             playing as {{ program.current_character.name }}
             {% else %}
             no active face
+            {% end %}
+            {% else %}
+            log in to enter this realm
             {% end %}
           </span>
         </a>
@@ -322,11 +340,14 @@ A studio program ready for scenes, casting, and writer movement.
     </div>
     <div class="elbysodic-network-strip__metrics">
       {{ metric_item(network.programs | length, "programs") }}
+      {% if viewer %}
       {{ metric_item(viewer.identity_options | length, "memberships") }}
       {{ metric_item(viewer.unread_notification_count, "current unread") }}
+      {% end %}
     </div>
   </section>
 
+  {% if viewer %}
   <section class="elbysodic-network-rail" aria-labelledby="continue-writing-heading">
     <div class="elbysodic-network-rail__header">
       <div>
@@ -343,6 +364,7 @@ A studio program ready for scenes, casting, and writer movement.
       {% end %}
     </div>
   </section>
+  {% end %}
 
   <section class="elbysodic-network-rail" aria-labelledby="featured-worlds-heading">
     <div class="elbysodic-network-rail__header">

--- a/src/elbysodic/web/pages/network/page.py
+++ b/src/elbysodic/web/pages/network/page.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from chirp.http.request import Request
 from chirp.templating.returns import Page
 
-from elbysodic.services.read_models import StudioNetworkProgramView
+from elbysodic.services.forum import AppServices
+from elbysodic.services.read_models import ForumView, StudioNetworkProgramView
 from elbysodic.web.state import get_services
 
 
@@ -33,9 +34,9 @@ def _matches_query(program: StudioNetworkProgramView, query: str) -> bool:
         catalog_keywords.append("urban real life city")
     haystack_parts = [
         program.community.name,
-        program.membership.display_name,
-        program.membership.username,
-        program.role.name,
+        program.membership.display_name if program.membership else "",
+        program.membership.username if program.membership else "",
+        program.role.name if program.role else "",
         program.current_character.name if program.current_character else "",
         program.premise.material.title if program.premise else "",
         program.premise.material.summary if program.premise else "",
@@ -48,8 +49,8 @@ def _matches_query(program: StudioNetworkProgramView, query: str) -> bool:
 
 
 def get(request: Request) -> Page:
-    services = get_services(request)
-    network = services.studio_network()
+    services, viewer = _network_services(request)
+    network = services.studio_network() if viewer is not None else services.public_studio_network()
     query = str(request.query.get("q") or "").strip()
     return Page(
         "network/page.html",
@@ -59,10 +60,18 @@ def get(request: Request) -> Page:
         page_title="Explore · Elbysodic",
         network_mode="explore",
         network_search_query=query,
-        viewer=services.viewer(),
+        viewer=viewer,
         network=network,
         explore_programs=[
             program for program in network.programs if _matches_query(program, query)
         ],
         show_community_shell=False,
     )
+
+
+def _network_services(request: Request) -> tuple[AppServices, ForumView | None]:
+    try:
+        services = get_services(request)
+        return services, services.viewer()
+    except PermissionError:
+        return get_services(), None

--- a/src/elbysodic/web/pages/page.py
+++ b/src/elbysodic/web/pages/page.py
@@ -6,7 +6,8 @@ from chirp.http.request import Request
 from chirp.templating.returns import Page
 
 from elbysodic.domain.boards import is_community_board, is_desk_board, is_location_board
-from elbysodic.services.read_models import MaterialSummary, WorldHub
+from elbysodic.services.forum import AppServices
+from elbysodic.services.read_models import ForumView, MaterialSummary, WorldHub
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_tenant_slug
 
@@ -32,9 +33,11 @@ def _first_material(materials: list[MaterialSummary]) -> MaterialSummary | None:
 
 
 def get(request: Request) -> Page:
-    services = get_services(request)
     if request_tenant_slug(request) is None:
-        network = services.studio_network()
+        services, viewer = _network_services(request)
+        network = (
+            services.studio_network() if viewer is not None else services.public_studio_network()
+        )
         return Page(
             "network/page.html",
             "page_content",
@@ -44,11 +47,12 @@ def get(request: Request) -> Page:
             network_mode="home",
             network_search_query="",
             explore_programs=network.programs,
-            viewer=services.viewer(),
+            viewer=viewer,
             network=network,
             show_community_shell=False,
         )
 
+    services = get_services(request)
     viewer = services.viewer()
     boards = services.list_boards()
     hub = services.world_hub()
@@ -76,3 +80,11 @@ def get(request: Request) -> Page:
         attention=services.needs_attention(),
         activity=services.recent_activity(),
     )
+
+
+def _network_services(request: Request) -> tuple[AppServices, ForumView | None]:
+    try:
+        services = get_services(request)
+        return services, services.viewer()
+    except PermissionError:
+        return get_services(), None

--- a/src/elbysodic/web/security.py
+++ b/src/elbysodic/web/security.py
@@ -23,7 +23,7 @@ ELBYSODIC_HSTS = "ELBYSODIC_HSTS"
 MIN_SECRET_KEY_LENGTH = 32
 PRODUCTION_ENVS = frozenset({"production", "prod", "staging"})
 DEFAULT_PRODUCTION_ALLOWED_HOSTS = (".up.railway.app", ".railway.app")
-PUBLIC_PATHS = frozenset({"/health", "/login", "/logout"})
+PUBLIC_PATHS = frozenset({"/", "/health", "/login", "/logout", "/network"})
 PUBLIC_PREFIXES = ("/elbysodic-static/",)
 
 
@@ -95,7 +95,7 @@ class RequireLoginMiddleware:
         self._security = security
 
     async def __call__(self, request: Request, call_next: Next) -> AnyResponse:
-        if not self._security.production or _is_public_path(request.path):
+        if not self._security.production or _is_public_request(request):
             return await call_next(request)
 
         if _session_is_valid(request):
@@ -156,8 +156,14 @@ def _strict_transport_security() -> str | None:
     return normalized
 
 
-def _is_public_path(path: str) -> bool:
-    return path in PUBLIC_PATHS or any(path.startswith(prefix) for prefix in PUBLIC_PREFIXES)
+def _is_public_request(request: Request) -> bool:
+    from elbysodic.web.tenant import request_tenant_slug
+
+    if request_tenant_slug(request) is not None and request.path in {"/", "/network"}:
+        return False
+    return request.path in PUBLIC_PATHS or any(
+        request.path.startswith(prefix) for prefix in PUBLIC_PREFIXES
+    )
 
 
 def _session_is_valid(request: Request) -> bool:

--- a/src/elbysodic/web/shell.py
+++ b/src/elbysodic/web/shell.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from chirp.context import get_request
 from chirp.http.request import Request
 
-SIDEBAR_HIDDEN_COOKIE = "elbysodic_sidebar_hidden"
+SIDEBAR_HIDDEN_COOKIE = "elbysodic_sidebar_hidden_v2"
 SIDEBAR_HIDDEN_CLASS = "elbysodic-app-shell--sidebar-hidden"
 
 

--- a/src/elbysodic/web/static/elbysodic-shell.js
+++ b/src/elbysodic/web/static/elbysodic-shell.js
@@ -1,6 +1,5 @@
 (function () {
-  const COOKIE_NAME = "elbysodic_sidebar_hidden";
-  const LEGACY_STORAGE_KEYS = ["chirpui-sidebar-collapsed", "elbysodic:sidebar-collapsed"];
+  const COOKIE_NAME = "elbysodic_sidebar_hidden_v2";
   const HIDDEN_CLASS = "elbysodic-app-shell--sidebar-hidden";
   const YEAR_SECONDS = 60 * 60 * 24 * 365;
 
@@ -12,25 +11,10 @@
     return decodeURIComponent(match[2]) === "true";
   }
 
-  function readLegacyPreference() {
-    try {
-      for (const key of LEGACY_STORAGE_KEYS) {
-        const value = window.localStorage.getItem(key);
-        if (value !== null) {
-          return value === "true";
-        }
-      }
-    } catch (_error) {
-      // Legacy migration is optional; cookie persistence is the source of truth.
-    }
-    return null;
-  }
-
   function clearLegacyPreference() {
     try {
-      for (const key of LEGACY_STORAGE_KEYS) {
-        window.localStorage.removeItem(key);
-      }
+      window.localStorage.removeItem("chirpui-sidebar-collapsed");
+      window.localStorage.removeItem("elbysodic:sidebar-collapsed");
     } catch (_error) {
       // Best-effort cleanup only.
     }
@@ -54,12 +38,7 @@
       return cookieValue;
     }
 
-    const legacyValue = readLegacyPreference();
-    if (legacyValue !== null) {
-      writeCookiePreference(legacyValue);
-      clearLegacyPreference();
-      return legacyValue;
-    }
+    clearLegacyPreference();
     return false;
   }
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2494,7 +2494,7 @@ def test_sidebar_hidden_preference_is_cookie_backed_and_server_rendered() -> Non
         async with TestClient(app) as client:
             world = await client.get("/boards/xavier-institute")
             assert world.status == 200
-            assert 'var cookieName = "elbysodic_sidebar_hidden";' in world.text
+            assert 'var cookieName = "elbysodic_sidebar_hidden_v2";' in world.text
             assert "elbysodic-theme.css?v=sidebar-cookie-1" in world.text
             assert "elbysodic-shell.js?v=sidebar-cookie-2" in world.text
             assert "elbysodic-composer.js?v=sidebar-cookie-1" in world.text
@@ -2504,7 +2504,7 @@ def test_sidebar_hidden_preference_is_cookie_backed_and_server_rendered() -> Non
 
             hidden_world = await client.get(
                 "/boards/xavier-institute",
-                headers={"Cookie": "elbysodic_sidebar_hidden=true"},
+                headers={"Cookie": "elbysodic_sidebar_hidden_v2=true"},
             )
             assert hidden_world.status == 200
             assert 'id="elbysodic-sidebar-cookie-state"' in hidden_world.text
@@ -2517,11 +2517,11 @@ def test_sidebar_hidden_preference_is_cookie_backed_and_server_rendered() -> Non
 
             script = await client.get("/elbysodic-static/elbysodic-shell.js")
             assert script.status == 200
-            assert 'const COOKIE_NAME = "elbysodic_sidebar_hidden";' in script.text
+            assert 'const COOKIE_NAME = "elbysodic_sidebar_hidden_v2";' in script.text
             assert 'document.getElementById("elbysodic-sidebar-cookie-state")' in script.text
             assert "serverStyle.disabled = !hidden" in script.text
             assert "document.documentElement.classList.toggle(HIDDEN_CLASS, hidden)" in script.text
-            assert "window.localStorage.removeItem(key)" in script.text
+            assert 'window.localStorage.removeItem("chirpui-sidebar-collapsed")' in script.text
 
             composer = await client.get("/elbysodic-static/elbysodic-composer.js")
             assert composer.status == 200

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -147,8 +147,11 @@ def test_production_routes_require_session(monkeypatch) -> None:
 
         async with TestClient(app) as client:
             health = await client.get("/health")
+            root = await client.get("/")
+            network = await client.get("/network?q=magic")
             login = await client.get("/login")
             studio = await client.get("/studio")
+            tenant = await client.get("/c/x-men-apocalypse")
             post = await client.post(
                 "/identity",
                 body=urlencode({"intent": "set_default_character", "character_id": "0"}).encode(),
@@ -157,11 +160,24 @@ def test_production_routes_require_session(monkeypatch) -> None:
             personas = await client.get("/dev/personas")
 
         assert health.status == 200
+        assert root.status == 200
+        assert "Studio Network" in root.text
+        assert "starlane" not in root.text
+        assert "playing as Rogue" not in root.text
+        assert "elbysodic-identity-menu" not in root.text
+        assert "chirpui-theme-toggle" in root.text
+        assert network.status == 200
+        assert "HP Universe" in network.text
+        assert "starlane" not in network.text
+        assert "current realm" not in network.text
+        assert "Public preview" in network.text
         assert login.status == 200
         assert "_csrf_token" in login.text
         assert "Staff in X-Men Apocalypse" not in login.text
         assert studio.status == 302
         assert dict(studio.headers)["location"] == "/login?next=/studio"
+        assert tenant.status == 302
+        assert dict(tenant.headers)["location"] == "/login?next=%2Fc%2Fx-men-apocalypse"
         assert post.status == 403
         assert "Log in to keep writing." in post.text
         assert "/login?next=/identity" in post.text
@@ -254,6 +270,7 @@ def test_production_release_smoke_core_user_flow(monkeypatch) -> None:
                 next_url="/c/x-men-apocalypse",
             )
             cookies.update(_cookie_values(login))
+            original_session = cookies["elbysodic_session"]
             xmen_home = await client.get(
                 "/c/x-men-apocalypse",
                 headers={"Cookie": _cookie_header(cookies)},
@@ -294,6 +311,10 @@ def test_production_release_smoke_core_user_flow(monkeypatch) -> None:
                 "/studio",
                 headers={"Cookie": _cookie_header(cookies)},
             )
+            studio_with_stale_session = await client.get(
+                "/studio",
+                headers={"Cookie": f"elbysodic_session={original_session}"},
+            )
 
         assert health.status == 200
         assert login.status == 302
@@ -313,6 +334,8 @@ def test_production_release_smoke_core_user_flow(monkeypatch) -> None:
         assert logout.status == 302
         assert studio_after_logout.status == 302
         assert dict(studio_after_logout.headers)["location"] == "/login?next=/studio"
+        assert studio_with_stale_session.status == 302
+        assert dict(studio_with_stale_session.headers)["location"] == "/login?next=/studio"
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary

This PR opens a narrow logged-out production surface while keeping community and workflow routes session-gated.

- Allows anonymous production access to `/` and `/network` only.
- Adds an anonymous-safe public Studio Network catalog read model that omits membership names, active faces, unread counts, staff signals, identity switch forms, and private writer queues.
- Keeps `/studio`, tenant-prefixed community pages, Desk, boards, writing, notifications, and identity actions behind session auth.
- Keeps the theme toggle available on logged-out public pages.
- Resets the sidebar hidden preference to a v2 cookie so old collapsed browser state no longer forces the community sidebar closed; fresh sessions default open.
- Updates Railway/security docs and changelog fragments for the public catalog and sidebar behavior.

## Validation

- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`

## Steward Notes

Accepted web/service/security findings: production should expose only a small anonymous catalog, route handlers should use an anonymous read model instead of fallback identity, logged-out shell chrome should still support theme controls, and sidebar persistence should default open after the cookie reset. Deferred: broader anonymous browsing of community pages, public board/thread privacy policy, and full visual redesign of the login page.