### PR TITLE
[codex] Pay down steward tech debt

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ with `ELBYSODIC_DB_PATH` or `elbysodic --db-path path/to/forum.sqlite3`.
 
 ```bash
 elbysodic init-db
+elbysodic seed-demo
 elbysodic serve --port 8001
 ```
 
@@ -200,8 +201,9 @@ the app with:
 elbysodic --host 0.0.0.0 --port $PORT --no-debug
 ```
 
-The app creates the SQLite schema and idempotently seeds the demo forum on
-startup. For a long-lived demo, attach a Railway Volume to the service. Railway
+The app creates the SQLite schema on startup. Seed the demo forum intentionally
+with `elbysodic seed-demo` before sharing demo credentials. For a long-lived
+demo, attach a Railway Volume to the service. Railway
 exposes the mount at `RAILWAY_VOLUME_MOUNT_PATH`, and Elbysodic stores SQLite at
 `$RAILWAY_VOLUME_MOUNT_PATH/elbysodic.sqlite3` unless `ELBYSODIC_DB_PATH` is set.
 The recommended mount path is `/app/var`, which also matches the local

--- a/changelog.d/+accepted-face-story-actions.fixed.md
+++ b/changelog.d/+accepted-face-story-actions.fixed.md
@@ -1,0 +1,1 @@
+Story actions now require an accepted face, so draft or revision-requested characters cannot start scenes, reply, or claim wanted and plot hooks.

--- a/changelog.d/+blueprint-admin-flag-validation.fixed.md
+++ b/changelog.d/+blueprint-admin-flag-validation.fixed.md
@@ -1,0 +1,1 @@
+Program Blueprint previews now require `program.role.is_admin` to be a real boolean instead of treating strings or numbers as staff power.

--- a/changelog.d/+blueprint-vocabulary-validation.fixed.md
+++ b/changelog.d/+blueprint-vocabulary-validation.fixed.md
@@ -1,0 +1,1 @@
+Program Blueprint previews now reject unknown director material and wanted-hook types before hydration.

--- a/changelog.d/+composer-draft-submit.fixed.md
+++ b/changelog.d/+composer-draft-submit.fixed.md
@@ -1,0 +1,1 @@
+Composer forms now preserve the latest local draft on submit instead of clearing drafts before the server confirms the post.

--- a/changelog.d/+explicit-demo-seeding.changed.md
+++ b/changelog.d/+explicit-demo-seeding.changed.md
@@ -1,0 +1,1 @@
+Database setup now keeps demo content opt-in through explicit seed commands and serve flags.

--- a/changelog.d/+post-number-allocation.fixed.md
+++ b/changelog.d/+post-number-allocation.fixed.md
@@ -1,0 +1,1 @@
+Scene replies now allocate post numbers inside a repository transaction to avoid duplicate numbering under concurrent posting.

--- a/changelog.d/+repository-vocabulary-boundaries.fixed.md
+++ b/changelog.d/+repository-vocabulary-boundaries.fixed.md
@@ -1,0 +1,1 @@
+Repository writes now reject unsupported material, wanted-hook, and plot-hook types before they can create generic board content.

--- a/changelog.d/+tenant-form-value-scoping.fixed.md
+++ b/changelog.d/+tenant-form-value-scoping.fixed.md
@@ -1,0 +1,1 @@
+Tenant URL scoping now preserves authored form values while still scoping navigation-style return fields.

--- a/docs/architecture/primitives.md
+++ b/docs/architecture/primitives.md
@@ -140,6 +140,10 @@ World materials are director-authored pillar content outside the thread format.
 They are community-scoped structured pages for premise, rules, factions,
 application guidance, events, or other board-defining material.
 
+Current material types are intentionally bounded: premise, guide, factions,
+application, and event. Repository writes reject unknown material types so
+director-authored material does not become a generic CMS page.
+
 Materials can be facet-tagged so the same world lenses can connect lore,
 characters, boards, scenes, and wanted hooks. This is the current home for
 special pages that old PBP forums often represented as pinned information
@@ -170,6 +174,8 @@ Wanted hooks can also list related characters and facets. That lets a hook like
 characters, threads, and event pages.
 
 Current statuses are intentionally small: open, reserved, filled, and archived.
+Current wanted-hook types are canon, connection, event role, faction need, plot
+role, relationship, and rival.
 Future workflows can add interest, claims, reserve expiry, staff review, and
 application spawning without turning wanted hooks into generic threads.
 
@@ -191,6 +197,7 @@ resolution, or unpublished character intent.
 
 Character plot hooks are face-authored invitations for relationship, scene, or
 arc discovery. They belong to a community, membership, and character.
+Current plot-hook types are scene, relationship, connection, event, and other.
 
 Plotting rooms are structured handoff spaces between wanted interest, character
 hooks, and scenes. They store participants, messages, planning fields, target

--- a/docs/product/program-blueprints.md
+++ b/docs/product/program-blueprints.md
@@ -212,6 +212,15 @@ The goal is for Jurassic Park, HP, RL NYC, and RL Small Town to feel like
 different rooms in one studio network while sharing Elbysodic's operational
 grammar.
 
+## Shared PBP Vocabulary
+
+Blueprint validation uses the same material and wanted-hook vocabulary as the
+rendered app labels:
+
+- Material types: `premise`, `guide`, `factions`, `application`, and `event`.
+- Wanted hook types: `canon`, `connection`, `event_role`, `faction_need`,
+  `plot_role`, `relationship`, and `rival`.
+
 ## Validation Rules
 
 Blueprint validation should fail before hydration when:
@@ -222,6 +231,8 @@ Blueprint validation should fail before hydration when:
 - A blueprint has no director materials.
 - Program, character, board, material, or wanted slugs are duplicated.
 - A board uses an unknown `board_kind`.
+- A director material uses an unknown material type.
+- A wanted hook uses an unknown wanted-hook type.
 - A board media URL is present without alt text, or alt text is present without
   a URL.
 - A board media treatment, focal point, or overlay is outside the Studio

--- a/plans/in-progress/production-readiness-roadmap-2026-05-09.md
+++ b/plans/in-progress/production-readiness-roadmap-2026-05-09.md
@@ -474,3 +474,9 @@ move before manual scene outcomes and rendered privacy proof.
   prerequisites for next primitives. Canon, public registration, partial staff
   capabilities, catalog facets, and appearance variants remain behind the
   production trust gates unless they directly close one of those gates.
+- 2026-05-09: Paid down the first steward debt pass after pulling latest main:
+  strict Blueprint staff flags, explicit demo seeding, serialized post-number
+  allocation, accepted-face requirements for story actions, production
+  application-room CSRF/privacy proof, safer tenant URL scoping for authored
+  form values, draft-preserving composer submit behavior, shared PBP
+  vocabulary validation, and repository write guards for story vocabulary.

--- a/src/elbysodic/blueprints/programs.py
+++ b/src/elbysodic/blueprints/programs.py
@@ -14,6 +14,7 @@ from elbysodic.domain.boards import (
     BOARD_IMAGE_TREATMENTS,
     BOARD_KINDS,
 )
+from elbysodic.domain.vocabulary import MATERIAL_TYPES, WANTED_TYPES
 
 THEME_FONT_KEYS: frozenset[str] = frozenset({"system", "serif", "condensed", "mono"})
 THEME_RADIUS_KEYS: frozenset[str] = frozenset({"square", "sm", "md"})
@@ -24,9 +25,7 @@ APPEARANCE_POST_ACCENT_STYLES: frozenset[str] = frozenset({"soft", "line", "glow
 APPEARANCE_POST_BORDER_STYLES: frozenset[str] = frozenset({"none", "hairline", "bracket", "double"})
 APPEARANCE_POST_TITLE_STYLES: frozenset[str] = frozenset({"standard", "serif", "condensed", "mono"})
 APPEARANCE_POST_DENSITIES: frozenset[str] = frozenset({"calm", "compact", "dramatic"})
-APPEARANCE_MATERIAL_TYPES: frozenset[str] = frozenset(
-    {"premise", "guide", "factions", "application", "event"}
-)
+APPEARANCE_MATERIAL_TYPES: frozenset[str] = MATERIAL_TYPES
 APPEARANCE_MATERIAL_VARIANTS: frozenset[str] = frozenset(
     {"chapter", "dossier", "noticeboard", "archive"}
 )
@@ -411,6 +410,12 @@ def _validate_material_blueprints(
         _require_text(errors, f"{material_path}.title", material.title)
         _require_text(errors, f"{material_path}.material_type", material.material_type)
         _require_text(errors, f"{material_path}.summary", material.summary)
+        _validate_choice(
+            errors,
+            f"{material_path}.material_type",
+            material.material_type,
+            MATERIAL_TYPES,
+        )
         material_slugs.add(material.slug)
     return material_slugs
 
@@ -428,6 +433,12 @@ def _validate_wanted_blueprints(
         _require_text(errors, f"{hook_path}.title", hook.title)
         _require_text(errors, f"{hook_path}.wanted_type", hook.wanted_type)
         _require_text(errors, f"{hook_path}.summary", hook.summary)
+        _validate_choice(
+            errors,
+            f"{hook_path}.wanted_type",
+            hook.wanted_type,
+            WANTED_TYPES,
+        )
         if hook.related_material_slug and hook.related_material_slug not in material_slugs:
             errors.append(
                 f"{hook_path}.related_material_slug references unknown material: "

--- a/src/elbysodic/blueprints/programs.py
+++ b/src/elbysodic/blueprints/programs.py
@@ -263,7 +263,7 @@ def preview_program_blueprint_yaml(source: str) -> ProgramBlueprintPreview:
         name=_text(program_data.get("name")),
         role_slug=_field(role_data, "slug"),
         role_name=_field(role_data, "name"),
-        is_admin=bool(role_data.get("is_admin")),
+        is_admin=_optional_bool_field(role_data, "is_admin", "program.role.is_admin", errors),
         characters=_characters_from_yaml(root.get("characters"), errors),
         boards=_boards_from_yaml(root.get("boards"), errors),
         materials=_materials_from_yaml(root.get("materials"), errors),
@@ -603,6 +603,21 @@ def _text(value: object) -> str:
 
 def _field(mapping: dict[str, Any], key: str) -> str:
     return _text(mapping.get(key))
+
+
+def _optional_bool_field(
+    mapping: dict[str, Any],
+    key: str,
+    path: str,
+    errors: list[str],
+) -> bool:
+    value = mapping.get(key)
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    errors.append(f"{path} must be true or false")
+    return False
 
 
 def _characters_from_yaml(value: object, errors: list[str]) -> tuple[BlueprintCharacter, ...]:

--- a/src/elbysodic/cli.py
+++ b/src/elbysodic/cli.py
@@ -16,7 +16,7 @@ def main(argv: list[str] | None = None) -> None:
 
     command = args.command or "serve"
     if command == "init-db":
-        db_path = initialize_database(args.db_path, seed_demo=not args.no_seed)
+        db_path = initialize_database(args.db_path, seed_demo=args.seed)
         sys.stdout.write(f"initialized {db_path}\n")
         return
 
@@ -25,7 +25,7 @@ def main(argv: list[str] | None = None) -> None:
         sys.stdout.write(f"seeded {db_path}\n")
         return
 
-    app = create_app(debug=args.debug, db_path=args.db_path)
+    app = create_app(debug=args.debug, db_path=args.db_path, seed_demo=args.seed_demo)
     app.run(host=args.host, port=args.port)
 
 
@@ -59,9 +59,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Create the SQLite schema.",
     )
     init_db.add_argument(
-        "--no-seed",
+        "--seed",
         action="store_true",
-        help="Create the schema without demo forum data.",
+        help="Also seed demo forum data after creating the schema.",
     )
 
     subparsers.add_parser(
@@ -92,4 +92,10 @@ def _add_serve_options(parser: argparse.ArgumentParser, *, include_defaults: boo
         action=argparse.BooleanOptionalAction,
         default=True if include_defaults else default,
         help="Enable or disable Chirp debug mode.",
+    )
+    parser.add_argument(
+        "--seed-demo",
+        action="store_true",
+        default=False if include_defaults else default,
+        help="Seed demo data during app startup.",
     )

--- a/src/elbysodic/db/repositories/base.py
+++ b/src/elbysodic/db/repositories/base.py
@@ -6,6 +6,7 @@ import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
+from threading import RLock
 
 
 class TenantBoundaryError(ValueError):
@@ -17,13 +18,19 @@ class RepositoryBase:
 
     def __init__(self, connection: sqlite3.Connection) -> None:
         self.connection = connection
+        self._transaction_lock = RLock()
         self._transaction_depth = 0
 
     @contextmanager
     def transaction(self) -> Iterator[None]:
+        self._transaction_lock.acquire()
         outermost = self._transaction_depth == 0
         if outermost:
-            self.connection.execute("BEGIN")
+            try:
+                self.connection.execute("BEGIN IMMEDIATE")
+            except Exception:
+                self._transaction_lock.release()
+                raise
         self._transaction_depth += 1
         try:
             yield
@@ -31,11 +38,13 @@ class RepositoryBase:
             self._transaction_depth -= 1
             if outermost:
                 self.connection.rollback()
+            self._transaction_lock.release()
             raise
         else:
             self._transaction_depth -= 1
             if outermost:
                 self._commit()
+            self._transaction_lock.release()
 
     def _commit(self) -> None:
         if self._transaction_depth == 0:

--- a/src/elbysodic/db/repositories/materials.py
+++ b/src/elbysodic/db/repositories/materials.py
@@ -6,6 +6,7 @@ from elbysodic.db.repositories.base import _last_id, _utc_now
 from elbysodic.db.repositories.facets import FacetRepositoryMixin
 from elbysodic.db.repositories.rows import _community_from_row, _material_from_row
 from elbysodic.domain.models import Community, Material
+from elbysodic.domain.vocabulary import MATERIAL_TYPES
 
 
 class MaterialRepositoryMixin(FacetRepositoryMixin):
@@ -23,6 +24,7 @@ class MaterialRepositoryMixin(FacetRepositoryMixin):
         is_featured: bool = False,
     ) -> Material:
         self.get_community(community_id)
+        _require_material_type(material_type)
         now = _utc_now()
         cursor = self.connection.execute(
             """
@@ -156,6 +158,7 @@ class MaterialRepositoryMixin(FacetRepositoryMixin):
         is_featured: bool = False,
     ) -> Material:
         self.get_material(community_id, material_id)
+        _require_material_type(material_type)
         self.connection.execute(
             """
             UPDATE materials
@@ -219,3 +222,9 @@ class MaterialRepositoryMixin(FacetRepositoryMixin):
             params,
         ).fetchall()
         return [_material_from_row(row) for row in rows]
+
+
+def _require_material_type(material_type: str) -> None:
+    if material_type not in MATERIAL_TYPES:
+        allowed = ", ".join(sorted(MATERIAL_TYPES))
+        raise ValueError(f"material_type must be one of: {allowed}")

--- a/src/elbysodic/db/repositories/plot_hooks.py
+++ b/src/elbysodic/db/repositories/plot_hooks.py
@@ -9,6 +9,7 @@ from elbysodic.db.repositories.rows import (
 )
 from elbysodic.db.repositories.wanted import WantedRepositoryMixin
 from elbysodic.domain.models import CharacterPlotHook, CharacterPlotHookInterest
+from elbysodic.domain.vocabulary import PLOT_HOOK_TYPES
 
 
 class PlotHookRepositoryMixin(WantedRepositoryMixin):
@@ -27,6 +28,7 @@ class PlotHookRepositoryMixin(WantedRepositoryMixin):
         status: str = "open",
     ) -> CharacterPlotHook:
         self.get_membership(community_id, author_membership_id)
+        _require_plot_hook_type(hook_type)
         character = self.get_character(community_id, character_id)
         if character.membership_id != author_membership_id:
             raise TenantBoundaryError("plot hook character must belong to author membership")
@@ -82,6 +84,7 @@ class PlotHookRepositoryMixin(WantedRepositoryMixin):
         related_material_id: int | None = None,
     ) -> CharacterPlotHook:
         self.get_character_plot_hook(community_id, plot_hook_id)
+        _require_plot_hook_type(hook_type)
         if related_material_id is not None:
             self.get_material(community_id, related_material_id)
         self.connection.execute(
@@ -404,3 +407,9 @@ class PlotHookRepositoryMixin(WantedRepositoryMixin):
         )
         self._commit()
         return self.get_character_plot_hook_interest(community_id, interest_id)
+
+
+def _require_plot_hook_type(hook_type: str) -> None:
+    if hook_type not in PLOT_HOOK_TYPES:
+        allowed = ", ".join(sorted(PLOT_HOOK_TYPES))
+        raise ValueError(f"hook_type must be one of: {allowed}")

--- a/src/elbysodic/db/repositories/posts.py
+++ b/src/elbysodic/db/repositories/posts.py
@@ -23,62 +23,63 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
         author_character_id: int,
         body: str,
     ) -> Post:
-        self.get_thread(community_id, thread_id)
-        character = self.get_character(community_id, author_character_id)
-        now = _utc_now()
-        post_number = self._next_post_number(community_id, thread_id)
-        cursor = self.connection.execute(
-            """
-            INSERT INTO posts (
-                community_id,
-                thread_id,
-                post_number,
-                author_membership_id,
-                author_character_id,
-                body,
-                created_at,
-                updated_at
+        with self.transaction():
+            self.get_thread(community_id, thread_id)
+            character = self.get_character(community_id, author_character_id)
+            now = _utc_now()
+            post_number = self._next_post_number(community_id, thread_id)
+            cursor = self.connection.execute(
+                """
+                INSERT INTO posts (
+                    community_id,
+                    thread_id,
+                    post_number,
+                    author_membership_id,
+                    author_character_id,
+                    body,
+                    created_at,
+                    updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    community_id,
+                    thread_id,
+                    post_number,
+                    character.membership_id,
+                    author_character_id,
+                    body,
+                    now,
+                    now,
+                ),
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                community_id,
-                thread_id,
-                post_number,
-                character.membership_id,
-                author_character_id,
-                body,
-                now,
-                now,
-            ),
-        )
-        self.connection.execute(
-            """
-            UPDATE community_memberships
-            SET post_count = post_count + 1
-            WHERE community_id = ? AND id = ?
-            """,
-            (community_id, character.membership_id),
-        )
-        self.connection.execute(
-            """
-            UPDATE threads
-            SET updated_at = ?
-            WHERE community_id = ? AND id = ?
-            """,
-            (now, community_id, thread_id),
-        )
-        self.connection.execute(
-            """
-            INSERT OR IGNORE INTO thread_participants (
-                community_id, thread_id, character_id, added_at
+            post_id = _last_id(cursor)
+            self.connection.execute(
+                """
+                UPDATE community_memberships
+                SET post_count = post_count + 1
+                WHERE community_id = ? AND id = ?
+                """,
+                (community_id, character.membership_id),
             )
-            VALUES (?, ?, ?, ?)
-            """,
-            (community_id, thread_id, author_character_id, now),
-        )
-        self._commit()
-        return self.get_post(community_id, _last_id(cursor))
+            self.connection.execute(
+                """
+                UPDATE threads
+                SET updated_at = ?
+                WHERE community_id = ? AND id = ?
+                """,
+                (now, community_id, thread_id),
+            )
+            self.connection.execute(
+                """
+                INSERT OR IGNORE INTO thread_participants (
+                    community_id, thread_id, character_id, added_at
+                )
+                VALUES (?, ?, ?, ?)
+                """,
+                (community_id, thread_id, author_character_id, now),
+            )
+        return self.get_post(community_id, post_id)
 
     def _next_post_number(self, community_id: int, thread_id: int) -> int:
         row = self.connection.execute(

--- a/src/elbysodic/db/repositories/wanted.py
+++ b/src/elbysodic/db/repositories/wanted.py
@@ -11,6 +11,7 @@ from elbysodic.db.repositories.rows import (
     _wanted_ad_interest_from_row,
 )
 from elbysodic.domain.models import Character, Community, WantedAd, WantedAdInterest
+from elbysodic.domain.vocabulary import WANTED_TYPES
 
 
 class WantedRepositoryMixin(MaterialRepositoryMixin):
@@ -29,6 +30,7 @@ class WantedRepositoryMixin(MaterialRepositoryMixin):
         status: str = "open",
     ) -> WantedAd:
         self.get_membership(community_id, creator_membership_id)
+        _require_wanted_type(wanted_type)
         if creator_character_id is not None:
             character = self.get_character(community_id, creator_character_id)
             if character.membership_id != creator_membership_id:
@@ -524,3 +526,9 @@ class WantedRepositoryMixin(MaterialRepositoryMixin):
         )
         self._commit()
         return self.get_wanted_ad_interest(community_id, interest_id)
+
+
+def _require_wanted_type(wanted_type: str) -> None:
+    if wanted_type not in WANTED_TYPES:
+        allowed = ", ".join(sorted(WANTED_TYPES))
+        raise ValueError(f"wanted_type must be one of: {allowed}")

--- a/src/elbysodic/db/schema.py
+++ b/src/elbysodic/db/schema.py
@@ -728,6 +728,9 @@ def connect(path: str | Path = ":memory:", *, check_same_thread: bool = True) ->
     connection = sqlite3.connect(path, check_same_thread=check_same_thread)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA busy_timeout = 5000")
+    if str(path) != ":memory:":
+        connection.execute("PRAGMA journal_mode = WAL")
     return connection
 
 

--- a/src/elbysodic/domain/__init__.py
+++ b/src/elbysodic/domain/__init__.py
@@ -71,6 +71,17 @@ from elbysodic.domain.models import (
     WantedAd,
     WantedAdInterest,
 )
+from elbysodic.domain.vocabulary import (
+    MATERIAL_TYPE_LABELS,
+    MATERIAL_TYPES,
+    PLOT_HOOK_TYPE_LABELS,
+    PLOT_HOOK_TYPES,
+    WANTED_TYPE_LABELS,
+    WANTED_TYPES,
+    material_type_label,
+    plot_hook_type_label,
+    wanted_type_label,
+)
 
 __all__ = [
     "BOARD_IMAGE_FOCAL_POINTS",
@@ -81,6 +92,12 @@ __all__ = [
     "DEFAULT_COMMUNITY_ID",
     "DEFAULT_COMMUNITY_SLUG",
     "DEFAULT_SIDEBAR_SECTION_CONFIGS",
+    "MATERIAL_TYPES",
+    "MATERIAL_TYPE_LABELS",
+    "PLOT_HOOK_TYPES",
+    "PLOT_HOOK_TYPE_LABELS",
+    "WANTED_TYPES",
+    "WANTED_TYPE_LABELS",
     "ApplicationFieldValue",
     "ApplicationTemplateField",
     "Board",
@@ -133,9 +150,12 @@ __all__ = [
     "is_location_board",
     "is_location_sidebar_board",
     "is_studio_sidebar_board",
+    "material_type_label",
     "normalize_board_image_focal_point",
     "normalize_board_image_overlay",
     "normalize_board_image_treatment",
     "normalize_board_kind",
     "normalize_board_sidebar_section",
+    "plot_hook_type_label",
+    "wanted_type_label",
 ]

--- a/src/elbysodic/domain/vocabulary.py
+++ b/src/elbysodic/domain/vocabulary.py
@@ -1,0 +1,48 @@
+"""Shared PBP vocabulary for typed story and director materials."""
+
+from __future__ import annotations
+
+MATERIAL_TYPE_LABELS: dict[str, str] = {
+    "premise": "Premise",
+    "guide": "Guide",
+    "factions": "Factions",
+    "application": "Application",
+    "event": "Event",
+}
+MATERIAL_TYPES: frozenset[str] = frozenset(MATERIAL_TYPE_LABELS)
+
+WANTED_TYPE_LABELS: dict[str, str] = {
+    "canon": "Canon",
+    "connection": "Connection",
+    "event_role": "Event Role",
+    "faction_need": "Faction Need",
+    "plot_role": "Plot Role",
+    "relationship": "Relationship",
+    "rival": "Rival",
+}
+WANTED_TYPES: frozenset[str] = frozenset(WANTED_TYPE_LABELS)
+
+PLOT_HOOK_TYPE_LABELS: dict[str, str] = {
+    "scene": "Scene",
+    "relationship": "Relationship",
+    "connection": "Connection",
+    "event": "Event",
+    "other": "Other",
+}
+PLOT_HOOK_TYPES: frozenset[str] = frozenset(PLOT_HOOK_TYPE_LABELS)
+
+
+def vocabulary_label(value: str, labels: dict[str, str]) -> str:
+    return labels.get(value, value.replace("_", " ").title())
+
+
+def material_type_label(material_type: str) -> str:
+    return vocabulary_label(material_type, MATERIAL_TYPE_LABELS)
+
+
+def wanted_type_label(wanted_type: str) -> str:
+    return vocabulary_label(wanted_type, WANTED_TYPE_LABELS)
+
+
+def plot_hook_type_label(hook_type: str) -> str:
+    return vocabulary_label(hook_type, PLOT_HOOK_TYPE_LABELS)

--- a/src/elbysodic/services/access.py
+++ b/src/elbysodic/services/access.py
@@ -54,7 +54,7 @@ class RequestIdentityResolver:
     def __init__(
         self,
         repo: AccessRepository,
-        default: DefaultRequestIdentity,
+        default: DefaultRequestIdentity | None,
         *,
         allow_development_identity: bool = True,
         require_session: bool = False,
@@ -128,12 +128,19 @@ class RequestIdentityResolver:
                     membership_id=membership.id,
                 )
 
-        resolved_user_id = user_id if user_id is not None else self._default.user_id
+        if user_id is None:
+            if self._default is None:
+                raise PermissionError("login is required")
+            resolved_user_id = self._default.user_id
+        else:
+            resolved_user_id = user_id
         try:
             self._repo.get_user(resolved_user_id)
         except LookupError:
             if not user_from_cookie:
                 raise PermissionError(f"{DEV_USER_HEADER} must identify a known user") from None
+            if self._default is None:
+                raise PermissionError("login is required") from None
             resolved_user_id = self._default.user_id
             self._repo.get_user(resolved_user_id)
         membership = self._repo.get_membership_for_user(community.id, resolved_user_id)
@@ -186,6 +193,8 @@ class RequestIdentityResolver:
             except LookupError:
                 pass
 
+        if self._default is None:
+            raise PermissionError("login is required")
         default_community = self._repo.get_community(self._default.community_id)
         if external_host is not None and default_community.host:
             raise LookupError(f"community not found for host: {external_host}")

--- a/src/elbysodic/services/casting.py
+++ b/src/elbysodic/services/casting.py
@@ -301,6 +301,7 @@ def read_wanted_ad(
         can_express_interest=(
             wanted_ad.status == "open"
             and viewer.current_character is not None
+            and policies.can_story_act_as(viewer.membership, viewer.current_character)
             and viewer_interest is None
             and not is_created_by_viewer
         ),
@@ -348,6 +349,10 @@ def express_wanted_interest(
 ) -> WantedAdInterest:
     if viewer.current_character is None:
         raise ValueError("create a character before expressing interest")
+    if not policies.can_story_act_as(viewer.membership, viewer.current_character):
+        raise PermissionError(
+            f"membership {viewer.membership.id} cannot use character {viewer.current_character.id}"
+        )
     wanted_ad = repo.get_wanted_ad_by_slug(viewer.community.id, wanted_slug)
     if wanted_ad.status != "open":
         raise ValueError(f"wanted hook {wanted_ad.id} is not open")

--- a/src/elbysodic/services/casting.py
+++ b/src/elbysodic/services/casting.py
@@ -13,6 +13,7 @@ from elbysodic.domain.models import (
     WantedAd,
     WantedAdInterest,
 )
+from elbysodic.domain.vocabulary import wanted_type_label
 from elbysodic.services import policies
 from elbysodic.services.facets import FacetReadRepository, facet_tags
 from elbysodic.services.markup import render_prose_body
@@ -529,17 +530,6 @@ def wanted_ad_summary(
         ),
         type_label=wanted_type_label(wanted_ad.wanted_type),
     )
-
-
-def wanted_type_label(wanted_type: str) -> str:
-    return {
-        "canon": "Canon",
-        "connection": "Connection",
-        "event_role": "Event Role",
-        "faction_need": "Faction Need",
-        "plot_role": "Plot Role",
-        "rival": "Rival",
-    }.get(wanted_type, wanted_type.replace("_", " ").title())
 
 
 def wanted_ad_interest_view(

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -266,29 +266,31 @@ class AppServices:
     def __init__(
         self,
         repo: ForumRepository,
-        seed: DemoSeed,
+        seed: DemoSeed | None,
         *,
         identity_resolver: RequestIdentityResolver | None = None,
         identity_context: RequestIdentityContext | None = None,
     ) -> None:
         self.repo = repo
-        self.seed = seed
+        self._seed = seed
         self._identity_resolver = identity_resolver or RequestIdentityResolver(
             repo,
-            DefaultRequestIdentity(
-                community_id=seed.community.id,
-                user_id=seed.user.id,
-                membership_id=seed.membership.id,
-            ),
+            _default_request_identity(seed),
         )
         self._identity_context = identity_context
+
+    @property
+    def seed(self) -> DemoSeed:
+        if self._seed is None:
+            raise RuntimeError("demo seed is not configured for these services")
+        return self._seed
 
     def for_request(self, request: object) -> AppServices:
         """Return a request-scoped facade sharing the same repository."""
 
         return AppServices(
             self.repo,
-            self.seed,
+            self._seed,
             identity_resolver=self._identity_resolver,
             identity_context=self._identity_resolver.resolve(request),
         )
@@ -298,14 +300,10 @@ class AppServices:
 
         return AppServices(
             self.repo,
-            self.seed,
+            self._seed,
             identity_resolver=RequestIdentityResolver(
                 self.repo,
-                DefaultRequestIdentity(
-                    community_id=self.seed.community.id,
-                    user_id=self.seed.user.id,
-                    membership_id=self.seed.membership.id,
-                ),
+                _default_request_identity(self._seed),
                 allow_development_identity=not production,
                 require_session=production,
             ),
@@ -494,7 +492,7 @@ class AppServices:
             current_identity = self._identity_context or self._identity_resolver.resolve()
             preferred_community_id = current_identity.community_id
         except PermissionError:
-            preferred_community_id = self.seed.community.id
+            preferred_community_id = None if self._seed is None else self._seed.community.id
         identity = self._default_identity_for_user(
             session.user.id,
             preferred_community_id=preferred_community_id,
@@ -2415,18 +2413,18 @@ class AppServices:
         return board, thread
 
 
-def create_services(path: str | Path | None = None) -> AppServices:
+def create_services(path: str | Path | None = None, *, seed_demo: bool = True) -> AppServices:
     database_path = _resolve_database_path(path)
     if database_path != ":memory:":
         Path(database_path).parent.mkdir(parents=True, exist_ok=True)
     connection = connect(database_path, check_same_thread=False)
     create_schema(connection)
     repo = ForumRepository(connection)
-    seed = seed_demo_forum(repo)
+    seed = seed_demo_forum(repo) if seed_demo else None
     return AppServices(repo, seed)
 
 
-def initialize_database(path: str | Path | None = None, *, seed_demo: bool = True) -> Path:
+def initialize_database(path: str | Path | None = None, *, seed_demo: bool = False) -> Path:
     database_path = _resolve_database_path(path)
     if database_path == ":memory:":
         raise ValueError("persistent database initialization requires a filesystem path")
@@ -2456,6 +2454,16 @@ def _resolve_database_path(path: str | Path | None) -> str | Path:
     if path is None:
         return default_database_path()
     return path
+
+
+def _default_request_identity(seed: DemoSeed | None) -> DefaultRequestIdentity | None:
+    if seed is None:
+        return None
+    return DefaultRequestIdentity(
+        community_id=seed.community.id,
+        user_id=seed.user.id,
+        membership_id=seed.membership.id,
+    )
 
 
 def _resolve_current_character(

--- a/src/elbysodic/services/materials.py
+++ b/src/elbysodic/services/materials.py
@@ -15,6 +15,7 @@ from elbysodic.domain.models import (
     Thread,
     WantedAd,
 )
+from elbysodic.domain.vocabulary import material_type_label
 from elbysodic.services import policies
 from elbysodic.services.facets import FacetReadRepository, facet_tags
 from elbysodic.services.markup import post_snippet, render_prose_body
@@ -218,16 +219,6 @@ def related_materials(
             continue
         related.append(material_summary(repo, community_id, candidate))
     return related
-
-
-def material_type_label(material_type: str) -> str:
-    return {
-        "premise": "Premise",
-        "guide": "Guide",
-        "factions": "Factions",
-        "application": "Application",
-        "event": "Event",
-    }.get(material_type, material_type.replace("_", " ").title())
 
 
 def material_related_locations(

--- a/src/elbysodic/services/plot_hooks.py
+++ b/src/elbysodic/services/plot_hooks.py
@@ -13,6 +13,7 @@ from elbysodic.domain.models import (
     Facet,
     Material,
 )
+from elbysodic.domain.vocabulary import PLOT_HOOK_TYPE_LABELS, plot_hook_type_label
 from elbysodic.services import policies
 from elbysodic.services.facets import (
     FacetReadRepository,
@@ -31,7 +32,7 @@ from elbysodic.services.read_models import (
 from elbysodic.services.timestamps import timestamp_label
 
 PLOT_HOOK_STATUSES = ("open", "plotting", "paused", "closed", "archived")
-PLOT_HOOK_TYPES = ("scene", "relationship", "connection", "event", "other")
+PLOT_HOOK_TYPES = tuple(PLOT_HOOK_TYPE_LABELS)
 
 
 class PlotHookReadRepository(FacetReadRepository, PostViewRepository, Protocol):
@@ -386,16 +387,6 @@ def plot_hook_interest_view(
         character=repo.get_character(community_id, interest.character_id),
         created_at_label=timestamp_label(interest.created_at),
     )
-
-
-def plot_hook_type_label(hook_type: str) -> str:
-    return {
-        "scene": "Scene",
-        "relationship": "Relationship",
-        "connection": "Connection",
-        "event": "Event",
-        "other": "Other",
-    }.get(hook_type, hook_type.replace("_", " ").title())
 
 
 def can_manage_plot_hook(viewer: ForumView, plot_hook: CharacterPlotHook) -> bool:

--- a/src/elbysodic/services/plot_hooks.py
+++ b/src/elbysodic/services/plot_hooks.py
@@ -241,6 +241,7 @@ def read_plot_hook(
         can_express_interest=(
             plot_hook.status == "open"
             and viewer.current_character is not None
+            and policies.can_story_act_as(viewer.membership, viewer.current_character)
             and viewer_interest is None
             and plot_hook.author_membership_id != viewer.membership.id
         ),
@@ -265,7 +266,7 @@ def create_plot_hook(
     facet_slugs: list[str],
 ) -> CharacterPlotHook:
     character = repo.get_character_by_slug(viewer.community.id, character_slug)
-    if not policies.can_post_as(viewer.membership, character):
+    if not policies.can_story_act_as(viewer.membership, character):
         raise PermissionError(
             f"membership {viewer.membership.id} cannot create hooks for character {character.id}"
         )
@@ -348,6 +349,10 @@ def express_plot_hook_interest(
 ) -> CharacterPlotHookInterest:
     if viewer.current_character is None:
         raise ValueError("create a character before expressing interest")
+    if not policies.can_story_act_as(viewer.membership, viewer.current_character):
+        raise PermissionError(
+            f"membership {viewer.membership.id} cannot use character {viewer.current_character.id}"
+        )
     detail = read_plot_hook(repo, viewer, character_slug, hook_slug)
     if detail.plot_hook.status != "open":
         raise ValueError(f"plot hook {detail.plot_hook.id} is not open")

--- a/src/elbysodic/services/policies.py
+++ b/src/elbysodic/services/policies.py
@@ -105,6 +105,10 @@ def can_post_as(membership: CommunityMembership, character: Character) -> bool:
     )
 
 
+def can_story_act_as(membership: CommunityMembership, character: Character) -> bool:
+    return can_post_as(membership, character) and character.application_status == "accepted"
+
+
 def can_edit_post(
     membership: CommunityMembership,
     post: Post,

--- a/src/elbysodic/services/posting.py
+++ b/src/elbysodic/services/posting.py
@@ -311,7 +311,7 @@ def join_thread_as_current_character(
         raise PermissionError(f"thread {thread.id} is not open to join")
     if not policies.can_reply(viewer.membership, thread, viewer.role):
         raise PermissionError(f"membership {viewer.membership.id} cannot join thread {thread.id}")
-    if not policies.can_post_as(viewer.membership, viewer.current_character):
+    if not policies.can_story_act_as(viewer.membership, viewer.current_character):
         raise PermissionError(
             f"membership {viewer.membership.id} cannot use character {viewer.current_character.id}"
         )
@@ -332,7 +332,7 @@ def reply_to_thread(
     body: str,
 ) -> Post:
     character = repo.get_character(viewer.community.id, character_id)
-    if not policies.can_post_as(viewer.membership, character):
+    if not policies.can_story_act_as(viewer.membership, character):
         raise PermissionError(
             f"membership {viewer.membership.id} cannot use character {character_id}"
         )
@@ -367,7 +367,7 @@ def start_thread(
     participant_ids: list[int] | None = None,
 ) -> CreatedThread:
     character = repo.get_character(viewer.community.id, character_id)
-    if not policies.can_post_as(viewer.membership, character):
+    if not policies.can_story_act_as(viewer.membership, character):
         raise PermissionError(
             f"membership {viewer.membership.id} cannot use character {character_id}"
         )

--- a/src/elbysodic/web/app.py
+++ b/src/elbysodic/web/app.py
@@ -39,6 +39,7 @@ def create_app(
     services: AppServices | None = None,
     db_path: str | Path | None = None,
     dev_tools: bool | None = None,
+    seed_demo: bool = False,
 ) -> App:
     security = resolve_web_security_config(debug=debug)
     config = AppConfig(
@@ -51,9 +52,9 @@ def create_app(
     )
     app = App(config=config)
     register_error_handlers(app, include_internal=not debug)
-    configured_services = (services or create_services(db_path)).with_request_auth(
-        production=security.production
-    )
+    configured_services = (
+        services or create_services(db_path, seed_demo=seed_demo)
+    ).with_request_auth(production=security.production)
 
     configure_services(
         configured_services,

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.html
@@ -36,7 +36,7 @@
         hx-boost="false"
         class="chirpui-stack chirpui-stack--md elbysodic-composer elbysodic-composer--opening"
         x-data="elbysodicComposer('{{ composer_config_id }}')"
-        @submit="clearDraft()">
+        @submit="submitDraft()">
     <div class="elbysodic-composer-heading">
       <div>
         <p class="elbysodic-kicker">Scene draft</p>

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
@@ -416,7 +416,7 @@
           hx-boost="false"
           class="chirpui-stack chirpui-stack--md elbysodic-composer elbysodic-composer--reply"
           x-data="elbysodicComposer('{{ composer_config_id }}')"
-          @submit="clearDraft()">
+          @submit="submitDraft()">
       <input type="hidden" name="intent" value="reply">
       <div class="elbysodic-composer-heading">
         <div>

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.html
@@ -27,7 +27,7 @@
         hx-boost="false"
         class="chirpui-stack chirpui-stack--md"
         x-data="elbysodicComposer('{{ composer_config_id }}')"
-        @submit="clearDraft()">
+        @submit="submitDraft()">
     <div class="elbysodic-composer-heading">
       <div>
         <h2>{{ edit_view.thread.title }}</h2>

--- a/src/elbysodic/web/static/elbysodic-composer.js
+++ b/src/elbysodic/web/static/elbysodic-composer.js
@@ -495,6 +495,10 @@
         this.draftState = "";
       },
 
+      submitDraft() {
+        this.saveDraft();
+      },
+
       closeBodyMention() {
         this.bodyMentionOpen = false;
         this.bodyMentionHighlightedIndex = 0;

--- a/src/elbysodic/web/tenant.py
+++ b/src/elbysodic/web/tenant.py
@@ -50,8 +50,12 @@ _UNSCOPED_PATH_PREFIXES = (
     "/static",
 )
 _URL_ATTR_RE = re.compile(
-    r'(?P<attr>\b(?:href|action|value|sse-connect|hx-(?:get|post|put|patch|delete))=["\'])'
+    r'(?P<attr>\b(?:href|action|sse-connect|hx-(?:get|post|put|patch|delete))=["\'])'
     r'(?P<url>/[^"\']*)'
+)
+_FORM_URL_VALUE_RE = re.compile(
+    r'(?P<attr><input\b(?=[^>]*\bname=["\'](?:next|redirect|return_to)["\'])'
+    r'[^>]*\bvalue=["\'])(?P<url>/[^"\']*)'
 )
 
 
@@ -167,7 +171,7 @@ def _scope_html_links(html: str, community_slug: str) -> str:
         url = match.group("url")
         return f"{match.group('attr')}{scoped_path(community_slug, url)}"
 
-    return _URL_ATTR_RE.sub(replace_match, html)
+    return _FORM_URL_VALUE_RE.sub(replace_match, _URL_ATTR_RE.sub(replace_match, html))
 
 
 def _scope_query(community_slug: str, query: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from elbysodic import cli
+from elbysodic.db import connect
+from elbysodic.services import initialize_database
 
 RAILWAY_HOST = ".".join(("0", "0", "0", "0"))
 
@@ -19,9 +21,10 @@ class _FakeApp:
 def test_cli_can_start_production_server_on_railway_host_and_port(monkeypatch) -> None:
     calls: dict[str, object] = {}
 
-    def fake_create_app(*, debug: bool, db_path: Path) -> _FakeApp:
+    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
         calls["debug"] = debug
         calls["db_path"] = db_path
+        calls["seed_demo"] = seed_demo
         return _FakeApp(calls)
 
     monkeypatch.setattr(cli, "create_app", fake_create_app)
@@ -29,6 +32,7 @@ def test_cli_can_start_production_server_on_railway_host_and_port(monkeypatch) -
     cli.main(["--host", RAILWAY_HOST, "--port", "1234", "--no-debug"])
 
     assert calls["debug"] is False
+    assert calls["seed_demo"] is False
     assert calls["host"] == RAILWAY_HOST
     assert calls["port"] == 1234
 
@@ -36,9 +40,10 @@ def test_cli_can_start_production_server_on_railway_host_and_port(monkeypatch) -
 def test_cli_serve_subcommand_accepts_same_server_options(monkeypatch) -> None:
     calls: dict[str, object] = {}
 
-    def fake_create_app(*, debug: bool, db_path: Path) -> _FakeApp:
+    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
         calls["debug"] = debug
         calls["db_path"] = db_path
+        calls["seed_demo"] = seed_demo
         return _FakeApp(calls)
 
     monkeypatch.setattr(cli, "create_app", fake_create_app)
@@ -46,5 +51,78 @@ def test_cli_serve_subcommand_accepts_same_server_options(monkeypatch) -> None:
     cli.main(["serve", "--host", RAILWAY_HOST, "--port", "5678", "--no-debug"])
 
     assert calls["debug"] is False
+    assert calls["seed_demo"] is False
     assert calls["host"] == RAILWAY_HOST
     assert calls["port"] == 5678
+
+
+def test_cli_serve_can_explicitly_seed_demo_data(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
+        calls["debug"] = debug
+        calls["db_path"] = db_path
+        calls["seed_demo"] = seed_demo
+        return _FakeApp(calls)
+
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+
+    cli.main(["serve", "--seed-demo"])
+
+    assert calls["seed_demo"] is True
+
+
+def test_cli_init_db_creates_schema_without_demo_seed_by_default(monkeypatch, tmp_path) -> None:
+    calls: dict[str, object] = {}
+    db_path = tmp_path / "forum.sqlite3"
+
+    def fake_initialize_database(path: Path, *, seed_demo: bool) -> Path:
+        calls["path"] = path
+        calls["seed_demo"] = seed_demo
+        return path
+
+    monkeypatch.setattr(cli, "initialize_database", fake_initialize_database)
+
+    cli.main(["init-db", "--db-path", str(db_path)])
+
+    assert calls == {"path": db_path, "seed_demo": False}
+
+
+def test_cli_init_db_can_explicitly_seed_demo_data(monkeypatch, tmp_path) -> None:
+    calls: dict[str, object] = {}
+    db_path = tmp_path / "forum.sqlite3"
+
+    def fake_initialize_database(path: Path, *, seed_demo: bool) -> Path:
+        calls["path"] = path
+        calls["seed_demo"] = seed_demo
+        return path
+
+    monkeypatch.setattr(cli, "initialize_database", fake_initialize_database)
+
+    cli.main(["init-db", "--db-path", str(db_path), "--seed"])
+
+    assert calls == {"path": db_path, "seed_demo": True}
+
+
+def test_initialize_database_leaves_demo_seed_explicit(tmp_path) -> None:
+    db_path = tmp_path / "forum.sqlite3"
+
+    initialize_database(db_path)
+    connection = connect(db_path)
+    try:
+        community_count = connection.execute("SELECT COUNT(*) FROM communities").fetchone()[0]
+    finally:
+        connection.close()
+
+    assert community_count == 0
+
+    initialize_database(db_path, seed_demo=True)
+    connection = connect(db_path)
+    try:
+        seeded_community_count = connection.execute("SELECT COUNT(*) FROM communities").fetchone()[
+            0
+        ]
+    finally:
+        connection.close()
+
+    assert seeded_community_count > 0

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -4288,6 +4288,76 @@ def test_character_plot_hooks_render_create_and_notify_interest() -> None:
     asyncio.run(run())
 
 
+def test_unaccepted_faces_cannot_take_story_actions() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    community = services.seed.community
+    assert services.seed.default_character is not None
+    character = repo.update_character_application_status(
+        community.id,
+        services.seed.default_character.id,
+        "submitted",
+    )
+    thread = repo.get_thread_by_slug(
+        community.id,
+        repo.get_board_by_slug(community.id, "danger-room").id,
+        "sentinel-drill",
+    )
+    role = repo.get_role_by_slug(community.id, "member")
+    other_user = repo.create_user("story-counterparty@example.com", "hash")
+    other_membership = repo.create_membership(
+        community.id,
+        other_user.id,
+        role.id,
+        "storycounter",
+        "Story Counter",
+    )
+    other_character = repo.create_character(
+        community.id,
+        other_membership.id,
+        "story-counter-face",
+        "Story Counter Face",
+    )
+    repo.create_character_plot_hook(
+        community.id,
+        other_membership.id,
+        other_character.id,
+        "outside-hook",
+        "Outside hook",
+        summary="A hook for someone else.",
+    )
+    repo.create_wanted_ad(
+        community.id,
+        other_membership.id,
+        "outside-wanted",
+        "Outside wanted",
+        summary="A wanted hook for someone else.",
+    )
+
+    with pytest.raises(PermissionError):
+        services.start_thread(
+            board_slug="danger-room",
+            character_id=character.id,
+            title="Submitted face scene",
+            body="This should wait for acceptance.",
+        )
+    with pytest.raises(PermissionError):
+        services.reply_to_thread("danger-room", thread.slug, character.id, "Not yet.")
+    with pytest.raises(PermissionError):
+        services.create_plot_hook(
+            character.slug,
+            title="Submitted face hook",
+            hook_type="scene",
+            summary="This should wait.",
+            body="This should wait for acceptance.",
+            facet_slugs=[],
+        )
+    with pytest.raises(PermissionError):
+        services.express_plot_hook_interest("story-counter-face", "outside-hook")
+    with pytest.raises(PermissionError):
+        services.express_wanted_interest("outside-wanted")
+
+
 def test_wanted_hooks_accept_prospective_character_interest() -> None:
     async def run() -> None:
         _app()

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode
 
 import pytest
 from chirp.app import App
+from chirp.http.response import Response
 from chirp.testing import TestClient
 from chirp_ui.alpine import check_alpine_runtime
 
@@ -19,6 +20,7 @@ from elbysodic.domain import Community, Thread
 from elbysodic.services import AppServices, create_services, default_database_path
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
+from elbysodic.web.tenant import scope_response_urls
 
 _FORM = {"Content-Type": "application/x-www-form-urlencoded"}
 
@@ -407,6 +409,27 @@ def test_tenant_prefixed_route_keeps_scoped_links_inside_prefix() -> None:
         assert 'href="/c/jurassic-park-universe/elbysodic-static' not in response.text
 
     asyncio.run(run())
+
+
+def test_tenant_scoping_preserves_authored_form_values() -> None:
+    response = Response(
+        """
+        <a href="/world">World</a>
+        <form action="/boards/danger-room/threads/new">
+          <input name="title" value="/not-a-route">
+          <input name="next" value="/boards/danger-room">
+        </form>
+        """,
+        content_type="text/html",
+    )
+
+    scoped = scope_response_urls(response, "x-men-apocalypse")
+
+    assert isinstance(scoped.body, str)
+    assert 'href="/c/x-men-apocalypse/world"' in scoped.body
+    assert 'action="/c/x-men-apocalypse/boards/danger-room/threads/new"' in scoped.body
+    assert 'name="title" value="/not-a-route"' in scoped.body
+    assert 'name="next" value="/c/x-men-apocalypse/boards/danger-room"' in scoped.body
 
 
 def test_unknown_tenant_prefix_returns_not_found() -> None:

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -432,6 +432,22 @@ def test_tenant_scoping_preserves_authored_form_values() -> None:
     assert 'name="next" value="/c/x-men-apocalypse/boards/danger-room"' in scoped.body
 
 
+def test_composer_forms_save_drafts_on_submit_instead_of_clearing_early() -> None:
+    composer_paths = [
+        Path("src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.html"),
+        Path("src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html"),
+        Path(
+            "src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/"
+            "{post_id}/edit/page.html"
+        ),
+    ]
+
+    for path in composer_paths:
+        template = path.read_text(encoding="utf-8")
+        assert '@submit="clearDraft()"' not in template
+        assert '@submit="submitDraft()"' in template
+
+
 def test_unknown_tenant_prefix_returns_not_found() -> None:
     async def run() -> None:
         app = _app()

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from elbysodic.domain.models import Board, CommunityMembership, Post, Role, Thread
+from elbysodic.domain.models import Board, Character, CommunityMembership, Post, Role, Thread
 from elbysodic.services import policies
 
 
@@ -164,3 +164,39 @@ def test_staff_can_edit_posts_through_thread_management_capability(
 
     assert policies.can_edit_post(membership, post, admin_role)
     assert not policies.can_edit_post(membership, post, member_role)
+
+
+def test_story_actions_require_accepted_character(membership: CommunityMembership) -> None:
+    accepted = Character(
+        id=40,
+        community_id=membership.community_id,
+        membership_id=membership.id,
+        name="Accepted Face",
+        slug="accepted-face",
+        avatar_url=None,
+        poster_url=None,
+        poster_alt="",
+        tagline="",
+        accent_color="",
+        summary="Ready for scenes.",
+        post_profile_variant="bio",
+        post_accent_style="soft",
+        post_border_style="hairline",
+        post_title_style="standard",
+        post_density="calm",
+        application_status="accepted",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+    submitted = replace(accepted, id=41, slug="submitted-face", application_status="submitted")
+    revision_requested = replace(
+        accepted,
+        id=42,
+        slug="revision-face",
+        application_status="revision_requested",
+    )
+
+    assert policies.can_post_as(membership, submitted)
+    assert policies.can_story_act_as(membership, accepted)
+    assert not policies.can_story_act_as(membership, submitted)
+    assert not policies.can_story_act_as(membership, revision_requested)

--- a/tests/test_program_blueprints.py
+++ b/tests/test_program_blueprints.py
@@ -465,6 +465,89 @@ wanted:
     assert preview.wanted_count == 1
 
 
+@pytest.mark.parametrize(
+    ("role_yaml", "expected_is_admin"),
+    (
+        ("is_admin: true", True),
+        ("is_admin: false", False),
+        ("", False),
+    ),
+)
+def test_program_blueprint_yaml_preview_parses_admin_flag_strictly(
+    role_yaml: str,
+    expected_is_admin: bool,
+) -> None:
+    preview = preview_program_blueprint_yaml(
+        f"""
+elbysodic_blueprint: 1
+program:
+  slug: rl-small-town
+  name: RL Small Town
+  role:
+    slug: director
+    name: Director
+    {role_yaml}
+characters:
+  - slug: june-calloway
+    name: June Calloway
+    summary: Florist and town council note-taker.
+boards:
+  - slug: main-street
+    name: Main Street
+    kind: location
+    tagline: One stoplight, twelve opinions.
+    description: The town's public spine.
+materials:
+  - slug: premise
+    title: Premise
+    type: premise
+    summary: A small-town ensemble.
+    body: Founder's Week should be a cozy pressure cooker.
+"""
+    )
+
+    assert preview.is_valid
+    assert preview.blueprint is not None
+    assert preview.blueprint.is_admin is expected_is_admin
+
+
+@pytest.mark.parametrize("role_yaml", ("is_admin: 'false'", "is_admin: 'true'", "is_admin: 1"))
+def test_program_blueprint_yaml_preview_rejects_non_boolean_admin_flag(role_yaml: str) -> None:
+    preview = preview_program_blueprint_yaml(
+        f"""
+elbysodic_blueprint: 1
+program:
+  slug: rl-small-town
+  name: RL Small Town
+  role:
+    slug: director
+    name: Director
+    {role_yaml}
+characters:
+  - slug: june-calloway
+    name: June Calloway
+    summary: Florist and town council note-taker.
+boards:
+  - slug: main-street
+    name: Main Street
+    kind: location
+    tagline: One stoplight, twelve opinions.
+    description: The town's public spine.
+materials:
+  - slug: premise
+    title: Premise
+    type: premise
+    summary: A small-town ensemble.
+    body: Founder's Week should be a cozy pressure cooker.
+"""
+    )
+
+    assert not preview.is_valid
+    assert "program.role.is_admin must be true or false" in preview.errors
+    assert preview.blueprint is not None
+    assert preview.blueprint.is_admin is False
+
+
 def test_program_blueprint_yaml_preview_reports_parse_and_validation_errors() -> None:
     parse_preview = preview_program_blueprint_yaml("program: [")
     validation_preview = preview_program_blueprint_yaml(

--- a/tests/test_program_blueprints.py
+++ b/tests/test_program_blueprints.py
@@ -286,6 +286,34 @@ def test_program_blueprint_reports_unknown_board_kind() -> None:
     assert any(".board_kind must be one of:" in error for error in errors)
 
 
+def test_program_blueprint_reports_unknown_material_and_wanted_types() -> None:
+    blueprint = _blueprint(
+        materials=(
+            BlueprintMaterial(
+                "mood-board",
+                "Mood Board",
+                "cms_page",
+                "A generic page that should not hydrate.",
+                "This is not a director material type.",
+            ),
+        ),
+        wanted=(
+            BlueprintWanted(
+                "anyone",
+                "Anyone",
+                "generic_listing",
+                "A generic listing that should not hydrate.",
+                "Wanted hooks should use the shared PBP vocabulary.",
+            ),
+        ),
+    )
+
+    errors = validate_program_blueprint(blueprint)
+
+    assert any(".materials.mood-board.material_type must be one of:" in error for error in errors)
+    assert any(".wanted.anyone.wanted_type must be one of:" in error for error in errors)
+
+
 def test_program_blueprint_accepts_safe_board_media_payload() -> None:
     preview = preview_program_blueprint_yaml(
         """
@@ -467,11 +495,11 @@ wanted:
 
 @pytest.mark.parametrize(
     ("role_yaml", "expected_is_admin"),
-    (
+    [
         ("is_admin: true", True),
         ("is_admin: false", False),
         ("", False),
-    ),
+    ],
 )
 def test_program_blueprint_yaml_preview_parses_admin_flag_strictly(
     role_yaml: str,
@@ -511,7 +539,7 @@ materials:
     assert preview.blueprint.is_admin is expected_is_admin
 
 
-@pytest.mark.parametrize("role_yaml", ("is_admin: 'false'", "is_admin: 'true'", "is_admin: 1"))
+@pytest.mark.parametrize("role_yaml", ["is_admin: 'false'", "is_admin: 'true'", "is_admin: 1"])
 def test_program_blueprint_yaml_preview_rejects_non_boolean_admin_flag(role_yaml: str) -> None:
     preview = preview_program_blueprint_yaml(
         f"""

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -1579,6 +1579,68 @@ def test_plotting_room_participants_are_unique_for_nullable_identity(
     ]
 
 
+def test_repository_rejects_unknown_story_vocabulary(repo: ForumRepository) -> None:
+    community = repo.get_community(1)
+    role = repo.create_role(community.id, "member", "Member")
+    user = repo.create_user("vocabulary@example.com", "hash")
+    membership = repo.create_membership(community.id, user.id, role.id, "writer", "Writer")
+    character = repo.create_character(community.id, membership.id, "rogue", "Rogue")
+    material = repo.create_material(
+        community.id,
+        "premise",
+        "Premise",
+        material_type="premise",
+        summary="A valid director material.",
+    )
+    hook = repo.create_character_plot_hook(
+        community.id,
+        membership.id,
+        character.id,
+        "open-scene",
+        "Open scene",
+        hook_type="scene",
+    )
+
+    with pytest.raises(ValueError, match="material_type must be one of:"):
+        repo.create_material(community.id, "cms-page", "CMS Page", material_type="cms_page")
+    with pytest.raises(ValueError, match="material_type must be one of:"):
+        repo.update_material(
+            community.id,
+            material.id,
+            title=material.title,
+            material_type="cms_page",
+            summary=material.summary,
+            body=material.body,
+        )
+    with pytest.raises(ValueError, match="wanted_type must be one of:"):
+        repo.create_wanted_ad(
+            community.id,
+            membership.id,
+            "generic-listing",
+            "Generic listing",
+            wanted_type="generic_listing",
+        )
+    with pytest.raises(ValueError, match="hook_type must be one of:"):
+        repo.create_character_plot_hook(
+            community.id,
+            membership.id,
+            character.id,
+            "generic-hook",
+            "Generic hook",
+            hook_type="generic_hook",
+        )
+    with pytest.raises(ValueError, match="hook_type must be one of:"):
+        repo.update_character_plot_hook(
+            community.id,
+            hook.id,
+            title=hook.title,
+            hook_type="generic_hook",
+            summary=hook.summary,
+            body=hook.body,
+            status=hook.status,
+        )
+
+
 def test_threads_and_posts_cannot_cross_community_boundaries(repo: ForumRepository) -> None:
     default = repo.get_community(1)
     hosted = repo.create_community("hosted", "Hosted Test")

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -1653,6 +1654,50 @@ def test_threads_and_posts_cannot_cross_community_boundaries(repo: ForumReposito
 
     with pytest.raises(LookupError):
         repo.create_post(hosted.id, post.id, hosted_character.id, "Wrong community.")
+
+
+def test_concurrent_post_creation_assigns_unique_post_numbers(tmp_path) -> None:
+    connection = connect(tmp_path / "forum.sqlite3", check_same_thread=False)
+    try:
+        create_schema(connection)
+        repository = ForumRepository(connection)
+        community = repository.seed_default_community()
+        user = repository.create_user("writer@example.com", "hash")
+        role = repository.create_role(community.id, "member", "Member")
+        membership = repository.create_membership(
+            community.id,
+            user.id,
+            role.id,
+            "lark",
+            "Lark",
+        )
+        character = repository.create_character(community.id, membership.id, "rogue", "Rogue")
+        board = repository.create_board(community.id, "ic", "In Character")
+        thread = repository.create_thread(
+            community.id,
+            board.id,
+            character.id,
+            "opening-scene",
+            "Opening Scene",
+        )
+
+        def create_reply(index: int) -> int:
+            return repository.create_post(
+                community.id,
+                thread.id,
+                character.id,
+                f"Concurrent beat {index}.",
+            ).post_number
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            post_numbers = list(executor.map(create_reply, range(8)))
+
+        posts = repository.list_posts(community.id, thread.id)
+    finally:
+        connection.close()
+
+    assert sorted(post_numbers) == list(range(1, 9))
+    assert [post.post_number for post in posts] == list(range(1, 9))
 
 
 def test_thread_flags_sort_pinned_threads_first(repo: ForumRepository) -> None:

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -415,6 +415,88 @@ def test_production_membership_switch_is_session_bound(monkeypatch) -> None:
     asyncio.run(run())
 
 
+def test_production_application_room_requires_csrf_and_accepts_rendered_token(
+    monkeypatch,
+) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+        services = get_services()
+        community = services.seed.community
+        kitty = services.repo.get_character_by_slug(community.id, "kitty-pryde")
+
+        async with TestClient(app) as client:
+            _login, cookies = await _production_login(
+                client,
+                email="alex@example.com",
+                next_url="/applications/kitty-pryde",
+            )
+            room = await client.get(
+                "/applications/kitty-pryde",
+                headers={"Cookie": _cookie_header(cookies)},
+            )
+            cookies.update(_cookie_values(room))
+            missing_csrf = await client.post(
+                "/applications/kitty-pryde",
+                body=urlencode(
+                    {
+                        "intent": "save_review",
+                        "staff_notes": "Private staff note.",
+                        "checklist": "Voice\nHooks",
+                    }
+                ).encode(),
+                headers={**_FORM, "Cookie": _cookie_header(cookies)},
+            )
+            saved = await client.post(
+                "/applications/kitty-pryde",
+                body=urlencode(
+                    {
+                        "intent": "save_review",
+                        "staff_notes": "Private staff note.",
+                        "checklist": "Voice\nHooks",
+                        "_csrf_token": _csrf_token(room.text),
+                    }
+                ).encode(),
+                headers={**_FORM, "Cookie": _cookie_header(cookies)},
+            )
+
+        application = services.repo.get_character_application_for_character(
+            community.id,
+            kitty.id,
+        )
+        assert room.status == 200
+        assert missing_csrf.status == 403
+        assert saved.status == 302
+        assert application.staff_notes == "Private staff note."
+        assert application.checklist == "Voice\nHooks"
+
+    asyncio.run(run())
+
+
+def test_production_application_room_denies_same_community_outsider(monkeypatch) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+
+        async with TestClient(app) as client:
+            _login, cookies = await _production_login(
+                client,
+                email="simon@example.com",
+                next_url="/applications/kitty-pryde",
+            )
+            room = await client.get(
+                "/applications/kitty-pryde",
+                headers={"Cookie": _cookie_header(cookies)},
+            )
+
+        assert room.status == 403
+        assert "Application Review Room" not in room.text
+        assert "Director Review" not in room.text
+        assert "Applicant Notes" not in room.text
+
+    asyncio.run(run())
+
+
 def test_production_tenant_prefix_overrides_session_selected_community(monkeypatch) -> None:
     async def run() -> None:
         _set_production_env(monkeypatch)


### PR DESCRIPTION
## Summary

This PR pays down the accepted steward tech-debt findings as separate commits after pulling latest `main`.

- Strictly validates Blueprint `program.role.is_admin` as a real boolean.
- Makes demo seeding explicit for CLI/server startup paths.
- Serializes post-number allocation inside repository transactions.
- Requires accepted faces for story actions such as scene posting, plot hooks, and wanted interest.
- Adds production CSRF/privacy proof for application review rooms.
- Preserves authored form values during tenant URL scoping while still scoping return-style fields.
- Preserves composer drafts on submit instead of clearing before server success.
- Centralizes PBP vocabulary labels/allowlists and applies them to Blueprint and repository writes.
- Adds release fragments and production-readiness progress collateral.

## Steward Notes

Consulted stewards: root constitution, Blueprint, Domain, DB/storage, Services, Web, Tests, Docs, Changelog, and Plans.

Accepted findings: Blueprint staff-power validation, explicit seeding posture, concurrent posting transaction safety, accepted-face story-action policy, application-room production proof, tenant form-value scoping, draft submit safety, shared PBP vocabulary, repository vocabulary guards, and release/roadmap collateral.

Deferred / not-now: full browser-confirmed composer draft clearing after successful navigation; Towncrier config cleanup for `changelog.d/AGENTS.md`; broader Blueprint apply/hydration work; public catalog/search work; Railway live smoke.

Collateral: updated Blueprint and primitive docs, added changelog fragments, and recorded the debt pass in the production-readiness roadmap.

## Validation

- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run pytest -q --tb=short`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run python scripts/check_changelog_fragments.py ...new fragments...`

Known tooling note: `make changelog-check` currently fails because Towncrier treats the pre-existing `changelog.d/AGENTS.md` steward file as an invalid fragment. This PR does not change release config.
