### PR TITLE
Document launch runbooks and harden production gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Post-deploy smoke for the shared Railway host:
 Use [docs/operations/railway-smoke.md](docs/operations/railway-smoke.md) as the
 recorded runbook before sharing the URL. The production gate is still open until
 that smoke includes restart persistence on the attached volume.
+The current SQLite operating contract is documented in
+[docs/operations/sqlite-production.md](docs/operations/sqlite-production.md).
 
 ## Product Voice
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ Post-deploy smoke for the shared Railway host:
 - confirm seed media under `/elbysodic-static/seed-media/...` returns `200`
 - keep the Railway service at one replica while SQLite is volume-backed
 
+Use [docs/operations/railway-smoke.md](docs/operations/railway-smoke.md) as the
+recorded runbook before sharing the URL. The production gate is still open until
+that smoke includes restart persistence on the attached volume.
+
 ## Product Voice
 
 Use language that fits roleplayers. Prefer face, roster, thread, scene,

--- a/changelog.d/+blueprint-preview-fingerprint.added.md
+++ b/changelog.d/+blueprint-preview-fingerprint.added.md
@@ -1,0 +1,1 @@
+Program Blueprint dry runs now show a preview fingerprint for future stale-apply checks.

--- a/changelog.d/+login-launch-posture.changed.md
+++ b/changelog.d/+login-launch-posture.changed.md
@@ -1,0 +1,1 @@
+Production login now says when the launch is invite-only instead of advertising demo seed passwords.

--- a/changelog.d/+studio-builder-checklist.added.md
+++ b/changelog.d/+studio-builder-checklist.added.md
@@ -1,0 +1,1 @@
+Director Operations now includes a community builder checklist for launch-critical board, world, application, wanted, plotting, and notification surfaces.

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -1,0 +1,62 @@
+# Railway Smoke Runbook
+
+Use this runbook before sharing a production Railway URL with writers or
+directors. A local test can prove the route contract, but this run records the
+real host, volume, cookie, static media, and restart posture.
+
+## Required Posture
+
+- `ELBYSODIC_ENV=production`
+- `ELBYSODIC_SECRET_KEY` is set to a random value of at least 32 characters.
+- `ELBYSODIC_ALLOWED_HOSTS` includes the Railway host and any custom host.
+- `ELBYSODIC_DEMO_MODE=1` only when seeded demo credentials should work.
+- A Railway Volume is attached and mounted at `/app/var`, or
+  `ELBYSODIC_DB_PATH` points at an attached volume path.
+- The service runs one replica while SQLite is the production-like store.
+
+## Smoke Script
+
+Record the date, Railway deployment ID, public URL, and tester account used.
+
+1. Visit `/health` and confirm `200`.
+2. Visit `/network?q=magic` while signed out and confirm only public catalog
+   language appears. No writer username, active face, unread count, staff note,
+   or identity menu should render.
+3. Log in with the intended demo or invite account.
+4. Enter `/c/x-men-apocalypse` and confirm the realm, membership label, and
+   active face are correct.
+5. Open a board and thread, then confirm composer controls show the intended
+   posting face.
+6. Switch to another membership through the rendered identity control and
+   confirm the destination keeps the `/c/{community_slug}` prefix.
+7. Open wanted, applications, plotting, notifications, and Studio surfaces as
+   the permitted viewer.
+8. Complete one CSRF-protected write, such as switching membership, updating a
+   draft, or posting in a safe test scene.
+9. Open at least one seed media URL from the rendered page and confirm it
+   returns successfully.
+10. Log out and confirm protected routes redirect to `/login`.
+11. Restart or redeploy the service, then confirm the write from step 8 and any
+    director-edited board/world data still exist.
+
+## Pass Record
+
+Paste a short record into the relevant PR or plan update:
+
+```text
+Railway smoke:
+- Date:
+- URL:
+- Deployment:
+- Volume path:
+- Replica count:
+- Demo mode:
+- Account:
+- Write tested:
+- Restart persistence:
+- Seed media:
+- Result:
+```
+
+Do not mark the production gate closed until the smoke record includes restart
+persistence and the one-replica SQLite posture.

--- a/docs/operations/sqlite-production.md
+++ b/docs/operations/sqlite-production.md
@@ -1,0 +1,47 @@
+# SQLite Production-Like Operations
+
+Elbysodic can run a production-like Railway demo on SQLite when the deployment
+is deliberately constrained. This is the operating contract until the project
+chooses a different persistence backend.
+
+## Runtime Contract
+
+- Run exactly one web replica against the SQLite file.
+- Store the database on an attached Railway Volume, not the ephemeral app
+  filesystem.
+- Prefer the default Railway path:
+  `$RAILWAY_VOLUME_MOUNT_PATH/elbysodic.sqlite3`.
+- Set `ELBYSODIC_DB_PATH` only when the deployment needs a different attached
+  volume path.
+- Seed demo data intentionally with `elbysodic seed-demo`; app startup creates
+  the schema but should not be treated as a demo reset.
+
+## Persistence Checks
+
+Before sharing a URL, prove these survive restart or redeploy:
+
+- writer posts
+- thread read/watch state
+- membership and active face selection
+- director-edited boards
+- director-edited world materials
+- application/review room state
+- wanted interest and plotting room state
+
+The Railway smoke runbook records this as restart persistence. If any of these
+rows reset after restart, stop the launch and inspect the volume mount path,
+replica count, and seed command history.
+
+## Backup And Export Expectation
+
+For the first production-like community demos, take a volume/database snapshot
+before:
+
+- manual demo seed refreshes
+- schema migrations
+- public test sessions with real writers
+- long-running director editing sessions
+
+Keep the backup process simple and explicit. A copied SQLite file is acceptable
+when the service is stopped or quiescent; a live backup command can replace
+that once the deployment runbook grows a maintenance window.

--- a/src/elbysodic/blueprints/programs.py
+++ b/src/elbysodic/blueprints/programs.py
@@ -173,6 +173,7 @@ class ProgramBlueprintPreview:
     blueprint: ProgramBlueprint | None
     errors: tuple[str, ...]
     diff_rows: tuple[BlueprintDiffRow, ...] = ()
+    preview_fingerprint: str = ""
 
     @property
     def is_valid(self) -> bool:

--- a/src/elbysodic/services/blueprints.py
+++ b/src/elbysodic/services/blueprints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable
 from dataclasses import replace
 from typing import Literal, Protocol
@@ -45,7 +46,12 @@ def preview_program_blueprint(
     preview = preview_program_blueprint_yaml(source)
     if not preview.is_valid or preview.blueprint is None:
         return preview
-    return replace(preview, diff_rows=plan_program_blueprint_hydration(repo, preview.blueprint))
+    diff_rows = plan_program_blueprint_hydration(repo, preview.blueprint)
+    return replace(
+        preview,
+        diff_rows=diff_rows,
+        preview_fingerprint=_preview_fingerprint(source, diff_rows),
+    )
 
 
 def plan_program_blueprint_hydration(
@@ -241,3 +247,18 @@ def _row_for_existing(
     except LookupError:
         return BlueprintDiffRow(section, slug, label, "create", create_detail)
     return BlueprintDiffRow(section, slug, label, existing_action, update_detail)
+
+
+def _preview_fingerprint(source: str, rows: tuple[BlueprintDiffRow, ...]) -> str:
+    digest = hashlib.sha256()
+    digest.update(source.encode("utf-8"))
+    for row in rows:
+        digest.update(b"\0")
+        digest.update(row.section.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(row.slug.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(row.action.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(row.detail.encode("utf-8"))
+    return digest.hexdigest()[:16]

--- a/src/elbysodic/services/network.py
+++ b/src/elbysodic/services/network.py
@@ -1,0 +1,56 @@
+"""Network catalog search helpers."""
+
+from __future__ import annotations
+
+from elbysodic.services.read_models import StudioNetworkDirectory, StudioNetworkProgramView
+
+
+def search_studio_network(
+    directory: StudioNetworkDirectory,
+    query: str,
+) -> list[StudioNetworkProgramView]:
+    """Return network programs matching a public catalog query."""
+
+    normalized_query = query.strip().lower()
+    if not normalized_query:
+        return list(directory.programs)
+    return [
+        program
+        for program in directory.programs
+        if normalized_query in _program_search_text(program)
+    ]
+
+
+def _program_search_text(program: StudioNetworkProgramView) -> str:
+    catalog_keywords: list[str] = []
+    if program.open_wanted_count:
+        catalog_keywords.append("wanted hooks casting open roles")
+    if program.application_count:
+        catalog_keywords.append("application applications")
+    if program.plotting_room_count:
+        catalog_keywords.append("plotting rooms")
+    if program.current_event:
+        catalog_keywords.append("event current event")
+    if "hp" in program.community.slug or "magic" in program.community.name.lower():
+        catalog_keywords.append("magic school fantasy")
+    if "jurassic" in program.community.slug:
+        catalog_keywords.append("survival sci-fi science island")
+    if "x-men" in program.community.slug or "mutant" in program.community.name.lower():
+        catalog_keywords.append("superhero crisis mutants")
+    if "small-town" in program.community.slug:
+        catalog_keywords.append("small town found family")
+    if "nyc" in program.community.slug:
+        catalog_keywords.append("urban real life city")
+    haystack_parts = [
+        program.community.name,
+        program.membership.display_name if program.membership else "",
+        program.membership.username if program.membership else "",
+        program.role.name if program.role else "",
+        program.current_character.name if program.current_character else "",
+        program.premise.material.title if program.premise else "",
+        program.premise.material.summary if program.premise else "",
+        program.current_event.material.title if program.current_event else "",
+        program.current_event.material.summary if program.current_event else "",
+        *catalog_keywords,
+    ]
+    return " ".join(haystack_parts).lower()

--- a/src/elbysodic/services/plotting.py
+++ b/src/elbysodic/services/plotting.py
@@ -510,22 +510,23 @@ def create_thread_from_plotting_room(
         for item in participants
         if item.participant.character_id is not None
     ]
-    created = _start_thread(
-        repo,
-        viewer,
-        board_slug=board.slug,
-        character_id=character_id,
-        title=title,
-        body=body,
-        status="active",
-        location=location,
-        timeline=timeline,
-        summary=summary,
-        posting_mode=posting_mode,
-        participant_ids=participant_ids,
-    )
-    repo.attach_plotting_room_thread(viewer.community.id, room.id, created.thread.id)
-    _notify_room_threaded(repo, viewer, room, participants, created.thread)
+    with repo.transaction():
+        created = _start_thread(
+            repo,
+            viewer,
+            board_slug=board.slug,
+            character_id=character_id,
+            title=title,
+            body=body,
+            status="active",
+            location=location,
+            timeline=timeline,
+            summary=summary,
+            posting_mode=posting_mode,
+            participant_ids=participant_ids,
+        )
+        repo.attach_plotting_room_thread(viewer.community.id, room.id, created.thread.id)
+        _notify_room_threaded(repo, viewer, room, participants, created.thread)
     return created
 
 

--- a/src/elbysodic/web/pages/login/page.html
+++ b/src/elbysodic/web/pages/login/page.html
@@ -28,7 +28,13 @@
       <input name="password" type="password" autocomplete="current-password" required>
     </label>
     <div class="chirpui-cluster chirpui-cluster--between">
-      <p class="elbysodic-copy-helper">Seed accounts use password: <code>password</code>.</p>
+      <p class="elbysodic-copy-helper">
+        {% if seed_passwords_enabled %}
+        Invite/demo accounts use password: <code>password</code>.
+        {% else %}
+        Access is invite-only for this launch; public registration is not open.
+        {% end %}
+      </p>
       <button class="chirpui-btn chirpui-btn--primary" type="submit">Log in</button>
     </div>
   </form>

--- a/src/elbysodic/web/pages/login/page.py
+++ b/src/elbysodic/web/pages/login/page.py
@@ -10,7 +10,7 @@ from chirp.http.response import Response
 from chirp.templating.returns import Page
 
 from elbysodic.services.access import DEV_IDENTITY_COOKIE, dev_identity_cookie_value
-from elbysodic.services.auth import SESSION_COOKIE
+from elbysodic.services.auth import SESSION_COOKIE, seed_passwords_enabled
 from elbysodic.web.security import session_cookie
 from elbysodic.web.state import get_services, get_web_security_config
 
@@ -80,6 +80,7 @@ def _render_login(
         email=email,
         next_url=next_url or _safe_next(str(getattr(request, "query", {}).get("next", "/"))),
         error=error,
+        seed_passwords_enabled=seed_passwords_enabled(),
     )
 
 

--- a/src/elbysodic/web/pages/network/page.py
+++ b/src/elbysodic/web/pages/network/page.py
@@ -6,46 +6,9 @@ from chirp.http.request import Request
 from chirp.templating.returns import Page
 
 from elbysodic.services.forum import AppServices
-from elbysodic.services.read_models import ForumView, StudioNetworkProgramView
+from elbysodic.services.network import search_studio_network
+from elbysodic.services.read_models import ForumView
 from elbysodic.web.state import get_services
-
-
-def _matches_query(program: StudioNetworkProgramView, query: str) -> bool:
-    if not query:
-        return True
-    catalog_keywords: list[str] = []
-    if program.open_wanted_count:
-        catalog_keywords.append("wanted hooks casting open roles")
-    if program.application_count:
-        catalog_keywords.append("application applications")
-    if program.plotting_room_count:
-        catalog_keywords.append("plotting rooms")
-    if program.current_event:
-        catalog_keywords.append("event current event")
-    if "hp" in program.community.slug or "magic" in program.community.name.lower():
-        catalog_keywords.append("magic school fantasy")
-    if "jurassic" in program.community.slug:
-        catalog_keywords.append("survival sci-fi science island")
-    if "x-men" in program.community.slug or "mutant" in program.community.name.lower():
-        catalog_keywords.append("superhero crisis mutants")
-    if "small-town" in program.community.slug:
-        catalog_keywords.append("small town found family")
-    if "nyc" in program.community.slug:
-        catalog_keywords.append("urban real life city")
-    haystack_parts = [
-        program.community.name,
-        program.membership.display_name if program.membership else "",
-        program.membership.username if program.membership else "",
-        program.role.name if program.role else "",
-        program.current_character.name if program.current_character else "",
-        program.premise.material.title if program.premise else "",
-        program.premise.material.summary if program.premise else "",
-        program.current_event.material.title if program.current_event else "",
-        program.current_event.material.summary if program.current_event else "",
-        *catalog_keywords,
-    ]
-    haystack = " ".join(haystack_parts).lower()
-    return query.lower() in haystack
 
 
 def get(request: Request) -> Page:
@@ -62,9 +25,7 @@ def get(request: Request) -> Page:
         network_search_query=query,
         viewer=viewer,
         network=network,
-        explore_programs=[
-            program for program in network.programs if _matches_query(program, query)
-        ],
+        explore_programs=search_studio_network(network, query),
         show_community_shell=False,
     )
 

--- a/src/elbysodic/web/pages/studio/intake/page.html
+++ b/src/elbysodic/web/pages/studio/intake/page.html
@@ -99,6 +99,9 @@
       {% if blueprint_preview.diff_rows %}
       <div class="chirpui-stack chirpui-stack--xs">
         <p class="chirpui-field__label">Hydration diff preview</p>
+        {% if blueprint_preview.preview_fingerprint %}
+        <p class="elbysodic-copy-meta">Preview fingerprint: {{ blueprint_preview.preview_fingerprint }}</p>
+        {% end %}
         {% for row in blueprint_preview.diff_rows %}
         <p class="elbysodic-copy-status">
           <strong>{{ row.action }}</strong> {{ row.section }}: {{ row.label }}

--- a/src/elbysodic/web/pages/studio/operations/page.py
+++ b/src/elbysodic/web/pages/studio/operations/page.py
@@ -190,6 +190,20 @@ def _director_operations(
                 "Complete one CSRF-protected write, then log out.",
             ),
         ),
+        OperationsCard(
+            kicker="Launch",
+            title="Community builder checklist",
+            summary="Director-owned surfaces a real program needs before writers arrive.",
+            count=6,
+            href="/studio",
+            cta="Open Studio",
+            variant="attention",
+            items=(
+                "Boards and world materials carry the community premise.",
+                "Applications, claims, and wanted hooks have review paths.",
+                "Plotting handoffs and notifications move writers into scenes.",
+            ),
+        ),
     ]
     return DirectorOperations(
         cards=cards,

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -815,7 +815,7 @@ def test_login_route_creates_account_session_and_membership_context() -> None:
             studio = await client.get("/studio", headers={"Cookie": cookie_header})
 
         assert page.status == 200
-        assert "Seed accounts use password" in page.text
+        assert "Invite/demo accounts use password" in page.text
         assert login.status == 302
         assert _response_header(login, "location") == "/studio"
         assert any(cookie.startswith("elbysodic_session=") for cookie in set_cookies)
@@ -1726,6 +1726,10 @@ def test_director_studio_surfaces_community_production_work() -> None:
             assert "Draft materials" in operations.text
             assert "Dry-run intake" in operations.text
             assert "Release smoke" in operations.text
+            assert "Community builder checklist" in operations.text
+            assert "Boards and world materials carry the community premise." in operations.text
+            assert "Applications, claims, and wanted hooks have review paths." in operations.text
+            assert "Plotting handoffs and notifications move writers into scenes." in operations.text
             assert "Log in, enter a realm, and switch memberships." in operations.text
             assert 'href="/studio/intake#program-blueprint-preview"' in operations.text
             assert 'href="/network"' in operations.text

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -4802,6 +4802,71 @@ def test_plotting_room_plan_can_turn_into_scene() -> None:
     asyncio.run(run())
 
 
+def test_plotting_room_scene_handoff_rolls_back_on_attach_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def run() -> None:
+        app = _app()
+        async with TestClient(app) as client:
+            response = await client.post(
+                "/wanted/human-un-liaison-for-b24",
+                body=b"intent=express_interest",
+                headers=_FORM,
+            )
+            assert response.status == 302
+
+        services = get_services()
+        repo = services.repo
+        community = services.seed.community
+        wanted_ad = repo.get_wanted_ad_by_slug(community.id, "human-un-liaison-for-b24")
+        rogue = repo.get_character_by_slug(community.id, "rogue")
+        interest = repo.get_wanted_ad_interest_for_character(community.id, wanted_ad.id, rogue.id)
+        charlie_membership = repo.get_membership_by_username(community.id, "charlie")
+        charlie_user = repo.get_user(charlie_membership.user_id)
+        xavier = repo.get_character_by_slug(community.id, "charles-xavier")
+        charlie_services = AppServices(
+            repo,
+            DemoSeed(community, charlie_user, charlie_membership, xavier),
+        )
+        charlie_app = create_app(debug=False, services=charlie_services)
+        async with TestClient(charlie_app) as charlie_client:
+            room_response = await charlie_client.post(
+                "/wanted/human-un-liaison-for-b24",
+                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                headers=_FORM,
+            )
+            assert room_response.status == 302
+
+        room = repo.get_plotting_room_for_wanted_interest(community.id, interest.id)
+        plotting_board = repo.get_board_by_slug(community.id, "plotting")
+
+        def fail_attach(*_args, **_kwargs):
+            raise RuntimeError("forced attach failure")
+
+        monkeypatch.setattr(repo, "attach_plotting_room_thread", fail_attach)
+        with pytest.raises(RuntimeError, match="forced attach failure"):
+            charlie_services.create_thread_from_plotting_room(
+                room.id,
+                board_id=plotting_board.id,
+                character_id=xavier.id,
+                title="Rollback Liaison Debrief",
+                summary="This scene should not persist.",
+                location="Xavier Institute",
+                timeline="After B-24",
+                body="Charles starts a scene that should roll back.",
+            )
+
+        rolled_back_room = repo.get_plotting_room(community.id, room.id)
+        assert rolled_back_room.target_thread_id is None
+        assert rolled_back_room.status == "brainstorming"
+        assert all(
+            thread.title != "Rollback Liaison Debrief"
+            for thread in repo.list_threads(community.id, plotting_board.id)
+        )
+
+    asyncio.run(run())
+
+
 def test_plotting_room_notifications_do_not_leak_to_non_participants() -> None:
     async def run() -> None:
         app = _app()

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -1729,7 +1729,9 @@ def test_director_studio_surfaces_community_production_work() -> None:
             assert "Community builder checklist" in operations.text
             assert "Boards and world materials carry the community premise." in operations.text
             assert "Applications, claims, and wanted hooks have review paths." in operations.text
-            assert "Plotting handoffs and notifications move writers into scenes." in operations.text
+            assert (
+                "Plotting handoffs and notifications move writers into scenes." in operations.text
+            )
             assert "Log in, enter a realm, and switch memberships." in operations.text
             assert 'href="/studio/intake#program-blueprint-preview"' in operations.text
             assert 'href="/network"' in operations.text
@@ -1894,6 +1896,7 @@ appearance:
         assert "1 appearance" in response.text
         assert "postbit: poster rail, hairline frame; 1 guidebook variants" in response.text
         assert "Hydration diff preview" in response.text
+        assert "Preview fingerprint:" in response.text
         assert "create</strong> program: RL Small Town Preview" in response.text
         assert "create</strong> scene hub: Main Street" in response.text
         assert "create</strong> wanted hook: Returning sibling" in response.text

--- a/tests/test_program_blueprints.py
+++ b/tests/test_program_blueprints.py
@@ -21,7 +21,8 @@ from elbysodic.blueprints import (
 )
 from elbysodic.db import ForumRepository, connect, create_schema
 from elbysodic.db import seed as seed_module
-from elbysodic.db.seed import seed_demo_forum
+from elbysodic.db.seed import DemoSeed, seed_demo_forum
+from elbysodic.services import AppServices
 
 
 def _blueprint(
@@ -637,6 +638,59 @@ def test_seed_hydrates_program_blueprints_into_network_programs() -> None:
         ("rl-nyc", "rent-week"),
         ("rl-small-town", "founders-week"),
     ]
+
+
+def test_program_blueprint_preview_fingerprint_changes_with_source() -> None:
+    connection = connect()
+    create_schema(connection)
+    repo = ForumRepository(connection)
+    seed = seed_demo_forum(repo)
+    moira = repo.get_membership_by_username(seed.community.id, "moira")
+    admin_services = AppServices(
+        repo,
+        DemoSeed(
+            seed.community,
+            repo.get_user(moira.user_id),
+            moira,
+            repo.get_character_by_slug(seed.community.id, "moira-mactaggert"),
+        ),
+    )
+    source = """
+elbysodic_blueprint: 1
+program:
+  slug: rl-small-town-preview
+  name: RL Small Town Preview
+  role:
+    slug: director
+    name: Director
+    is_admin: true
+characters:
+  - slug: june-calloway
+    name: June Calloway
+    summary: Florist and town council note-taker.
+boards:
+  - slug: main-street
+    name: Main Street
+    kind: location
+    tagline: One stoplight, twelve opinions.
+    description: The town's public spine.
+materials:
+  - slug: premise
+    title: Premise
+    type: premise
+    summary: A small-town ensemble.
+    body: Founder's Week should be a cozy pressure cooker.
+"""
+
+    preview = admin_services.preview_program_blueprint(source)
+    changed = admin_services.preview_program_blueprint(
+        source.replace("RL Small Town Preview", "RL Small Town Preview 2")
+    )
+
+    assert preview.is_valid
+    assert preview.preview_fingerprint
+    assert len(preview.preview_fingerprint) == 16
+    assert changed.preview_fingerprint != preview.preview_fingerprint
 
 
 def test_seed_hydrates_blueprint_board_media_fields(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -134,6 +134,9 @@ def test_production_seed_password_requires_demo_mode(monkeypatch) -> None:
             )
 
         assert response.status == 200
+        assert "Access is invite-only for this launch" in page.text
+        assert "public registration is not open" in page.text
+        assert "Invite/demo accounts use password" not in page.text
         assert "email or password is incorrect" in response.text
         assert "elbysodic_session=" not in "\n".join(_response_headers(response, "set-cookie"))
 

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -386,8 +386,10 @@ def test_production_release_smoke_core_user_flow(monkeypatch) -> None:
         assert "X-Men Apocalypse" in xmen_home.text
         assert network.status == 200
         assert "HP Universe" in network.text
+        assert "playing as Rogue" in network.text
         assert thread.status == 200
         assert "Sentinel drill after midnight" in thread.text
+        assert "Reply as Rogue" in thread.text
         assert wanted.status == 200
         assert "Wanted" in wanted.text
         assert applications.status == 200
@@ -402,6 +404,7 @@ def test_production_release_smoke_core_user_flow(monkeypatch) -> None:
         assert dict(switch.headers)["location"] == "/c/hp-universe"
         assert hp_home.status == 200
         assert "Director in HP Universe" in hp_home.text
+        assert "playing as Rowan Ash" in hp_home.text
         assert jurassic_board.status == 200
         assert "Paddock Twelve" in jurassic_board.text
         assert logout.status == 302

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -310,6 +310,26 @@ def test_production_release_smoke_core_user_flow(monkeypatch) -> None:
                 "/c/x-men-apocalypse/boards/danger-room/threads/sentinel-drill",
                 headers={"Cookie": _cookie_header(cookies)},
             )
+            wanted = await client.get(
+                "/c/x-men-apocalypse/wanted",
+                headers={"Cookie": _cookie_header(cookies)},
+            )
+            applications = await client.get(
+                "/c/x-men-apocalypse/applications",
+                headers={"Cookie": _cookie_header(cookies)},
+            )
+            plotting = await client.get(
+                "/c/x-men-apocalypse/plotting",
+                headers={"Cookie": _cookie_header(cookies)},
+            )
+            notifications = await client.get(
+                "/c/x-men-apocalypse/notifications",
+                headers={"Cookie": _cookie_header(cookies)},
+            )
+            studio = await client.get(
+                "/c/x-men-apocalypse/studio",
+                headers={"Cookie": _cookie_header(cookies)},
+            )
             cookies.update(_cookie_values(thread))
             switch = await client.post(
                 "/identity",
@@ -352,6 +372,16 @@ def test_production_release_smoke_core_user_flow(monkeypatch) -> None:
         assert "HP Universe" in network.text
         assert thread.status == 200
         assert "Sentinel drill after midnight" in thread.text
+        assert wanted.status == 200
+        assert "Wanted" in wanted.text
+        assert applications.status == 200
+        assert "Applications" in applications.text
+        assert plotting.status == 200
+        assert "Plotting" in plotting.text
+        assert notifications.status == 200
+        assert "Notifications" in notifications.text
+        assert studio.status == 200
+        assert "Studio" in studio.text
         assert switch.status == 302
         assert dict(switch.headers)["location"] == "/c/hp-universe"
         assert hp_home.status == 200

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -8,6 +8,7 @@ import pytest
 from chirp.testing import TestClient
 
 from elbysodic.services import create_services
+from elbysodic.services.network import search_studio_network
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
 
@@ -211,6 +212,21 @@ def test_public_network_catalog_hides_membership_and_staff_signals(monkeypatch) 
         assert "Staff notes" not in network.text
 
     asyncio.run(run())
+
+
+def test_public_network_search_contract_stays_service_owned() -> None:
+    services = create_services(path=":memory:")
+
+    directory = services.public_studio_network()
+    magic_results = search_studio_network(directory, "magic")
+    wanted_results = search_studio_network(directory, "wanted")
+
+    assert [program.community.slug for program in magic_results] == ["hp-universe"]
+    assert {program.community.slug for program in wanted_results}
+    assert all(program.membership is None for program in wanted_results)
+    assert all(program.current_character is None for program in wanted_results)
+    assert all(program.unread_notification_count == 0 for program in wanted_results)
+    assert all(program.plotting_room_count == 0 for program in wanted_results)
 
 
 def test_production_login_preserves_tenant_prefixed_destination(monkeypatch) -> None:

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -189,6 +189,30 @@ def test_production_routes_require_session(monkeypatch) -> None:
     asyncio.run(run())
 
 
+def test_public_network_catalog_hides_membership_and_staff_signals(monkeypatch) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+
+        async with TestClient(app) as client:
+            network = await client.get("/network?q=wanted")
+
+        assert network.status == 200
+        assert "Public preview" in network.text
+        assert "Open Wanted" in network.text or "wanted hooks" in network.text
+        assert "starlane" not in network.text
+        assert "moira" not in network.text
+        assert "Director in" not in network.text
+        assert "Member in" not in network.text
+        assert "playing as" not in network.text
+        assert "current realm" not in network.text
+        assert "unread" not in network.text
+        assert "Application Review Room" not in network.text
+        assert "Staff notes" not in network.text
+
+    asyncio.run(run())
+
+
 def test_production_login_preserves_tenant_prefixed_destination(monkeypatch) -> None:
     async def run() -> None:
         _set_production_env(monkeypatch)


### PR DESCRIPTION
## Summary
- Added Railway and SQLite production runbooks so the shared-host launch contract is explicit and reviewable.
- Clarified invite-only login posture, removed demo-password messaging from the production login copy, and updated coverage accordingly.
- Tightened launch readiness with public network privacy proof, broader production smoke coverage, a Studio community-builder checklist, a plotting-room transaction rollback regression, and a Blueprint preview fingerprint for stale-apply checks.
- Moved network search into a service helper so public catalog semantics are reusable and easier to test.

## Testing
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run pytest -q --tb=short`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`