### PR TITLE
[codex] Fix first-time entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ The development app currently includes:
 
 Gated production-readiness work is tracked in
 [plans/in-progress/production-readiness-roadmap-2026-05-09.md](plans/in-progress/production-readiness-roadmap-2026-05-09.md).
-The current launch posture is login-only demo/invite-style access until a
-registration or request-access contract is explicitly designed.
+The current launch posture is invite-style access: public discovery and a
+request-access placeholder are visible, while account and membership creation
+remain director-provisioned until a full registration contract is explicitly
+designed.
 
 ## Architecture
 

--- a/changelog.d/+anonymous-entrypoints.fixed.md
+++ b/changelog.d/+anonymous-entrypoints.fixed.md
@@ -1,0 +1,1 @@
+Anonymous visitors now see a clear login action and an intentional launch state when a studio has not opened its first realm.

--- a/changelog.d/+production-csp.security.md
+++ b/changelog.d/+production-csp.security.md
@@ -1,0 +1,1 @@
+Production security headers now use an explicit CSP that supports the current Chirp shell while keeping frame, object, connection, and asset boundaries scoped.

--- a/changelog.d/+request-access.added.md
+++ b/changelog.d/+request-access.added.md
@@ -1,0 +1,1 @@
+Invite-only launches now expose a public request-access page without opening self-serve registration.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -92,6 +92,12 @@ Production mutating requests are protected by Chirp session-backed CSRF. The
 app injects the active CSRF field into rendered POST forms and rejects unsafe
 methods when the token is missing or invalid.
 
+Production responses also set a Content Security Policy sized to the current
+server-rendered Chirp and Chirp-UI stack. The policy keeps framing, object,
+base URI, image, and connection boundaries narrow, while allowing inline styles
+and Alpine expression evaluation until those upstream-rendered shell, theme,
+and progressive-enhancement patterns are replaced with CSP-stricter assets.
+
 ## Nullable Identity Shapes
 
 Some PBP workflows support a character-backed path and a prospective-character

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -63,7 +63,7 @@ Production mode is enabled with `ELBYSODIC_ENV=production` or `staging`.
 Production request identity is session-backed:
 
 - normal app routes require a valid `elbysodic_session`
-- `/health`, `/login`, `/logout`, `/`, `/network`, and static assets are public
+- `/health`, `/login`, `/logout`, `/`, `/network`, `/request-access`, and static assets are public
 - dev identity headers are ignored
 - unsigned `elbysodic_dev_identity` cookies are ignored and are not issued
 - `/dev/personas` is unavailable even when `ELBYSODIC_DEV_TOOLS` is set

--- a/src/elbysodic/web/app.py
+++ b/src/elbysodic/web/app.py
@@ -19,8 +19,8 @@ from elbysodic.services import AppServices, create_services
 from elbysodic.web.errors import register_error_handlers
 from elbysodic.web.navigation import location_nav_tree_items
 from elbysodic.web.security import (
-    AutoCSRFFormsMiddleware,
     PRODUCTION_CONTENT_SECURITY_POLICY,
+    AutoCSRFFormsMiddleware,
     RequireLoginMiddleware,
     resolve_web_security_config,
 )

--- a/src/elbysodic/web/app.py
+++ b/src/elbysodic/web/app.py
@@ -20,6 +20,7 @@ from elbysodic.web.errors import register_error_handlers
 from elbysodic.web.navigation import location_nav_tree_items
 from elbysodic.web.security import (
     AutoCSRFFormsMiddleware,
+    PRODUCTION_CONTENT_SECURITY_POLICY,
     RequireLoginMiddleware,
     resolve_web_security_config,
 )
@@ -111,6 +112,7 @@ def create_app(
         app.add_middleware(
             SecurityHeadersMiddleware(
                 SecurityHeadersConfig(
+                    content_security_policy=PRODUCTION_CONTENT_SECURITY_POLICY,
                     strict_transport_security=security.strict_transport_security,
                 )
             )

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -324,6 +324,9 @@
 </div>
 {% else %}
 <div class="elbysodic-anonymous-actions">
+  <a class="chirpui-btn chirpui-btn--secondary chirpui-btn--sm"
+     href="/request-access"
+     hx-boost="false">Request access</a>
   <a class="chirpui-btn chirpui-btn--primary chirpui-btn--sm"
      href="/login?next={{ current_path or "/" }}"
      hx-boost="false">Log in</a>

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -323,7 +323,12 @@
   </details>
 </div>
 {% else %}
-{{ theme_toggle() }}
+<div class="elbysodic-anonymous-actions">
+  <a class="chirpui-btn chirpui-btn--primary chirpui-btn--sm"
+     href="/login?next={{ current_path or "/" }}"
+     hx-boost="false">Log in</a>
+  {{ theme_toggle() }}
+</div>
 {% end %}
 {% end %}
 

--- a/src/elbysodic/web/pages/login/page.html
+++ b/src/elbysodic/web/pages/login/page.html
@@ -34,6 +34,7 @@
         {% else %}
         Access is invite-only for this launch; public registration is not open.
         {% end %}
+        <a class="chirpui-link" href="/request-access">Request access</a>.
       </p>
       <button class="chirpui-btn chirpui-btn--primary" type="submit">Log in</button>
     </div>

--- a/src/elbysodic/web/pages/login/page.py
+++ b/src/elbysodic/web/pages/login/page.py
@@ -81,6 +81,7 @@ def _render_login(
         next_url=next_url or _safe_next(str(getattr(request, "query", {}).get("next", "/"))),
         error=error,
         seed_passwords_enabled=seed_passwords_enabled(),
+        show_community_shell=False,
     )
 
 

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -418,10 +418,20 @@ A studio program ready for scenes, casting, and writer movement.
   {% end %}
   {% else %}
   {% call section_header("Studio Network") %}
-  Elbysodic is ready for its first play-by-post program.
+  This Elbysodic studio has not opened its first play-by-post realm yet.
   {% end %}
   {% call surface(variant="elevated") %}
-  <p class="elbysodic-empty-state">No programs are available yet.</p>
+  <div class="elbysodic-network-empty">
+    <p class="elbysodic-section-kicker">Launch state</p>
+    <h2>The first realm is still backstage.</h2>
+    <p class="elbysodic-empty-state">
+      Once a director opens a realm, this studio network will show public worlds,
+      wanted hooks, faces, scenes, and current events here.
+    </p>
+    <div class="elbysodic-network-empty__actions">
+      <a class="chirpui-btn chirpui-btn--primary" href="/login?next=/">Log in</a>
+    </div>
+  </div>
   {% end %}
   {% end %}
 {% end %}

--- a/src/elbysodic/web/pages/request-access/_meta.py
+++ b/src/elbysodic/web/pages/request-access/_meta.py
@@ -1,0 +1,3 @@
+from chirp.pages.types import RouteMeta
+
+META = RouteMeta(title="Request Access", breadcrumb_label="Request Access")

--- a/src/elbysodic/web/pages/request-access/page.html
+++ b/src/elbysodic/web/pages/request-access/page.html
@@ -1,0 +1,36 @@
+{% imports %}
+  {% from "chirpui/layout.html" import container, stack, section_header %}
+  {% from "chirpui/surface.html" import surface %}
+{% end %}
+
+{% block page_root %}
+<div id="page-root">
+{% block page_root_inner %}
+{% block page_content %}
+{% call container(max_width="42rem") %}
+{% call stack(gap="lg") %}
+  {% call section_header("Request Access") %}
+  Elbysodic is invite-only while the first realm and writer onboarding contracts settle.
+  {% end %}
+
+  {% call surface(variant="elevated") %}
+  <div class="elbysodic-access-panel">
+    <p class="elbysodic-section-kicker">Invite-only launch</p>
+    <h1>Access opens through a director invitation.</h1>
+    <p>
+      Public registration is not open yet. For this launch, a director creates
+      the account and community membership so writer names, roles, roster
+      ownership, and default faces start in the right realm.
+    </p>
+    <div class="elbysodic-access-panel__actions">
+      <a class="chirpui-btn chirpui-btn--primary" href="/login?next=/">Log in</a>
+      <a class="chirpui-btn chirpui-btn--secondary" href="/network">Explore realms</a>
+    </div>
+  </div>
+  {% end %}
+{% end %}
+{% end %}
+{% end %}
+</div>
+{% endblock %}
+{% endblock %}

--- a/src/elbysodic/web/pages/request-access/page.py
+++ b/src/elbysodic/web/pages/request-access/page.py
@@ -1,0 +1,18 @@
+"""Invite-only access posture page."""
+
+from __future__ import annotations
+
+from chirp.http.request import Request
+from chirp.templating.returns import Page
+
+
+def get(request: Request) -> Page:
+    return Page(
+        "request-access/page.html",
+        "page_content",
+        page_block_name="page_root",
+        current_path=request.url,
+        page_title="Request Access · Elbysodic",
+        viewer=None,
+        show_community_shell=False,
+    )

--- a/src/elbysodic/web/security.py
+++ b/src/elbysodic/web/security.py
@@ -23,7 +23,7 @@ ELBYSODIC_HSTS = "ELBYSODIC_HSTS"
 MIN_SECRET_KEY_LENGTH = 32
 PRODUCTION_ENVS = frozenset({"production", "prod", "staging"})
 DEFAULT_PRODUCTION_ALLOWED_HOSTS = (".up.railway.app", ".railway.app")
-PUBLIC_PATHS = frozenset({"/", "/health", "/login", "/logout", "/network"})
+PUBLIC_PATHS = frozenset({"/", "/health", "/login", "/logout", "/network", "/request-access"})
 PUBLIC_PREFIXES = ("/elbysodic-static/",)
 PRODUCTION_CONTENT_SECURITY_POLICY = (
     "default-src 'self'; "

--- a/src/elbysodic/web/security.py
+++ b/src/elbysodic/web/security.py
@@ -25,6 +25,16 @@ PRODUCTION_ENVS = frozenset({"production", "prod", "staging"})
 DEFAULT_PRODUCTION_ALLOWED_HOSTS = (".up.railway.app", ".railway.app")
 PUBLIC_PATHS = frozenset({"/", "/health", "/login", "/logout", "/network"})
 PUBLIC_PREFIXES = ("/elbysodic-static/",)
+PRODUCTION_CONTENT_SECURITY_POLICY = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://cdn.jsdelivr.net; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "base-uri 'self'; "
+    "frame-ancestors 'none'; "
+    "object-src 'none'"
+)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/elbysodic/web/static/elbysodic-theme.css
+++ b/src/elbysodic/web/static/elbysodic-theme.css
@@ -620,6 +620,12 @@ body {
     gap: 0.45rem;
 }
 
+.elbysodic-anonymous-actions {
+    align-items: center;
+    display: flex;
+    gap: 0.45rem;
+}
+
 .elbysodic-identity-menu {
     position: relative;
 }
@@ -4081,6 +4087,24 @@ body {
 .elbysodic-thread-card__meta,
 .elbysodic-empty-state {
     color: var(--chirpui-text-muted);
+}
+
+.elbysodic-network-empty {
+    display: grid;
+    gap: 0.8rem;
+    max-width: 44rem;
+}
+
+.elbysodic-network-empty h2,
+.elbysodic-network-empty p {
+    margin: 0;
+}
+
+.elbysodic-network-empty__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
 }
 
 .elbysodic-thread-card__meta {
@@ -8531,6 +8555,10 @@ a.elbysodic-metric:focus-visible {
 
     .elbysodic-shell-identity {
         gap: 0;
+    }
+
+    .elbysodic-anonymous-actions {
+        gap: 0.35rem;
     }
 
     .elbysodic-sidebar-resize {

--- a/src/elbysodic/web/static/elbysodic-theme.css
+++ b/src/elbysodic/web/static/elbysodic-theme.css
@@ -4107,6 +4107,23 @@ body {
     gap: 0.65rem;
 }
 
+.elbysodic-access-panel {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.elbysodic-access-panel h1,
+.elbysodic-access-panel p {
+    margin: 0;
+}
+
+.elbysodic-access-panel__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+}
+
 .elbysodic-thread-card__meta {
     align-items: center;
     display: flex;

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -169,6 +169,8 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert "starlane" not in root.text
         assert "playing as Rogue" not in root.text
         assert "elbysodic-identity-menu" not in root.text
+        assert "elbysodic-anonymous-actions" in root.text
+        assert 'href="/login?next=/"' in root.text
         assert "chirpui-theme-toggle" in root.text
         assert network.status == 200
         assert "HP Universe" in network.text
@@ -177,6 +179,7 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert "Public preview" in network.text
         assert login.status == 200
         assert "_csrf_token" in login.text
+        assert "chirpui-sidebar__section-title" not in login.text
         assert "Staff in X-Men Apocalypse" not in login.text
         assert studio.status == 302
         assert dict(studio.headers)["location"] == "/login?next=/studio"
@@ -186,6 +189,28 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert "Log in to keep writing." in post.text
         assert "/login?next=/identity" in post.text
         assert personas.status == 302
+
+    asyncio.run(run())
+
+
+def test_production_empty_network_renders_launch_state(monkeypatch) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        app = create_app(debug=False, db_path=":memory:", seed_demo=False)
+
+        async with TestClient(app) as client:
+            root = await client.get("/")
+            network = await client.get("/network")
+
+        assert root.status == 200
+        assert network.status == 200
+        for response in (root, network):
+            assert "Launch state" in response.text
+            assert "The first realm is still backstage." in response.text
+            assert "wanted hooks, faces, scenes, and current events" in response.text
+            assert 'href="/login?next=/"' in response.text
+            assert "No programs are available yet." not in response.text
+            assert "elbysodic-identity-menu" not in response.text
 
     asyncio.run(run())
 

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -300,7 +300,11 @@ def test_production_security_headers_are_set(monkeypatch) -> None:
         assert headers["x-content-type-options"] == "nosniff"
         assert headers["referrer-policy"] == "strict-origin-when-cross-origin"
         assert headers["strict-transport-security"] == "max-age=31536000"
-        assert "frame-ancestors 'none'" in headers["content-security-policy"]
+        csp = headers["content-security-policy"]
+        assert "frame-ancestors 'none'" in csp
+        assert "style-src 'self' 'unsafe-inline'" in csp
+        assert "script-src 'self' 'unsafe-inline' 'unsafe-eval'" in csp
+        assert "connect-src 'self'" in csp
 
     asyncio.run(run())
 

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -154,6 +154,7 @@ def test_production_routes_require_session(monkeypatch) -> None:
             root = await client.get("/")
             network = await client.get("/network?q=magic")
             login = await client.get("/login")
+            request_access = await client.get("/request-access")
             studio = await client.get("/studio")
             tenant = await client.get("/c/x-men-apocalypse")
             post = await client.post(
@@ -170,6 +171,7 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert "playing as Rogue" not in root.text
         assert "elbysodic-identity-menu" not in root.text
         assert "elbysodic-anonymous-actions" in root.text
+        assert 'href="/request-access"' in root.text
         assert 'href="/login?next=/"' in root.text
         assert "chirpui-theme-toggle" in root.text
         assert network.status == 200
@@ -179,8 +181,14 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert "Public preview" in network.text
         assert login.status == 200
         assert "_csrf_token" in login.text
+        assert 'href="/request-access"' in login.text
         assert "chirpui-sidebar__section-title" not in login.text
         assert "Staff in X-Men Apocalypse" not in login.text
+        assert request_access.status == 200
+        assert "Access opens through a director invitation." in request_access.text
+        assert "Public registration is not open yet." in request_access.text
+        assert "_csrf_token" not in request_access.text
+        assert "chirpui-sidebar__section-title" not in request_access.text
         assert studio.status == 302
         assert dict(studio.headers)["location"] == "/login?next=/studio"
         assert tenant.status == 302
@@ -208,6 +216,7 @@ def test_production_empty_network_renders_launch_state(monkeypatch) -> None:
             assert "Launch state" in response.text
             assert "The first realm is still backstage." in response.text
             assert "wanted hooks, faces, scenes, and current events" in response.text
+            assert 'href="/request-access"' in response.text
             assert 'href="/login?next=/"' in response.text
             assert "No programs are available yet." not in response.text
             assert "elbysodic-identity-menu" not in response.text


### PR DESCRIPTION
## Summary

Fixes the first-time visitor path around discovery, invite-only access, and the production shell:

- adds clear anonymous `Log in` and `Request access` actions
- keeps `/login` and `/request-access` on the platform shell instead of the community sidebar
- replaces the unseeded network dead end with an intentional launch-state empty page
- adds an explicit production CSP compatible with the current Chirp/Alpine shell
- documents the invite-only/request-access posture and security header tradeoff

## Root Cause

Production can start with schema but no seeded programs, so `/` and `/network` fell into a bare `No programs are available yet` state. Anonymous shell actions also rendered only the theme toggle, and `/login` inherited community navigation despite having no production viewer context. The default CSP also blocked the current inline style/Alpine expression patterns used by Chirp and Chirp-UI.

## Validation

- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run pytest -q --tb=short`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`

## Notes

Railway still needs this branch deployed. If the demo should show public realms instead of the launch state, seed the Railway volume intentionally with `elbysodic seed-demo`.
