### PR TITLE
[codex] add public realm previews

### DIFF
--- a/changelog.d/+public-realm-previews.added.md
+++ b/changelog.d/+public-realm-previews.added.md
@@ -1,0 +1,1 @@
+Public realm previews now let signed-out visitors browse a community's premise, guidebook, and wanted hooks without exposing private queues, staff controls, interest notes, or write actions.

--- a/docs/architecture/rendered-route-privacy-matrix.md
+++ b/docs/architecture/rendered-route-privacy-matrix.md
@@ -25,13 +25,14 @@ Use these viewer modes when a route can expose scoped data:
 | inactive | Membership exists but is inactive. | Actions fail and private data stays hidden. |
 | cross-tenant | Membership belongs to another community or route slug exists elsewhere. | Current community does not leak the other community's object. |
 | faceless | Membership has no active/current character. | Character-backed actions disappear or ask for a face instead of guessing. |
+| public | Signed-out visitor on a public-ready tenant preview route. | Published premise, guidebook, and wanted context is visible; identity, staff, queues, drafts, private notes, reserves, and POST actions stay hidden or blocked. |
 
 ## Route Families
 
 | Route Family | Sensitive Data | Member | Owner | Staff | Cross-Tenant / Missing | Coverage |
 | --- | --- | --- | --- | --- | --- | --- |
-| `/world`, `/world/{material}` | Draft materials, Material Studio controls, current event links. | Published materials only. | Same as member unless staff. | Drafts and edit controls visible. | Recovery page; no draft body. | covered for draft material regressions |
-| `/wanted`, `/wanted/{wanted}` | Archived hooks, interested faces, lifecycle controls, private interest notes, plotting-room links, and scene-handoff links. | Open/non-archived hooks only; unrelated members do not see another writer's note or room link. | Own hook controls and interest notes visible. | Casting controls and interest notes visible. | Recovery page; no archived body, private note, or room link. | covered for prospective-note privacy and wanted backstage handoff |
+| `/c/{community}/`, `/c/{community}/world`, `/c/{community}/world/{material}` | Draft materials, Material Studio controls, current event links, raw scene/thread activity, private queue state. | Published materials only on member-local `/world`; public tenant preview uses published public read models. | Same as member unless staff. | Drafts and edit controls visible. | Recovery page or 404; no draft body. | covered for draft material regressions and signed-out public tenant preview |
+| `/c/{community}/wanted`, `/c/{community}/wanted/{wanted}` | Archived hooks, interested faces, lifecycle controls, private interest notes, plotting-room links, reserves, and scene-handoff links. | Open/non-archived hooks only; unrelated members do not see another writer's note or room link. | Own hook controls and interest notes visible. | Casting controls and interest notes visible. | Recovery page or 404; no archived body, private note, reserve, or room link. | covered for prospective-note privacy, wanted backstage handoff, and signed-out public tenant preview |
 | `/claims`, `/claims?...` | Claim and reserve state, filtered counts, character links, director notes, staff maintenance controls. | Public claim/reserve directory state only; staff controls and director notes absent. | Same as member unless staff. | Claims maintenance forms and director notes visible only with casting/staff capability. | No claim, reserve, character, or count data from another community. | covered for rendered directory state and tenant-scoped query/link regressions; staff/member contrast still partial |
 | `/casting` | Casting desk lanes, active-face prompts, wanted handoffs, reserves, private notes surfaced through casting workflows. | Own visible casting opportunities and face-specific prompts. | Own hook/interest handoffs where applicable. | Casting controls, review lanes, and private notes visible only with capability. | No wanted, reserve, claim, or face data from another community. | partial |
 | `/applications`, `/applications/{character}` | Applicant draft body, staff notes, checklist, revision notes. | Own applications only. | Own applicant controls. | Review queue and staff notes visible. | Recovery page or local applications hub. | partial |
@@ -83,7 +84,7 @@ control appears or does not appear than to snapshot large HTML sections.
 
 ## Current Gaps
 
-- Production public catalog/search proof for signed-out and signed-in users.
+- Browser QA evidence for responsive public realm preview pages.
 - Application review room owner/staff/outsider route-family coverage.
 - Claims conflict and reserve visibility coverage beyond directory and
   tenant-scoped query/link rendering.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -64,6 +64,10 @@ Production request identity is session-backed:
 
 - normal app routes require a valid `elbysodic_session`
 - `/health`, `/login`, `/logout`, `/`, `/network`, `/request-access`, and static assets are public
+- signed-out shared-host tenant preview routes are public for `GET`/`HEAD` only:
+  `/c/{community}/`, `/c/{community}/world`,
+  `/c/{community}/world/{material_slug}`, `/c/{community}/wanted`, and
+  `/c/{community}/wanted/{wanted_slug}`
 - dev identity headers are ignored
 - unsigned `elbysodic_dev_identity` cookies are ignored and are not issued
 - `/dev/personas` is unavailable even when `ELBYSODIC_DEV_TOOLS` is set
@@ -73,6 +77,15 @@ They can show realm names, public premise or current-event summaries, public
 media, roster counts, and wanted-hook counts. They must not render membership
 names, active faces, unread counts, staff signals, identity switch forms, or
 private writer queues.
+
+Signed-out tenant previews use the same posture inside one public-ready realm.
+They can show published guidebook materials, public premise/current-event
+summaries, non-archived wanted hooks, public media, face counts, and
+request-access/login calls to action. They must not render draft materials,
+private or raw scene/thread activity, wanted interest notes, reserves, plotting
+room links, lifecycle controls, identity menus, unread counts, or any mutating
+forms. Raising interest, reserving, applying, replying, watching, and staff
+workflow actions still require a valid session and community-local membership.
 
 First-realm creation is not a public web permission. The current setup path is
 the operator-only `bootstrap-first-realm` CLI command, which creates a global

--- a/src/elbysodic/services/casting.py
+++ b/src/elbysodic/services/casting.py
@@ -183,6 +183,16 @@ def wanted_board(repo: CastingReadRepository, viewer: ForumView) -> WantedBoard:
     )
 
 
+def public_wanted_board(repo: CastingReadRepository, community_id: int) -> WantedBoard:
+    return WantedBoard(
+        open_ads=[
+            public_wanted_ad_summary(repo, community_id, wanted_ad)
+            for wanted_ad in repo.list_wanted_ads(community_id, status=None)
+            if wanted_ad.status != "archived"
+        ]
+    )
+
+
 def casting_desk(repo: CastingReadRepository, viewer: ForumView) -> CastingDesk:
     active_reserves = [
         character_reserve_view(repo, viewer.community.id, reserve)
@@ -343,6 +353,68 @@ def read_wanted_ad(
         rendered_body=render_prose_body(
             body,
             mentions=post_mention_links(repo, viewer.community.id),
+        ),
+        casting_packet=casting_packet,
+        type_label=wanted_type_label(wanted_ad.wanted_type),
+        related_ads=related[:4],
+    )
+
+
+def public_read_wanted_ad(
+    repo: CastingReadRepository,
+    community_id: int,
+    wanted_slug: str,
+) -> WantedAdDetail:
+    wanted_ad = repo.get_wanted_ad_by_slug(community_id, wanted_slug)
+    if wanted_ad.status == "archived":
+        raise LookupError(f"wanted ad not found in community {community_id}: {wanted_slug}")
+    facets = facet_tags(
+        repo,
+        community_id,
+        repo.list_wanted_ad_facets(community_id, wanted_ad.id),
+    )
+    facet_ids = {tag.facet.id for tag in facets}
+    related = []
+    for candidate in repo.list_wanted_ads(community_id, status=None):
+        if candidate.id == wanted_ad.id or candidate.status == "archived":
+            continue
+        candidate_facets = facet_tags(
+            repo,
+            community_id,
+            repo.list_wanted_ad_facets(community_id, candidate.id),
+        )
+        if facet_ids and not facet_ids.intersection({tag.facet.id for tag in candidate_facets}):
+            continue
+        related.append(public_wanted_ad_summary(repo, community_id, candidate))
+    body, casting_packet = parse_wanted_casting_packet(wanted_ad.body)
+    return WantedAdDetail(
+        wanted_ad=wanted_ad,
+        creator_membership=repo.get_membership(
+            community_id,
+            wanted_ad.creator_membership_id,
+        ),
+        creator_character=(
+            repo.get_character(community_id, wanted_ad.creator_character_id)
+            if wanted_ad.creator_character_id is not None
+            else None
+        ),
+        related_material=public_related_material(repo, community_id, wanted_ad),
+        related_characters=repo.list_wanted_ad_related_characters(
+            community_id,
+            wanted_ad.id,
+        ),
+        facets=facets,
+        interests=[],
+        reserves=[],
+        reserve_interest_ids=set(),
+        viewer_interest=None,
+        can_express_interest=False,
+        can_express_prospective_interest=False,
+        is_created_by_viewer=False,
+        can_manage=False,
+        rendered_body=render_prose_body(
+            body,
+            mentions=post_mention_links(repo, community_id),
         ),
         casting_packet=casting_packet,
         type_label=wanted_type_label(wanted_ad.wanted_type),
@@ -558,6 +630,41 @@ def wanted_ad_summary(
         ),
         type_label=wanted_type_label(wanted_ad.wanted_type),
     )
+
+
+def public_wanted_ad_summary(
+    repo: CastingReadRepository,
+    community_id: int,
+    wanted_ad: WantedAd,
+) -> WantedAdSummary:
+    return WantedAdSummary(
+        wanted_ad=wanted_ad,
+        creator_membership=repo.get_membership(community_id, wanted_ad.creator_membership_id),
+        creator_character=(
+            repo.get_character(community_id, wanted_ad.creator_character_id)
+            if wanted_ad.creator_character_id is not None
+            else None
+        ),
+        related_material=public_related_material(repo, community_id, wanted_ad),
+        related_characters=[],
+        facets=facet_tags(
+            repo,
+            community_id,
+            repo.list_wanted_ad_facets(community_id, wanted_ad.id),
+        ),
+        type_label=wanted_type_label(wanted_ad.wanted_type),
+    )
+
+
+def public_related_material(
+    repo: CastingReadRepository,
+    community_id: int,
+    wanted_ad: WantedAd,
+) -> Material | None:
+    if wanted_ad.related_material_id is None:
+        return None
+    material = repo.get_material(community_id, wanted_ad.related_material_id)
+    return material if material.status == "published" else None
 
 
 def wanted_ad_interest_view(

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -83,6 +83,9 @@ from elbysodic.services.casting import (
     express_prospective_wanted_interest as _express_prospective_wanted_interest,
 )
 from elbysodic.services.casting import express_wanted_interest as _express_wanted_interest
+from elbysodic.services.casting import public_read_wanted_ad as _public_read_wanted_ad
+from elbysodic.services.casting import public_wanted_ad_summary as _public_wanted_ad_summary
+from elbysodic.services.casting import public_wanted_board as _public_wanted_board
 from elbysodic.services.casting import read_wanted_ad as _read_wanted_ad
 from elbysodic.services.casting import reserve_wanted_interest as _reserve_wanted_interest
 from elbysodic.services.casting import (
@@ -125,6 +128,7 @@ from elbysodic.services.materials import (
 )
 from elbysodic.services.materials import material_detail as _material_detail
 from elbysodic.services.materials import material_summary as _material_summary
+from elbysodic.services.materials import public_material_detail as _public_material_detail
 from elbysodic.services.materials import (
     update_material_production_state as _update_material_production_state,
 )
@@ -768,6 +772,87 @@ class AppServices:
                 )
             )
         return StudioNetworkDirectory(programs=programs)
+
+    def public_studio_program(self, community_slug: str) -> StudioNetworkProgramView:
+        community = self._public_preview_community(community_slug)
+        materials = self.repo.list_materials(community.id)
+        wanted_ads = self.repo.list_wanted_ads(community.id, status=None)
+        community_characters = self.repo.list_community_characters(community.id)
+        theme = community_theme_view(self.repo.get_default_theme(community.id))
+        return StudioNetworkProgramView(
+            community=community,
+            membership=None,
+            role=None,
+            current_character=None,
+            premise=_first_material_summary(materials, "premise", self.repo, community.id),
+            current_event=_first_material_summary(
+                materials,
+                "event",
+                self.repo,
+                community.id,
+            ),
+            roster_count=len(community_characters),
+            open_wanted_count=sum(1 for wanted_ad in wanted_ads if wanted_ad.status == "open"),
+            application_count=0,
+            plotting_room_count=0,
+            unread_notification_count=0,
+            theme_preview=_network_theme_preview(theme),
+            is_current=False,
+        )
+
+    def public_world_hub(self, community_slug: str) -> WorldHub:
+        community = self._public_preview_community(community_slug)
+        materials = [
+            _material_summary(self.repo, community.id, material)
+            for material in self.repo.list_materials(community.id)
+        ]
+        additional_materials = [item for item in materials if not item.material.is_featured]
+        return WorldHub(
+            featured=[item for item in materials if item.material.is_featured],
+            guides=[
+                item
+                for item in additional_materials
+                if item.material.material_type in {"premise", "guide", "factions"}
+            ],
+            events=[item for item in materials if item.material.material_type == "event"],
+            application_materials=[
+                item
+                for item in additional_materials
+                if item.material.material_type == "application"
+            ],
+            can_manage=False,
+        )
+
+    def public_read_material(self, community_slug: str, material_slug: str) -> MaterialDetail:
+        community = self._public_preview_community(community_slug)
+        material = self.repo.get_material_by_slug(community.id, material_slug)
+        if material.status != "published":
+            raise LookupError(f"material not found in community {community.id}: {material_slug}")
+        return _public_material_detail(
+            self.repo,
+            community.id,
+            material,
+            wanted_summary_factory=lambda wanted_ad: _public_wanted_ad_summary(
+                self.repo,
+                community.id,
+                wanted_ad,
+            ),
+        )
+
+    def public_wanted_ads(self, community_slug: str) -> WantedBoard:
+        community = self._public_preview_community(community_slug)
+        return _public_wanted_board(self.repo, community.id)
+
+    def public_read_wanted_ad(self, community_slug: str, wanted_slug: str) -> WantedAdDetail:
+        community = self._public_preview_community(community_slug)
+        return _public_read_wanted_ad(self.repo, community.id, wanted_slug)
+
+    def _public_preview_community(self, community_slug: str) -> Community:
+        community = self.repo.get_community_by_slug(community_slug)
+        materials = self.repo.list_materials(community.id)
+        if not _is_public_network_ready(self.repo, community, materials):
+            raise LookupError(f"community not available for public preview: {community_slug}")
+        return community
 
     def list_boards(self) -> list[BoardSummary]:
         viewer = self.viewer()

--- a/src/elbysodic/services/materials.py
+++ b/src/elbysodic/services/materials.py
@@ -157,6 +157,56 @@ def material_detail(
     )
 
 
+def public_material_detail(
+    repo: MaterialReadRepository,
+    community_id: int,
+    material: Material,
+    *,
+    wanted_summary_factory: WantedAdSummaryFactory,
+) -> MaterialDetail:
+    facets = facet_tags(
+        repo,
+        community_id,
+        repo.list_material_facets(community_id, material.id),
+    )
+    facet_ids = {tag.facet.id for tag in facets}
+    related = related_materials(repo, community_id, material, facet_ids)
+    related_wanted_ads = public_material_related_wanted_ads(
+        repo,
+        community_id,
+        material,
+        facet_ids,
+        wanted_summary_factory=wanted_summary_factory,
+    )[:4]
+    return MaterialDetail(
+        material=material,
+        facets=facets,
+        rendered_body=render_prose_body(
+            material.body,
+            mentions=post_mention_links(repo, community_id),
+        ),
+        type_label=material_type_label(material.material_type),
+        related_materials=related[:4],
+        related_locations=[],
+        related_scenes=[],
+        related_wanted_ads=related_wanted_ads,
+        continuity_beats=material_continuity_beats(
+            material,
+            [],
+            [],
+            related_wanted_ads,
+        ),
+        event_actions=material_event_actions(
+            material,
+            [],
+            [],
+            [],
+            related_wanted_ads,
+        ),
+        can_manage=False,
+    )
+
+
 def update_material_production_state(
     repo: MaterialReadRepository,
     viewer: ForumView,
@@ -311,6 +361,37 @@ def material_related_wanted_ads(
     for wanted_ad in repo.list_wanted_ads(viewer.community.id):
         wanted_facet_ids = {
             facet.id for facet in repo.list_wanted_ad_facets(viewer.community.id, wanted_ad.id)
+        }
+        if wanted_ad.related_material_id != material.id and not facet_ids.intersection(
+            wanted_facet_ids
+        ):
+            continue
+        results.append(wanted_summary_factory(wanted_ad))
+    return sorted(
+        results,
+        key=lambda item: (
+            item.wanted_ad.related_material_id != material.id,
+            timestamp_key(item.wanted_ad.updated_at),
+            item.wanted_ad.id,
+        ),
+        reverse=True,
+    )
+
+
+def public_material_related_wanted_ads(
+    repo: MaterialReadRepository,
+    community_id: int,
+    material: Material,
+    facet_ids: set[int],
+    *,
+    wanted_summary_factory: WantedAdSummaryFactory,
+) -> list[WantedAdSummary]:
+    results: list[WantedAdSummary] = []
+    for wanted_ad in repo.list_wanted_ads(community_id, status=None):
+        if wanted_ad.status == "archived":
+            continue
+        wanted_facet_ids = {
+            facet.id for facet in repo.list_wanted_ad_facets(community_id, wanted_ad.id)
         }
         if wanted_ad.related_material_id != material.id and not facet_ids.intersection(
             wanted_facet_ids

--- a/src/elbysodic/web/pages/_components/wanted.html
+++ b/src/elbysodic/web/pages/_components/wanted.html
@@ -13,7 +13,7 @@
 </span>
 {% end %}
 
-{% def wanted_card(item) %}
+{% def wanted_card(item, link_context=true) %}
 {% call surface(variant="elevated", cls="elbysodic-wanted-card-shell elbysodic-wanted-card-shell--" ~ item.wanted_ad.status) %}
 <article class="chirpui-stack chirpui-stack--sm elbysodic-wanted-card elbysodic-wanted-card--{{ item.wanted_ad.status }}">
   <div class="chirpui-cluster chirpui-cluster--between elbysodic-wanted-card__header">
@@ -35,16 +35,24 @@
     {% if item.creator_character %}
     <span>
       wanted by
+      {% if link_context %}
       <a class="chirpui-link" href="/characters/{{ item.creator_character.slug }}">
         {{ item.creator_character.name }}
       </a>
+      {% else %}
+      {{ item.creator_character.name }}
+      {% end %}
     </span>
     {% else %}
     <span>
       wanted by
+      {% if link_context %}
       <a class="chirpui-link" href="/members/{{ item.creator_membership.username }}">
         {{ item.creator_membership.username }}
       </a>
+      {% else %}
+      {{ item.creator_membership.display_name or item.creator_membership.username }}
+      {% end %}
     </span>
     {% end %}
     {% if item.related_material %}

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -8,28 +8,33 @@
 {% set shell_has_community = show_community_shell | default(true) %}
 {% set shell_sidebar_hidden = shell_has_community and sidebar_is_hidden() %}
 
-{% block title %}{{ page_title if page_title is defined else (viewer.community.name if shell_has_community and viewer else "Elbysodic") }}{% end %}
+{% block title %}
+{% set title_viewer = viewer | default(none) %}
+{% set title_community = (title_viewer.community if shell_has_community and title_viewer else (community | default(none))) %}
+{{ page_title if page_title is defined else (title_community.name if title_community else "Elbysodic") }}
+{% end %}
 
 {% def program_theme_css(has_community, current_viewer) %}
-{% if has_community and current_viewer and current_viewer.program_theme %}
+{% set active_program_theme = current_viewer.program_theme if current_viewer else (program_theme if program_theme is defined else none) %}
+{% if has_community and active_program_theme %}
       :root {
-        {% for variable, value in current_viewer.program_theme.base_variables %}
+        {% for variable, value in active_program_theme.base_variables %}
         {{ variable }}: {{ value }};
         {% end %}
-        {% for variable, value in current_viewer.program_theme.dark_variables %}
+        {% for variable, value in active_program_theme.dark_variables %}
         {{ variable }}: {{ value }};
         {% end %}
       }
 
       [data-theme="light"] {
-        {% for variable, value in current_viewer.program_theme.light_variables %}
+        {% for variable, value in active_program_theme.light_variables %}
         {{ variable }}: {{ value }};
         {% end %}
       }
 
       @media (prefers-color-scheme: light) {
         [data-theme="system"] {
-          {% for variable, value in current_viewer.program_theme.light_variables %}
+          {% for variable, value in active_program_theme.light_variables %}
           {{ variable }}: {{ value }};
           {% end %}
         }
@@ -37,7 +42,7 @@
 
       @media (prefers-color-scheme: dark) {
         [data-theme="system"] {
-          {% for variable, value in current_viewer.program_theme.dark_variables %}
+          {% for variable, value in active_program_theme.dark_variables %}
           {{ variable }}: {{ value }};
           {% end %}
         }
@@ -112,7 +117,9 @@
 {% end %}
 
 {% block title_oob %}
-<title id="chirpui-document-title">{{ page_title if page_title is defined else (viewer.community.name if shell_has_community and viewer else "Elbysodic") }}</title>
+{% set title_viewer = viewer | default(none) %}
+{% set title_community = (title_viewer.community if show_community_shell | default(true) and title_viewer else (community | default(none))) %}
+<title id="chirpui-document-title">{{ page_title if page_title is defined else (title_community.name if title_community else "Elbysodic") }}</title>
 {% end %}
 
 {% block program_theme_oob %}
@@ -124,19 +131,22 @@
 {% end %}
 
 {% block brand_link %}
+{% set brand_has_community_shell = show_community_shell | default(true) %}
+{% set brand_viewer = viewer | default(none) %}
+{% set brand_community = (brand_viewer.community if brand_has_community_shell and brand_viewer else (community | default(none))) %}
 <a href="/"
    class="chirpui-app-shell__brand elbysodic-community-brand"
    hx-boost="false">
-  {% if shell_has_community and viewer and viewer.community.community_mark_url %}
+  {% if brand_community and brand_community.community_mark_url %}
   <img class="elbysodic-community-brand__mark"
-       src="{{ viewer.community.community_mark_url }}"
-       alt="{{ viewer.community.community_mark_alt }}">
-  {% elif not shell_has_community %}
+       src="{{ brand_community.community_mark_url }}"
+       alt="{{ brand_community.community_mark_alt }}">
+  {% elif not brand_has_community_shell %}
   <img class="elbysodic-community-brand__mark elbysodic-product-mark elbysodic-product-mark--brand"
        src="/elbysodic-static/brand/elbysodic-mark-small.svg"
        alt="">
   {% end %}
-  <span class="elbysodic-community-brand__name">{{ viewer.community.name if shell_has_community and viewer else "Elbysodic" }}</span>
+  <span class="elbysodic-community-brand__name">{{ brand_community.name if brand_community else "Elbysodic" }}</span>
 </a>
 {% end %}
 

--- a/src/elbysodic/web/pages/page.html
+++ b/src/elbysodic/web/pages/page.html
@@ -20,37 +20,80 @@
 {% block page_content %}
 {% call container(max_width="76rem") %}
 {% call stack(gap="lg") %}
-  {% set hero_treatment = viewer.community.world_hero_treatment or "split" %}
-  {% set hero_uses_media = viewer.community.world_hero_image_url and hero_treatment != "text" %}
-  <section class="elbysodic-world-hero elbysodic-world-hero--{{ hero_treatment }} elbysodic-world-hero--height-{{ viewer.community.world_hero_height or "standard" }} elbysodic-world-hero--overlay-{{ viewer.community.world_hero_overlay or "medium" }} elbysodic-world-hero--focal-{{ viewer.community.world_hero_focal_point or "center" }}{{ " elbysodic-world-hero--with-media" if hero_uses_media else "" }}">
+  {% set home_community = viewer.community if viewer else public_program.community %}
+  {% set hero_treatment = home_community.world_hero_treatment or "split" %}
+  {% set hero_uses_media = home_community.world_hero_image_url and hero_treatment != "text" %}
+  <section class="elbysodic-world-hero elbysodic-world-hero--{{ hero_treatment }} elbysodic-world-hero--height-{{ home_community.world_hero_height or "standard" }} elbysodic-world-hero--overlay-{{ home_community.world_hero_overlay or "medium" }} elbysodic-world-hero--focal-{{ home_community.world_hero_focal_point or "center" }}{{ " elbysodic-world-hero--with-media" if hero_uses_media else "" }}">
     <div class="elbysodic-world-hero__copy">
-      <p class="elbysodic-kicker">World status</p>
-      <h1>{{ viewer.community.name }}</h1>
+      <p class="elbysodic-kicker">{{ "World status" if viewer else "Public realm preview" }}</p>
+      <h1>{{ home_community.name }}</h1>
       <p class="elbysodic-copy-lead">
         <strong>{{ world_status_label }}</strong> {{ world_status_copy }}
       </p>
+      {% if not viewer %}
+      <div class="chirpui-cluster">
+        <a class="chirpui-btn chirpui-btn--primary" href="/world">Open guidebook</a>
+        {% if public_program.open_wanted_count %}
+        <a class="chirpui-btn chirpui-btn--secondary" href="/wanted">Browse wanted</a>
+        {% end %}
+        <a class="chirpui-btn chirpui-btn--secondary" href="/request-access" hx-boost="false">Request access</a>
+      </div>
+      {% end %}
+      {% if viewer %}
       {% if viewer.current_character %}
       <p class="elbysodic-copy-helper">
         Relevant locations are quietly marked for the active face.
       </p>
       {% else %}
       <p class="elbysodic-copy-helper">
-        Create your first character to start posting in {{ viewer.community.name }}.
+        Create your first character to start posting in {{ home_community.name }}.
       </p>
+      {% end %}
       {% end %}
     </div>
     <div class="elbysodic-world-hero__stats">
+      {% if viewer %}
       {{ stat(value=location_boards | length, label="Locations") }}
       {{ stat(value=viewer.roster | length, label="Characters") }}
       {{ stat(value=viewer.membership.post_count, label="Posts") }}
+      {% else %}
+      {{ stat(value=public_program.roster_count, label="Faces") }}
+      {{ stat(value=public_program.open_wanted_count, label="Wanted") }}
+      {{ stat(value=guidebook.featured | length + guidebook.guides | length + guidebook.events | length, label="Guides") }}
+      {% end %}
     </div>
     {% if hero_uses_media %}
     <figure class="elbysodic-world-hero__media">
-      <img src="{{ viewer.community.world_hero_image_url }}" alt="{{ viewer.community.world_hero_image_alt }}">
+      <img src="{{ home_community.world_hero_image_url }}" alt="{{ home_community.world_hero_image_alt }}">
     </figure>
     {% end %}
   </section>
 
+  {% if not viewer %}
+  {{ home_section_header("Start here", "Premise, current events, and public guidebook material directors have made visible.") }}
+
+  <div class="elbysodic-material-grid">
+    {% for item in guidebook.featured %}
+    <a class="elbysodic-current-event-card elbysodic-current-event-card--{{ item.material.material_type }}" href="/world/{{ item.material.slug }}">
+      <span class="elbysodic-material-card__type">{{ item.type_label }}</span>
+      <strong>{{ item.material.title }}</strong>
+      <span>{{ item.rendered_summary }}</span>
+    </a>
+    {% end %}
+    {% for item in guidebook.events[:2] %}
+    <a class="elbysodic-current-event-card elbysodic-current-event-card--{{ item.material.material_type }}" href="/world/{{ item.material.slug }}">
+      <span class="elbysodic-material-card__type">{{ item.type_label }}</span>
+      <strong>{{ item.material.title }}</strong>
+      <span>{{ item.rendered_summary }}</span>
+    </a>
+    {% end %}
+  </div>
+
+  {% if public_program.open_wanted_count %}
+  {{ home_section_header("Wanted hooks", "Open roles and story invitations that can become a first writing lane.") }}
+  <a class="chirpui-btn chirpui-btn--secondary" href="/wanted">Browse {{ public_program.open_wanted_count }} wanted hooks</a>
+  {% end %}
+  {% else %}
   {{ home_section_header("Locations", "In-character doors into the board's world, conflicts, and current event pressure.") }}
 
   <div class="elbysodic-location-grid">
@@ -90,6 +133,7 @@
     {{ activity_log_item(item.board, item.thread, item.post, item.snippet, "new" if item.is_unread else "", "info") }}
     {% end %}
   </div>
+  {% end %}
   {% end %}
 {% end %}
 {% end %}

--- a/src/elbysodic/web/pages/page.py
+++ b/src/elbysodic/web/pages/page.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from chirp.errors import HTTPError
 from chirp.http.request import Request
 from chirp.templating.returns import Page
 
@@ -33,7 +34,8 @@ def _first_material(materials: list[MaterialSummary]) -> MaterialSummary | None:
 
 
 def get(request: Request) -> Page:
-    if request_tenant_slug(request) is None:
+    tenant_slug = request_tenant_slug(request)
+    if tenant_slug is None:
         services, viewer = _network_services(request)
         network = (
             services.studio_network() if viewer is not None else services.public_studio_network()
@@ -50,8 +52,29 @@ def get(request: Request) -> Page:
             show_community_shell=False,
         )
 
-    services = get_services(request)
-    viewer = services.viewer()
+    try:
+        services = get_services().for_request(request)
+        viewer = services.viewer()
+    except LookupError, PermissionError:
+        services = get_services()
+        try:
+            program = services.public_studio_program(tenant_slug)
+            hub = services.public_world_hub(tenant_slug)
+        except LookupError as exc:
+            raise HTTPError(status=404, detail=str(exc)) from exc
+        world_status_label, world_status_copy = _home_world_status(hub)
+        return Page.mounted(
+            "page.html",
+            current_path=request.url,
+            page_title=program.community.name,
+            viewer=None,
+            public_program=program,
+            community=program.community,
+            world_status_label=world_status_label,
+            world_status_copy=world_status_copy,
+            guidebook=hub,
+            show_community_shell=False,
+        )
     boards = services.list_boards()
     hub = services.world_hub()
     world_status_label, world_status_copy = _home_world_status(hub)

--- a/src/elbysodic/web/pages/wanted/page.html
+++ b/src/elbysodic/web/pages/wanted/page.html
@@ -17,7 +17,7 @@
   {% if board.open_ads %}
   <div class="elbysodic-wanted-grid">
     {% for item in board.open_ads %}
-    {{ wanted_card(item) }}
+    {{ wanted_card(item, viewer is not none) }}
     {% end %}
   </div>
   {% else %}

--- a/src/elbysodic/web/pages/wanted/page.py
+++ b/src/elbysodic/web/pages/wanted/page.py
@@ -2,16 +2,36 @@
 
 from __future__ import annotations
 
+from chirp.errors import HTTPError
 from chirp.http.request import Request
 from chirp.templating.returns import Page
 
-from elbysodic.services import AppServices
+from elbysodic.web.state import get_services
+from elbysodic.web.tenant import request_tenant_slug
 
 
-def get(request: Request, services: AppServices) -> Page:
+def get(request: Request) -> Page:
+    tenant_slug = request_tenant_slug(request)
+    try:
+        services = get_services().for_request(request)
+        viewer = services.viewer()
+        board = services.wanted_ads()
+        community = viewer.community
+    except LookupError, PermissionError:
+        if tenant_slug is None:
+            raise
+        services = get_services()
+        viewer = None
+        try:
+            board = services.public_wanted_ads(tenant_slug)
+            community = services.public_studio_program(tenant_slug).community
+        except LookupError as exc:
+            raise HTTPError(status=404, detail=str(exc)) from exc
     return Page.mounted(
         "wanted/page.html",
         current_path=request.url,
-        viewer=services.viewer(),
-        board=services.wanted_ads(),
+        viewer=viewer,
+        community=community,
+        board=board,
+        show_community_shell=viewer is not None,
     )

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/page.html
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/page.html
@@ -29,9 +29,17 @@
         <span>
           wanted by
           {% if wanted.creator_character %}
+          {% if viewer %}
           <a class="chirpui-link" href="/characters/{{ wanted.creator_character.slug }}">{{ wanted.creator_character.name }}</a>
           {% else %}
+          {{ wanted.creator_character.name }}
+          {% end %}
+          {% else %}
+          {% if viewer %}
           <a class="chirpui-link" href="/members/{{ wanted.creator_membership.username }}">{{ wanted.creator_membership.username }}</a>
+          {% else %}
+          {{ wanted.creator_membership.display_name or wanted.creator_membership.username }}
+          {% end %}
           {% end %}
         </span>
         {% if wanted.related_material %}
@@ -48,6 +56,7 @@
       <p class="elbysodic-copy-meta">Related characters</p>
       <div class="elbysodic-character-chip-row">
         {% for character in wanted.related_characters %}
+        {% if viewer %}
         <a class="elbysodic-character-chip" href="/characters/{{ character.slug }}">
           <span class="elbysodic-character-avatar" aria-hidden="true">
             {% if character.avatar_url %}
@@ -58,6 +67,18 @@
           </span>
           <span>{{ character.name }}</span>
         </a>
+        {% else %}
+        <span class="elbysodic-character-chip">
+          <span class="elbysodic-character-avatar" aria-hidden="true">
+            {% if character.avatar_url %}
+            <img src="{{ character.avatar_url }}" alt="">
+            {% else %}
+            {{ character.name[:1] }}
+            {% end %}
+          </span>
+          <span>{{ character.name }}</span>
+        </span>
+        {% end %}
         {% end %}
       </div>
     </div>
@@ -147,6 +168,11 @@
       <p class="elbysodic-copy-status">You created this hook.</p>
       {% elif wanted.wanted_ad.status != "open" %}
       <p class="elbysodic-copy-status">This hook is {{ wanted.wanted_ad.status }}.</p>
+      {% elif not viewer %}
+      <div class="chirpui-cluster chirpui-cluster--end">
+        <a class="chirpui-btn chirpui-btn--primary" href="/login?next={{ current_path or "/" }}" hx-boost="false">Log in to raise interest</a>
+        <a class="chirpui-btn chirpui-btn--secondary" href="/request-access" hx-boost="false">Request access</a>
+      </div>
       {% end %}
       {% if wanted.can_express_prospective_interest %}
       <details class="elbysodic-management-disclosure elbysodic-action-disclosure elbysodic-prospective-interest">
@@ -373,7 +399,7 @@
   {% end %}
   <div class="elbysodic-wanted-grid">
     {% for item in wanted.related_ads %}
-    {{ wanted_card(item) }}
+    {{ wanted_card(item, viewer is not none) }}
     {% end %}
   </div>
   {% end %}

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
@@ -12,6 +12,7 @@ from chirp.templating.returns import Page
 
 from elbysodic.web.recovery import recover_missing_route
 from elbysodic.web.state import get_services
+from elbysodic.web.tenant import request_tenant_slug
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,16 +113,33 @@ async def post(request: Request, wanted_slug: str) -> Page | Redirect:
 
 
 def _render_wanted(request: Request, wanted_slug: str) -> Page:
-    services = get_services(request)
+    tenant_slug = request_tenant_slug(request)
     try:
-        wanted = services.read_wanted_ad(wanted_slug)
-    except LookupError:
-        return recover_missing_route(request, kind="wanted", slug=wanted_slug)
+        services = get_services().for_request(request)
+        viewer = services.viewer()
+    except LookupError, PermissionError:
+        if tenant_slug is None:
+            raise
+        services = get_services()
+        try:
+            wanted = services.public_read_wanted_ad(tenant_slug, wanted_slug)
+            community = services.public_studio_program(tenant_slug).community
+        except LookupError as exc:
+            raise HTTPError(status=404, detail=str(exc)) from exc
+        viewer = None
+    else:
+        try:
+            wanted = services.read_wanted_ad(wanted_slug)
+        except LookupError:
+            return recover_missing_route(request, kind="wanted", slug=wanted_slug)
+        community = viewer.community
     return Page.mounted(
         "wanted/{wanted_slug}/page.html",
         current_path=request.url,
-        viewer=services.viewer(),
+        viewer=viewer,
+        community=community,
         wanted=wanted,
+        show_community_shell=viewer is not None,
     )
 
 

--- a/src/elbysodic/web/pages/world/page.py
+++ b/src/elbysodic/web/pages/world/page.py
@@ -2,18 +2,37 @@
 
 from __future__ import annotations
 
+from chirp.errors import HTTPError
 from chirp.http.request import Request
 from chirp.templating.returns import Page
 
-from elbysodic.services import AppServices
+from elbysodic.web.state import get_services
+from elbysodic.web.tenant import request_tenant_slug
 
 
-def get(request: Request, services: AppServices) -> Page:
-    hub = services.world_hub()
+def get(request: Request) -> Page:
+    tenant_slug = request_tenant_slug(request)
+    try:
+        services = get_services().for_request(request)
+        viewer = services.viewer()
+        hub = services.world_hub()
+        community = viewer.community
+    except LookupError, PermissionError:
+        if tenant_slug is None:
+            raise
+        services = get_services()
+        viewer = None
+        try:
+            hub = services.public_world_hub(tenant_slug)
+            community = services.public_studio_program(tenant_slug).community
+        except LookupError as exc:
+            raise HTTPError(status=404, detail=str(exc)) from exc
     return Page.mounted(
         "world/page.html",
         current_path=request.url,
-        viewer=services.viewer(),
+        viewer=viewer,
+        community=community,
         hub=hub,
         guidebook=hub,
+        show_community_shell=viewer is not None,
     )

--- a/src/elbysodic/web/pages/world/{material_slug}/page.html
+++ b/src/elbysodic/web/pages/world/{material_slug}/page.html
@@ -195,7 +195,7 @@
   {% end %}
   <div class="elbysodic-wanted-grid">
     {% for item in material.related_wanted_ads %}
-    {{ wanted_card(item) }}
+    {{ wanted_card(item, viewer is not none) }}
     {% end %}
   </div>
   </section>

--- a/src/elbysodic/web/pages/world/{material_slug}/page.py
+++ b/src/elbysodic/web/pages/world/{material_slug}/page.py
@@ -13,6 +13,7 @@ from chirp.templating.returns import Page
 from elbysodic.services.forum import MATERIAL_STATUSES, MATERIAL_TYPES
 from elbysodic.web.recovery import recover_missing_route
 from elbysodic.web.state import get_services
+from elbysodic.web.tenant import request_tenant_slug
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,19 +75,38 @@ def _render_material(
     status: str | None = None,
     is_featured: bool | None = None,
 ) -> Page:
-    services = get_services(request)
+    tenant_slug = request_tenant_slug(request)
     try:
-        material = services.read_material(material_slug)
-    except LookupError:
-        return recover_missing_route(request, kind="material", slug=material_slug)
+        services = get_services().for_request(request)
+        viewer = services.viewer()
+    except LookupError, PermissionError:
+        if tenant_slug is None:
+            raise
+        services = get_services()
+        try:
+            material = services.public_read_material(tenant_slug, material_slug)
+            guidebook = services.public_world_hub(tenant_slug)
+            community = services.public_studio_program(tenant_slug).community
+        except LookupError as exc:
+            raise HTTPError(status=404, detail=str(exc)) from exc
+        viewer = None
+    else:
+        try:
+            material = services.read_material(material_slug)
+        except LookupError:
+            return recover_missing_route(request, kind="material", slug=material_slug)
+        guidebook = services.world_hub()
+        community = viewer.community
     return Page.mounted(
         "world/{material_slug}/page.html",
         current_path=request.url,
-        viewer=services.viewer(),
+        viewer=viewer,
+        community=community,
         material=material,
-        guidebook=services.world_hub(),
+        guidebook=guidebook,
         material_types=MATERIAL_TYPES,
         material_statuses=MATERIAL_STATUSES,
+        show_community_shell=viewer is not None,
         error=error,
         title=material.material.title if title is None else title,
         material_type=material.material.material_type if material_type is None else material_type,

--- a/src/elbysodic/web/security.py
+++ b/src/elbysodic/web/security.py
@@ -23,6 +23,8 @@ PRODUCTION_ENVS = frozenset({"production", "prod", "staging"})
 DEFAULT_PRODUCTION_ALLOWED_HOSTS = (".up.railway.app", ".railway.app")
 PUBLIC_PATHS = frozenset({"/", "/health", "/login", "/logout", "/network", "/request-access"})
 PUBLIC_PREFIXES = ("/elbysodic-static/",)
+PUBLIC_TENANT_GET_PATHS = frozenset({"/", "/world", "/wanted"})
+PUBLIC_TENANT_GET_PREFIXES = ("/world/", "/wanted/")
 PRODUCTION_CONTENT_SECURITY_POLICY = (
     "default-src 'self'; "
     "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://cdn.jsdelivr.net; "
@@ -151,10 +153,17 @@ def _strict_transport_security() -> str | None:
 
 
 def _is_public_request(request: Request) -> bool:
-    from elbysodic.web.tenant import request_tenant_slug
+    from elbysodic.web.tenant import request_tenant_slug, split_tenant_path
 
-    if request_tenant_slug(request) is not None and request.path in {"/", "/network"}:
-        return False
+    tenant_local_path = request.path if request_tenant_slug(request) is not None else None
+    split = split_tenant_path(request.path)
+    if split is not None:
+        _community_slug, tenant_local_path = split
+    if tenant_local_path is not None:
+        return request.method in {"GET", "HEAD"} and (
+            tenant_local_path in PUBLIC_TENANT_GET_PATHS
+            or any(tenant_local_path.startswith(prefix) for prefix in PUBLIC_TENANT_GET_PREFIXES)
+        )
     return request.path in PUBLIC_PATHS or any(
         request.path.startswith(prefix) for prefix in PUBLIC_PREFIXES
     )

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -182,6 +182,18 @@ def test_production_routes_require_session(monkeypatch) -> None:
             request_access = await client.get("/request-access")
             studio = await client.get("/studio")
             tenant = await client.get("/c/x-men-apocalypse")
+            tenant_world = await client.get("/c/x-men-apocalypse/world")
+            tenant_material = await client.get("/c/x-men-apocalypse/world/premise")
+            tenant_wanted = await client.get("/c/x-men-apocalypse/wanted")
+            tenant_wanted_detail = await client.get(
+                "/c/x-men-apocalypse/wanted/brotherhood-rival-for-rogue"
+            )
+            tenant_applications = await client.get("/c/x-men-apocalypse/applications")
+            tenant_wanted_post = await client.post(
+                "/c/x-men-apocalypse/wanted/brotherhood-rival-for-rogue",
+                body=urlencode({"intent": "express_interest"}).encode(),
+                headers=_FORM,
+            )
             post = await client.post(
                 "/identity",
                 body=urlencode({"intent": "set_default_character", "character_id": "0"}).encode(),
@@ -216,8 +228,36 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert "chirpui-sidebar__section-title" not in request_access.text
         assert studio.status == 302
         assert dict(studio.headers)["location"] == "/login?next=/studio"
-        assert tenant.status == 302
-        assert dict(tenant.headers)["location"] == "/login?next=%2Fc%2Fx-men-apocalypse"
+        assert tenant.status == 200
+        assert "Public realm preview" in tenant.text
+        assert "Current Event: B-24 Winter" in tenant.text
+        assert "starlane" not in tenant.text
+        assert "playing as Rogue" not in tenant.text
+        assert "elbysodic-identity-menu" not in tenant.text
+        assert tenant_world.status == 200
+        assert "World studio" in tenant_world.text
+        assert "Application Guide" in tenant_world.text
+        assert "Material studio" not in tenant_world.text
+        assert tenant_material.status == 200
+        assert "begins after the school has reopened under a fragile truce" in (
+            tenant_material.text
+        )
+        assert "Active scenes" not in tenant_material.text
+        assert "Material studio" not in tenant_material.text
+        assert tenant_wanted.status == 200
+        assert "Brotherhood rival from Rogue" in tenant_wanted.text
+        assert 'href="/c/x-men-apocalypse/characters/rogue"' not in tenant_wanted.text
+        assert tenant_wanted_detail.status == 200
+        assert "Rogue needs someone who remembers" in tenant_wanted_detail.text
+        assert "Log in to raise interest" in tenant_wanted_detail.text
+        assert "Hook lifecycle" not in tenant_wanted_detail.text
+        assert "Raised hands" not in tenant_wanted_detail.text
+        assert tenant_applications.status == 302
+        assert dict(tenant_applications.headers)["location"] == (
+            "/login?next=%2Fc%2Fx-men-apocalypse%2Fapplications"
+        )
+        assert tenant_wanted_post.status == 403
+        assert "Log in to keep writing." in tenant_wanted_post.text
         assert post.status == 403
         assert "Log in to keep writing." in post.text
         assert "/login?next=/identity" in post.text
@@ -267,6 +307,8 @@ def test_production_backstage_realm_stays_out_of_public_network(monkeypatch) -> 
         async with TestClient(app) as client:
             root = await client.get("/")
             network = await client.get("/network")
+            direct_preview = await client.get("/c/starter-realm")
+            direct_world = await client.get("/c/starter-realm/world")
             login, cookies = await _production_login(
                 client,
                 email="director@example.com",
@@ -285,6 +327,10 @@ def test_production_backstage_realm_stays_out_of_public_network(monkeypatch) -> 
             assert "The first realm is still backstage." in response.text
             assert "Starter Realm" not in response.text
             assert "starter-realm" not in response.text
+        assert direct_preview.status == 404
+        assert direct_world.status == 404
+        assert "Starter Director" not in direct_preview.text
+        assert "Starter Director" not in direct_world.text
         assert login.status == 302
         assert director_network.status == 200
         assert "Starter Realm" in director_network.text


### PR DESCRIPTION
## Summary

Adds a public realm preview wave for tenant URLs so signed-out visitors can browse a community's premise, guidebook, and wanted hooks before requesting access.

Public GET/HEAD routes now include:

- `/c/{community}/`
- `/c/{community}/world`
- `/c/{community}/world/{material_slug}`
- `/c/{community}/wanted`
- `/c/{community}/wanted/{wanted_slug}`

The implementation uses explicit public-safe read models instead of member viewer read models, and keeps POST actions, applications, plotting, desk, private queues, draft materials, wanted interest notes, reserves, lifecycle controls, and staff surfaces gated.

## Steward Notes

- Consulted stewards: root constitution, Rendering/UI, Service Layer, Tests, Docs, Changelog, and public discovery user-panel guidance.
- Accepted: expose public-ready premise/guidebook/wanted browsing through tenant-prefixed routes with anonymous calls to action.
- Deferred: public claims, public locations, raw thread pages, and application entry changes.
- Collateral: updated security boundaries, rendered privacy matrix, and added a changelog fragment.

## Validation

- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`
- `git diff --check`

## Notes

The pre-existing unstaged edits in `docs/operations/railway-smoke.md` and `docs/operations/sqlite-production.md` were intentionally left out of this PR.