### PR TITLE
Harden local dev lifecycle and query stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,15 @@ elbysodic dev db backup --output var/elbysodic-backup.sqlite3
 `backup` uses SQLite's online backup API and refuses to overwrite an existing
 file unless `--overwrite` is passed.
 
+Before handing off a branch, run the developer gate:
+
+```bash
+elbysodic dev check
+```
+
+Use `--quick` when iterating on the CLI itself; it keeps the lint/type/app
+checks but narrows pytest to the CLI tests.
+
 In this workspace, the direct app form is also useful:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ It prepares the local SQLite database with demo realm data and serves the app
 at `http://127.0.0.1:8001/`. Pass `--no-seed-demo` when you only want schema
 initialization before serving.
 
+For local navigation and htmx timing checks, use the production-like preview
+task. It keeps `debug=False` while enabling dev tools, including the htmx timing
+harness.
+
+```bash
+uv run poe preview-prod-devtools
+```
+
 Stop local servers with `Ctrl-C`/`SIGINT` or `SIGTERM` so Elbysodic can close
 its app services and SQLite connection. Debug-mode `serve` and `dev preview`
 also treat `SIGHUP` as a local shutdown signal. Deleting or archiving a live

--- a/README.md
+++ b/README.md
@@ -243,6 +243,18 @@ also treat `SIGHUP` as a local shutdown signal. Deleting or archiving a live
 worktree is not a clean shutdown contract; stop the process first, then archive
 or remove the isolated checkout.
 
+Use the developer DB helpers before copying or preserving a local realm
+database:
+
+```bash
+elbysodic dev db checkpoint
+elbysodic dev db backup --output var/elbysodic-backup.sqlite3
+```
+
+`checkpoint` runs a TRUNCATE WAL checkpoint against the configured SQLite file.
+`backup` uses SQLite's online backup API and refuses to overwrite an existing
+file unless `--overwrite` is passed.
+
 In this workspace, the direct app form is also useful:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ It prepares the local SQLite database with demo realm data and serves the app
 at `http://127.0.0.1:8001/`. Pass `--no-seed-demo` when you only want schema
 initialization before serving.
 
+Stop local servers with `Ctrl-C`/`SIGINT` or `SIGTERM` so Elbysodic can close
+its app services and SQLite connection. Debug-mode `serve` and `dev preview`
+also treat `SIGHUP` as a local shutdown signal. Deleting or archiving a live
+worktree is not a clean shutdown contract; stop the process first, then archive
+or remove the isolated checkout.
+
 In this workspace, the direct app form is also useful:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -226,6 +226,17 @@ elbysodic seed-demo
 elbysodic serve --port 8001
 ```
 
+For the standard seeded local preview, developers can use the Milo-backed dev
+namespace:
+
+```bash
+elbysodic dev preview
+```
+
+It prepares the local SQLite database with demo realm data and serves the app
+at `http://127.0.0.1:8001/`. Pass `--no-seed-demo` when you only want schema
+initialization before serving.
+
 In this workspace, the direct app form is also useful:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ harness.
 uv run poe preview-prod-devtools
 ```
 
+With that preview running, the latest-click-wins browser harness can exercise
+rapid htmx navigation settlement:
+
+```bash
+uv run poe latest-click-wins-qa
+```
+
 Stop local servers with `Ctrl-C`/`SIGINT` or `SIGTERM` so Elbysodic can close
 its app services and SQLite connection. Debug-mode `serve` and `dev preview`
 also treat `SIGHUP` as a local shutdown signal. Deleting or archiving a live

--- a/changelog.d/+demo-seed-recovery.fixed.md
+++ b/changelog.d/+demo-seed-recovery.fixed.md
@@ -1,0 +1,1 @@
+Documented and tested rerunning demo seed after an interrupted local setup.

--- a/changelog.d/+dev-check-command.added.md
+++ b/changelog.d/+dev-check-command.added.md
@@ -1,0 +1,1 @@
+Added a developer check command that runs the standard local verification gate.

--- a/changelog.d/+dev-db-maintenance.added.md
+++ b/changelog.d/+dev-db-maintenance.added.md
@@ -1,0 +1,1 @@
+Added developer SQLite checkpoint and online backup commands for local realm preservation.

--- a/changelog.d/+dev-preview-cli.added.md
+++ b/changelog.d/+dev-preview-cli.added.md
@@ -1,0 +1,1 @@
+Added a Milo-backed `elbysodic dev preview` command for seeded local preview runs.

--- a/changelog.d/+local-navigation-sqlite-stability.fixed.md
+++ b/changelog.d/+local-navigation-sqlite-stability.fixed.md
@@ -1,0 +1,1 @@
+Local navigation now keeps rendered GET requests read-only and avoids shared SQLite connection failures during rapid clicking.

--- a/changelog.d/+server-shutdown-lifecycle.fixed.md
+++ b/changelog.d/+server-shutdown-lifecycle.fixed.md
@@ -1,0 +1,1 @@
+Ensured CLI-started servers close app services and SQLite cleanly on supported stop signals.

--- a/docs/architecture/sqlite-request-lifecycle.md
+++ b/docs/architecture/sqlite-request-lifecycle.md
@@ -37,3 +37,21 @@ compatibility setting for connections that are otherwise scoped or synchronized.
 - Query-budget tests should be added for shell navigation, board thread lists,
   writer queues, and network catalog read models as those surfaces move to
   batched APIs.
+
+## Query Budgets
+
+Query budgets are route-specific guardrails, not performance targets. They
+should start from measured local baselines, include enough slack for harmless
+template or seed movement, and ratchet down only after a batch read API lands.
+
+Budgets should protect two contracts:
+
+- warm rendered routes do not reintroduce accidental per-board, per-thread, or
+  per-face query fanout after batching
+- performance work preserves tenant, membership, role, active-face, and
+  publication boundaries in the service read model
+
+Scale fixtures should be added when a surface has a true batch read contract.
+Those fixtures should seed multiple communities, boards, faces, scenes, claims,
+reserves, wanted hooks, private rows, and staff rows, then assert query growth is
+bounded against the number of rendered cards.

--- a/docs/architecture/sqlite-request-lifecycle.md
+++ b/docs/architecture/sqlite-request-lifecycle.md
@@ -10,6 +10,9 @@ and identity safety contract, not as incidental plumbing.
   and app-owned shutdown.
 - Filesystem-backed web requests use a request-scoped repository connection and
   close it after the response settles.
+- Page handlers must obtain request services through `get_services(request)`.
+  Manual `get_services().for_request(request)` calls bypass the shared request
+  cache and are not an accepted web entrypoint.
 - `:memory:` test services may share one synchronized connection because each
   new connection would create an empty database.
 - `connect()` owns SQLite pragmas: foreign keys, busy timeout, and WAL for

--- a/docs/architecture/sqlite-request-lifecycle.md
+++ b/docs/architecture/sqlite-request-lifecycle.md
@@ -1,0 +1,39 @@
+# SQLite Request Lifecycle
+
+Elbysodic uses SQLite for the current local and Railway deployment shape. The
+request lifecycle must treat SQLite connection ownership as part of the tenant
+and identity safety contract, not as incidental plumbing.
+
+## Contract
+
+- App startup may keep a root service facade for seed data, tests, CLI access,
+  and app-owned shutdown.
+- Filesystem-backed web requests use a request-scoped repository connection and
+  close it after the response settles.
+- `:memory:` test services may share one synchronized connection because each
+  new connection would create an empty database.
+- `connect()` owns SQLite pragmas: foreign keys, busy timeout, and WAL for
+  filesystem databases.
+- Repository list/read methods must not perform incidental writes or commits.
+  Defaults and reconciliation belong to schema creation, community creation,
+  migrations, seed/bootstrap, or explicit maintenance workflows.
+- Query/read-model batching must keep `community_id` explicit and leave policy,
+  membership posture, active face selection, and PBP queue vocabulary in
+  services.
+
+## Free-Threading Note
+
+Local development uses Python 3.14t in this workspace. Without the GIL,
+unsynchronized shared `sqlite3.Connection` access can fail under rapid
+navigation even when individual queries are valid. The app therefore avoids
+using `check_same_thread=False` as a concurrency strategy. It is only a
+compatibility setting for connections that are otherwise scoped or synchronized.
+
+## Proof
+
+- Concurrent rendered GET tests cover rapid htmx-style navigation against a
+  file-backed database.
+- Read-only GET tests trace SQL and fail if normal navigation performs writes.
+- Query-budget tests should be added for shell navigation, board thread lists,
+  writer queues, and network catalog read models as those surfaces move to
+  batched APIs.

--- a/docs/architecture/sqlite-request-lifecycle.md
+++ b/docs/architecture/sqlite-request-lifecycle.md
@@ -10,9 +10,11 @@ and identity safety contract, not as incidental plumbing.
   and app-owned shutdown.
 - Filesystem-backed web requests use a request-scoped repository connection and
   close it after the response settles.
-- Page handlers must obtain request services through `get_services(request)`.
-  Manual `get_services().for_request(request)` calls bypass the shared request
-  cache and are not an accepted web entrypoint.
+- Authenticated page branches must obtain request services through
+  `get_services(request)`. Manual `get_services().for_request(request)` calls
+  bypass the shared request cache and are not an accepted web entrypoint.
+  Signed-out public preview fallbacks may use the root public facade after
+  request identity has failed.
 - `:memory:` test services may share one synchronized connection because each
   new connection would create an empty database.
 - `connect()` owns SQLite pragmas: foreign keys, busy timeout, and WAL for

--- a/docs/operations/sqlite-production.md
+++ b/docs/operations/sqlite-production.md
@@ -19,6 +19,25 @@ chooses a different persistence backend.
 - Seed demo data intentionally with `elbysodic seed-demo`; app startup creates
   the schema but should not be treated as a demo reset.
 
+## Shutdown Contract
+
+`elbysodic serve` and `elbysodic dev preview` own the app service lifecycle for
+the process they start. On normal server exit, Elbysodic closes the shared
+SQLite connection and best-effort checkpoints WAL data for filesystem-backed
+databases before releasing the connection.
+
+Supported clean stop paths are:
+
+- `SIGTERM` from a process manager or deployment platform.
+- `SIGINT`, including local `Ctrl-C`.
+- `SIGHUP` for local debug-mode `serve` and `dev preview` processes.
+
+Abrupt filesystem removal is outside that contract. Do not delete, archive, or
+move an isolated worktree while an Elbysodic server from that checkout is still
+running; the process can still hold its port and SQLite handles while page and
+static assets disappear from disk. Stop the process first, verify the port is
+free, then archive or remove the checkout.
+
 ## Persistence Checks
 
 Before sharing a URL, prove these survive restart or redeploy:

--- a/docs/operations/sqlite-production.md
+++ b/docs/operations/sqlite-production.md
@@ -73,6 +73,19 @@ Keep the backup process simple and explicit. A copied SQLite file is acceptable
 when the service is stopped or quiescent; a live backup command can replace
 that once the deployment runbook grows a maintenance window.
 
+For local and staging-like developer workflows, use the Milo-backed helpers:
+
+```bash
+elbysodic dev db checkpoint --db-path /app/var/elbysodic.sqlite3
+elbysodic dev db backup --db-path /app/var/elbysodic.sqlite3 \
+  --output /app/var/elbysodic-backup.sqlite3
+```
+
+`checkpoint` performs `PRAGMA wal_checkpoint(TRUNCATE)` against the configured
+file. `backup` uses SQLite's online backup API and verifies
+`PRAGMA integrity_check` on the copied database before reporting success. It
+will not overwrite an existing backup unless `--overwrite` is passed.
+
 ## Backup/Restore Drill Record
 
 Latest known staging drill:

--- a/docs/operations/sqlite-production.md
+++ b/docs/operations/sqlite-production.md
@@ -18,6 +18,10 @@ chooses a different persistence backend.
   persistent database file.
 - Seed demo data intentionally with `elbysodic seed-demo`; app startup creates
   the schema but should not be treated as a demo reset.
+- Demo seeding is idempotent for interrupted local/staging setup. If a seed run
+  is stopped partway through, rerun `elbysodic seed-demo` or
+  `elbysodic dev preview` against the same database to repair the missing demo
+  rows before using the realm.
 
 ## Shutdown Contract
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ test-cov = { cmd = "pytest tests/ --cov=elbysodic --cov-report=term-missing", he
 browser-qa = { cmd = "python scripts/browser_qa.py", help = "Run Playwright visual smoke QA against the local app" }
 browser-qa-deep = { cmd = "python scripts/browser_qa.py --profile deep", help = "Run expanded Playwright visual QA against seeded routes" }
 rapid-click-qa = { cmd = "python scripts/rapid_click_qa.py --iterations 1", help = "Run rapid identity/navigation protocol smoke QA" }
+latest-click-wins-qa = { cmd = "python scripts/latest_click_wins_qa.py", help = "Run browser QA that rapid htmx navigation settles on the latest click" }
 preview-prod-devtools = { cmd = "python -c \"from elbysodic.web import create_app; create_app(debug=False, db_path='var/elbysodic-preview.sqlite3', dev_tools=True, seed_demo=True).run(host='127.0.0.1', port=8001)\"", help = "Run production-like local preview with dev tools and timing harness" }
 
 ty = { cmd = "ty check src/elbysodic/ tests/", help = "Run ty type checker" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ test-cov = { cmd = "pytest tests/ --cov=elbysodic --cov-report=term-missing", he
 browser-qa = { cmd = "python scripts/browser_qa.py", help = "Run Playwright visual smoke QA against the local app" }
 browser-qa-deep = { cmd = "python scripts/browser_qa.py --profile deep", help = "Run expanded Playwright visual QA against seeded routes" }
 rapid-click-qa = { cmd = "python scripts/rapid_click_qa.py --iterations 1", help = "Run rapid identity/navigation protocol smoke QA" }
+preview-prod-devtools = { cmd = "python -c \"from elbysodic.web import create_app; create_app(debug=False, db_path='var/elbysodic-preview.sqlite3', dev_tools=True, seed_demo=True).run(host='127.0.0.1', port=8001)\"", help = "Run production-like local preview with dev tools and timing harness" }
 
 ty = { cmd = "ty check src/elbysodic/ tests/", help = "Run ty type checker" }
 ty-strict = { cmd = "ty check src/elbysodic/ tests/ --error-on-warning", help = "Strict type checking" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 dependencies = [
     "bengal-chirp[config,forms,sessions,ui]>=0.6.0",
     "chirp-ui>=0.8.0",
+    "milo-cli>=0.2.2",
     "pyyaml>=6.0",
 ]
 

--- a/scripts/latest_click_wins_qa.py
+++ b/scripts/latest_click_wins_qa.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from urllib.parse import urljoin
+
+from playwright.async_api import async_playwright
+
+TARGETS = (
+    ("/network", "Studio Network"),
+    ("/c/rl-nyc/my/threads", "RL NYC"),
+    ("/c/rl-small-town/boards/town-hall?filter=mine", "RL Small Town"),
+    ("/c/jurassic-park-universe/world", "Jurassic Park Universe"),
+    ("/c/x-men-apocalypse/boards/danger-room", "Danger Room"),
+)
+
+
+async def _run(base_url: str) -> int:
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch()
+        page = await browser.new_page(viewport={"width": 1280, "height": 900})
+        try:
+            await page.goto(urljoin(base_url, "/"), wait_until="domcontentloaded")
+            await page.wait_for_function("window.htmx !== undefined")
+            await page.evaluate(
+                """
+                async (targets) => {
+                  for (const target of targets) {
+                    window.htmx.ajax("GET", target[0], {
+                      target: "#page-content",
+                      swap: "innerHTML"
+                    });
+                  }
+                }
+                """,
+                TARGETS,
+            )
+            await page.wait_for_function(
+                "document.body && document.body.innerText.includes('Danger Room')"
+            )
+            body_text = await page.locator("body").inner_text()
+        finally:
+            await browser.close()
+
+    failures = [
+        expected
+        for _path, expected in TARGETS[:-1]
+        if expected in body_text and expected != TARGETS[-1][1]
+    ]
+    if failures:
+        print(f"Latest-click-wins failed; stale content remained: {', '.join(failures)}")
+        return 1
+    print("Latest-click-wins QA passed.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify rapid htmx navigations settle on the last requested route."
+    )
+    parser.add_argument("--base-url", default="http://127.0.0.1:8001")
+    args = parser.parse_args()
+    return asyncio.run(_run(args.base_url))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/elbysodic/cli.py
+++ b/src/elbysodic/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import signal
+import sqlite3
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -104,7 +105,92 @@ def build_dev_cli() -> CLI:
             stop_on_sighup=debug,
         )
 
+    db = dev_cli.group("db", description="SQLite maintenance helpers for local work.")
+
+    @db.command(
+        "checkpoint",
+        description="Checkpoint the local SQLite WAL file.",
+        display_result=False,
+    )
+    def checkpoint(db_path: str = "") -> None:
+        """Run a best-effort TRUNCATE checkpoint against a local database."""
+
+        source_path = _coerce_db_path(db_path)
+        result = checkpoint_database(source_path)
+        sys.stdout.write(
+            "checkpointed "
+            f"{result.path} "
+            f"busy={result.busy} log={result.log_frames} checkpointed={result.checkpointed_frames}\n"
+        )
+
+    @db.command(
+        "backup",
+        description="Create an online SQLite backup of the local database.",
+        display_result=False,
+    )
+    def backup(db_path: str = "", output: str = "", overwrite: bool = False) -> None:
+        """Copy a local database using SQLite's online backup API."""
+
+        source_path = _coerce_db_path(db_path)
+        if output.strip() == "":
+            raise ValueError("output is required")
+        backup_path = backup_database(source_path, Path(output), overwrite=overwrite)
+        sys.stdout.write(f"backed up {source_path} to {backup_path}\n")
+
     return dev_cli
+
+
+class CheckpointResult:
+    def __init__(self, *, path: Path, busy: int, log_frames: int, checkpointed_frames: int) -> None:
+        self.path = path
+        self.busy = busy
+        self.log_frames = log_frames
+        self.checkpointed_frames = checkpointed_frames
+
+
+def checkpoint_database(path: Path) -> CheckpointResult:
+    if str(path) == ":memory:":
+        raise ValueError("checkpoint requires a filesystem database path")
+    if not path.exists():
+        raise FileNotFoundError(path)
+    connection = connect_for_maintenance(path)
+    try:
+        row = connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        return CheckpointResult(
+            path=path,
+            busy=int(row[0]),
+            log_frames=int(row[1]),
+            checkpointed_frames=int(row[2]),
+        )
+    finally:
+        connection.close()
+
+
+def backup_database(source_path: Path, backup_path: Path, *, overwrite: bool = False) -> Path:
+    if str(source_path) == ":memory:":
+        raise ValueError("backup requires a filesystem database path")
+    if not source_path.exists():
+        raise FileNotFoundError(source_path)
+    if backup_path.exists() and not overwrite:
+        raise FileExistsError(backup_path)
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    if backup_path.exists():
+        backup_path.unlink()
+    source = connect_for_maintenance(source_path)
+    destination = sqlite3.connect(backup_path)
+    try:
+        source.backup(destination)
+        integrity = destination.execute("PRAGMA integrity_check").fetchone()[0]
+        if integrity != "ok":
+            raise RuntimeError(f"backup integrity check failed: {integrity}")
+    finally:
+        destination.close()
+        source.close()
+    return backup_path
+
+
+def connect_for_maintenance(path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(path)
 
 
 def _run_server(

--- a/src/elbysodic/cli.py
+++ b/src/elbysodic/cli.py
@@ -6,13 +6,20 @@ import argparse
 import sys
 from pathlib import Path
 
+from milo import CLI
+
 from elbysodic.services import bootstrap_first_realm, default_database_path, initialize_database
 from elbysodic.web.app import create_app
 
 
 def main(argv: list[str] | None = None) -> None:
+    raw_args = list(sys.argv[1:] if argv is None else argv)
+    if raw_args and raw_args[0] == "dev":
+        build_dev_cli().run(raw_args[1:])
+        return
+
     parser = _build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(raw_args)
 
     command = args.command or "serve"
     if command == "init-db":
@@ -43,6 +50,41 @@ def main(argv: list[str] | None = None) -> None:
 
     app = create_app(debug=args.debug, db_path=args.db_path, seed_demo=args.seed_demo)
     app.run(host=args.host, port=args.port)
+
+
+def build_dev_cli() -> CLI:
+    """Build the Milo-backed developer workflow namespace."""
+
+    dev_cli = CLI(
+        name="elbysodic dev",
+        description="Developer workflows for local Elbysodic work.",
+        version="0.1.0",
+    )
+
+    @dev_cli.command(
+        "preview",
+        description="Prepare seeded demo data and run the local preview server.",
+        annotations={"destructiveHint": False, "idempotentHint": True},
+        display_result=False,
+    )
+    def preview(
+        db_path: str = "",
+        host: str = "127.0.0.1",
+        port: int = 8001,
+        debug: bool = True,
+        seed_demo: bool = True,
+    ) -> None:
+        """Run a seeded local preview on the standard development port."""
+
+        resolved_db_path = _coerce_db_path(db_path)
+        initialized_path = initialize_database(resolved_db_path, seed_demo=seed_demo)
+        sys.stdout.write(f"preview database ready {initialized_path}\n")
+        sys.stdout.write(f"serving local preview at http://{host}:{port}/\n")
+        sys.stdout.flush()
+        app = create_app(debug=debug, db_path=initialized_path, seed_demo=False)
+        app.run(host=host, port=port)
+
+    return dev_cli
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -114,7 +156,18 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     serve = subparsers.add_parser("serve", parents=[shared], help="Run the web server.")
     _add_serve_options(serve, include_defaults=False)
+    subparsers.add_parser(
+        "dev",
+        add_help=False,
+        help="Run developer workflows powered by Milo.",
+    )
     return parser
+
+
+def _coerce_db_path(db_path: str | Path | None) -> Path:
+    if db_path is None or str(db_path).strip() == "":
+        return default_database_path()
+    return Path(db_path)
 
 
 def _add_serve_options(parser: argparse.ArgumentParser, *, include_defaults: bool) -> None:

--- a/src/elbysodic/cli.py
+++ b/src/elbysodic/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import signal
 import sqlite3
+import subprocess
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -105,6 +106,17 @@ def build_dev_cli() -> CLI:
             stop_on_sighup=debug,
         )
 
+    @dev_cli.command(
+        "check",
+        description="Run the standard local developer verification gate.",
+        annotations={"destructiveHint": False, "idempotentHint": True},
+        display_result=False,
+    )
+    def check(quick: bool = False) -> None:
+        """Run the standard local verification commands."""
+
+        run_developer_checks(quick=quick)
+
     db = dev_cli.group("db", description="SQLite maintenance helpers for local work.")
 
     @db.command(
@@ -138,6 +150,35 @@ def build_dev_cli() -> CLI:
         sys.stdout.write(f"backed up {source_path} to {backup_path}\n")
 
     return dev_cli
+
+
+def developer_check_commands(*, quick: bool = False) -> list[list[str]]:
+    test_command = ["uv", "run", "pytest", "tests/test_cli.py", "-q", "--tb=short"]
+    if not quick:
+        test_command = ["uv", "run", "pytest", "-q", "--tb=short"]
+    return [
+        ["uv", "run", "ruff", "check", "."],
+        ["uv", "run", "ruff", "format", ".", "--check"],
+        test_command,
+        ["uv", "run", "ty", "check", "src/elbysodic/", "tests/"],
+        [
+            "uv",
+            "run",
+            "python",
+            "-c",
+            "from elbysodic.web import create_app; "
+            "create_app(debug=False, db_path=':memory:').check()",
+        ],
+    ]
+
+
+def run_developer_checks(*, quick: bool = False) -> None:
+    for command in developer_check_commands(quick=quick):
+        sys.stdout.write(f"$ {' '.join(command)}\n")
+        sys.stdout.flush()
+        completed = subprocess.run(command, check=False)  # noqa: S603 - commands are fixed gates.
+        if completed.returncode != 0:
+            raise SystemExit(completed.returncode)
 
 
 class CheckpointResult:

--- a/src/elbysodic/cli.py
+++ b/src/elbysodic/cli.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import signal
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from milo import CLI
 
-from elbysodic.services import bootstrap_first_realm, default_database_path, initialize_database
+from elbysodic.services import (
+    bootstrap_first_realm,
+    create_services,
+    default_database_path,
+    initialize_database,
+)
 from elbysodic.web.app import create_app
 
 
@@ -48,8 +56,14 @@ def main(argv: list[str] | None = None) -> None:
         )
         return
 
-    app = create_app(debug=args.debug, db_path=args.db_path, seed_demo=args.seed_demo)
-    app.run(host=args.host, port=args.port)
+    _run_server(
+        debug=args.debug,
+        db_path=args.db_path,
+        seed_demo=args.seed_demo,
+        host=args.host,
+        port=args.port,
+        stop_on_sighup=args.debug,
+    )
 
 
 def build_dev_cli() -> CLI:
@@ -81,10 +95,51 @@ def build_dev_cli() -> CLI:
         sys.stdout.write(f"preview database ready {initialized_path}\n")
         sys.stdout.write(f"serving local preview at http://{host}:{port}/\n")
         sys.stdout.flush()
-        app = create_app(debug=debug, db_path=initialized_path, seed_demo=False)
-        app.run(host=host, port=port)
+        _run_server(
+            debug=debug,
+            db_path=initialized_path,
+            seed_demo=False,
+            host=host,
+            port=port,
+            stop_on_sighup=debug,
+        )
 
     return dev_cli
+
+
+def _run_server(
+    *,
+    debug: bool,
+    db_path: Path,
+    seed_demo: bool,
+    host: str,
+    port: int,
+    stop_on_sighup: bool,
+) -> None:
+    services = create_services(db_path, seed_demo=seed_demo)
+    app = create_app(debug=debug, services=services)
+    try:
+        with _sighup_as_keyboard_interrupt(enabled=stop_on_sighup):
+            app.run(host=host, port=port)
+    finally:
+        services.close()
+
+
+@contextmanager
+def _sighup_as_keyboard_interrupt(*, enabled: bool) -> Iterator[None]:
+    if not enabled or not hasattr(signal, "SIGHUP"):
+        yield
+        return
+    previous_handler = signal.getsignal(signal.SIGHUP)
+
+    def handle_sighup(signum: int, frame: object) -> None:
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGHUP, handle_sighup)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGHUP, previous_handler)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/src/elbysodic/db/__init__.py
+++ b/src/elbysodic/db/__init__.py
@@ -2,5 +2,6 @@
 
 from elbysodic.db.repository import ForumRepository
 from elbysodic.db.schema import connect, create_schema
+from elbysodic.db.session import Database
 
-__all__ = ["ForumRepository", "connect", "create_schema"]
+__all__ = ["Database", "ForumRepository", "connect", "create_schema"]

--- a/src/elbysodic/db/repositories/boards.py
+++ b/src/elbysodic/db/repositories/boards.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from collections import defaultdict
+
 from elbysodic.db.repositories.base import (
     TenantBoundaryError,
     _last_id,
@@ -517,3 +520,47 @@ class BoardRepositoryMixin(NotificationRepositoryMixin):
                 (community_id, parent_board_id),
             ).fetchall()
         return [_board_from_row(row) for row in rows]
+
+    def list_child_boards_for_boards(
+        self,
+        community_id: int,
+        parent_board_ids: list[int],
+    ) -> dict[int, list[Board]]:
+        if not parent_board_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                id,
+                community_id,
+                parent_board_id,
+                slug,
+                name,
+                board_kind,
+                sidebar_section,
+                tagline,
+                description,
+                image_url,
+                image_alt,
+                image_treatment,
+                image_focal_point,
+                image_overlay,
+                sort_order,
+                navigation_order,
+                show_in_navigation,
+                is_private,
+                created_at,
+                updated_at
+            FROM boards
+            WHERE community_id = ?
+              AND parent_board_id IN (SELECT value FROM json_each(?))
+            ORDER BY parent_board_id, sort_order, name
+            """,
+            (community_id, json.dumps(parent_board_ids)),
+        ).fetchall()
+        children_by_parent: dict[int, list[Board]] = defaultdict(list)
+        for row in rows:
+            board = _board_from_row(row)
+            if board.parent_board_id is not None:
+                children_by_parent[board.parent_board_id].append(board)
+        return dict(children_by_parent)

--- a/src/elbysodic/db/repositories/boards.py
+++ b/src/elbysodic/db/repositories/boards.py
@@ -66,7 +66,6 @@ class BoardRepositoryMixin(NotificationRepositoryMixin):
         self._commit()
 
     def list_sidebar_sections(self, community_id: int) -> list[SidebarSectionConfig]:
-        self.ensure_sidebar_section_defaults(community_id)
         rows = self.connection.execute(
             """
             SELECT
@@ -103,7 +102,6 @@ class BoardRepositoryMixin(NotificationRepositoryMixin):
         section_key: str,
     ) -> SidebarSectionConfig:
         normalized_key = normalize_board_sidebar_section(section_key)
-        self.ensure_sidebar_section_defaults(community_id)
         row = self.connection.execute(
             """
             SELECT

--- a/src/elbysodic/db/repositories/characters.py
+++ b/src/elbysodic/db/repositories/characters.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from elbysodic.db.repositories.base import TenantBoundaryError, _last_id, _utc_now
 from elbysodic.db.repositories.identity import IdentityRepositoryMixin
 from elbysodic.db.repositories.rows import (
@@ -126,6 +128,43 @@ class CharacterRepositoryMixin(IdentityRepositoryMixin):
         if row is None:
             raise LookupError(f"character not found in community {community_id}: {character_id}")
         return _character_from_row(row)
+
+    def list_characters_by_ids(
+        self,
+        community_id: int,
+        character_ids: list[int],
+    ) -> dict[int, Character]:
+        if not character_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                id,
+                community_id,
+                membership_id,
+                name,
+                slug,
+                avatar_url,
+                poster_url,
+                poster_alt,
+                tagline,
+                accent_color,
+                summary,
+                post_profile_variant,
+                post_accent_style,
+                post_border_style,
+                post_title_style,
+                post_density,
+                application_status,
+                created_at,
+                updated_at
+            FROM characters
+            WHERE community_id = ?
+              AND id IN (SELECT value FROM json_each(?))
+            """,
+            (community_id, json.dumps(character_ids)),
+        ).fetchall()
+        return {int(row["id"]): _character_from_row(row) for row in rows}
 
     def get_character_by_slug(self, community_id: int, slug: str) -> Character:
         row = self.connection.execute(

--- a/src/elbysodic/db/repositories/facets.py
+++ b/src/elbysodic/db/repositories/facets.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from collections import defaultdict
+
 from elbysodic.db.repositories.base import _last_id, _utc_now
 from elbysodic.db.repositories.boards import BoardRepositoryMixin
 from elbysodic.db.repositories.rows import _facet_from_row, _facet_group_from_row
@@ -278,6 +281,49 @@ class FacetRepositoryMixin(BoardRepositoryMixin):
             community_id,
             thread_id,
         )
+
+    def list_thread_facets_for_threads(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+    ) -> dict[int, list[Facet]]:
+        if not thread_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                thread_facets.thread_id,
+                facets.id,
+                facets.community_id,
+                facets.facet_group_id,
+                facets.slug,
+                facets.name,
+                facets.description,
+                facets.accent_color,
+                facets.sort_order,
+                facets.created_at,
+                facets.updated_at
+            FROM thread_facets
+            JOIN facets
+              ON facets.community_id = thread_facets.community_id
+             AND facets.id = thread_facets.facet_id
+            JOIN facet_groups
+              ON facet_groups.community_id = facets.community_id
+             AND facet_groups.id = facets.facet_group_id
+            WHERE thread_facets.community_id = ?
+              AND thread_facets.thread_id IN (SELECT value FROM json_each(?))
+            ORDER BY thread_facets.thread_id,
+                     facet_groups.sort_order,
+                     facet_groups.name,
+                     facets.sort_order,
+                     facets.name
+            """,
+            (community_id, json.dumps(thread_ids)),
+        ).fetchall()
+        facets_by_thread: dict[int, list[Facet]] = defaultdict(list)
+        for row in rows:
+            facets_by_thread[int(row["thread_id"])].append(_facet_from_row(row))
+        return dict(facets_by_thread)
 
     def list_material_facets(self, community_id: int, material_id: int) -> list[Facet]:
         self.get_material(community_id, material_id)

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import sqlite3
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol, cast
 
 from elbysodic.db.repositories.base import RepositoryBase, _last_id, _utc_now
 from elbysodic.db.repositories.rows import (
@@ -29,6 +29,10 @@ from elbysodic.domain.models import (
 )
 
 COMMUNITY_LAUNCH_STATUSES = {"backstage", "invite-only", "public-preview"}
+
+
+class _SidebarDefaultsRepository(Protocol):
+    def ensure_sidebar_section_defaults(self, community_id: int) -> None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,7 +98,7 @@ class IdentityRepositoryMixin(RepositoryBase):
         )
         self._commit()
         community = self.get_community(DEFAULT_COMMUNITY_ID)
-        self.ensure_sidebar_section_defaults(community.id)
+        cast(_SidebarDefaultsRepository, self).ensure_sidebar_section_defaults(community.id)
         return community
 
     def create_community(self, slug: str, name: str, host: str | None = None) -> Community:
@@ -108,7 +112,7 @@ class IdentityRepositoryMixin(RepositoryBase):
         )
         self._commit()
         community = self.get_community(_last_id(cursor))
-        self.ensure_sidebar_section_defaults(community.id)
+        cast(_SidebarDefaultsRepository, self).ensure_sidebar_section_defaults(community.id)
         return community
 
     def get_community(self, community_id: int) -> Community:

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -297,6 +297,57 @@ class IdentityRepositoryMixin(RepositoryBase):
             for row in rows
         }
 
+    def network_membership_counts(self, membership_ids: list[int]) -> dict[int, dict[str, int]]:
+        if not membership_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                memberships.id AS membership_id,
+                (
+                    SELECT COUNT(*)
+                    FROM characters
+                    WHERE characters.community_id = memberships.community_id
+                      AND characters.application_status IN (
+                        'draft',
+                        'submitted',
+                        'revision_requested'
+                      )
+                ) AS reviewable_application_count,
+                (
+                    SELECT COUNT(*)
+                    FROM characters
+                    WHERE characters.community_id = memberships.community_id
+                      AND characters.membership_id = memberships.id
+                      AND characters.application_status IN (
+                        'draft',
+                        'submitted',
+                        'revision_requested'
+                      )
+                ) AS own_application_count,
+                (
+                    SELECT COUNT(DISTINCT rooms.id)
+                    FROM plotting_rooms AS rooms
+                    JOIN plotting_room_participants AS participants
+                      ON participants.community_id = rooms.community_id
+                     AND participants.plotting_room_id = rooms.id
+                    WHERE rooms.community_id = memberships.community_id
+                      AND participants.membership_id = memberships.id
+                ) AS plotting_room_count
+            FROM community_memberships AS memberships
+            WHERE memberships.id IN (SELECT value FROM json_each(?))
+            """,
+            (json.dumps(membership_ids),),
+        ).fetchall()
+        return {
+            int(row["membership_id"]): {
+                "reviewable_application_count": int(row["reviewable_application_count"]),
+                "own_application_count": int(row["own_application_count"]),
+                "plotting_room_count": int(row["plotting_room_count"]),
+            }
+            for row in rows
+        }
+
     def update_community_launch_status(self, community_id: int, launch_status: str) -> Community:
         status = launch_status.strip().lower()
         if status not in COMMUNITY_LAUNCH_STATUSES:

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -961,6 +961,35 @@ class IdentityRepositoryMixin(RepositoryBase):
             raise LookupError(f"membership not found in community {community_id}: {membership_id}")
         return _membership_from_row(row)
 
+    def list_memberships_by_ids(
+        self,
+        community_id: int,
+        membership_ids: list[int],
+    ) -> dict[int, CommunityMembership]:
+        if not membership_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                id,
+                community_id,
+                user_id,
+                username,
+                display_name,
+                avatar_url,
+                role_id,
+                default_character_id,
+                post_count,
+                is_active,
+                joined_at
+            FROM community_memberships
+            WHERE community_id = ?
+              AND id IN (SELECT value FROM json_each(?))
+            """,
+            (community_id, json.dumps(membership_ids)),
+        ).fetchall()
+        return {int(row["id"]): _membership_from_row(row) for row in rows}
+
     def get_membership_for_user(self, community_id: int, user_id: int) -> CommunityMembership:
         row = self.connection.execute(
             """

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -93,7 +93,9 @@ class IdentityRepositoryMixin(RepositoryBase):
             ),
         )
         self._commit()
-        return self.get_community(DEFAULT_COMMUNITY_ID)
+        community = self.get_community(DEFAULT_COMMUNITY_ID)
+        self.ensure_sidebar_section_defaults(community.id)
+        return community
 
     def create_community(self, slug: str, name: str, host: str | None = None) -> Community:
         now = _utc_now()
@@ -105,7 +107,9 @@ class IdentityRepositoryMixin(RepositoryBase):
             (name, slug, host, now, now),
         )
         self._commit()
-        return self.get_community(_last_id(cursor))
+        community = self.get_community(_last_id(cursor))
+        self.ensure_sidebar_section_defaults(community.id)
+        return community
 
     def get_community(self, community_id: int) -> Community:
         row = self.connection.execute(

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 from dataclasses import dataclass
 from typing import Any, Protocol, cast
@@ -251,6 +252,50 @@ class IdentityRepositoryMixin(RepositoryBase):
             """
         ).fetchall()
         return [_community_from_row(row) for row in rows]
+
+    def network_program_counts(self, community_ids: list[int]) -> dict[int, dict[str, int]]:
+        if not community_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                communities.id AS community_id,
+                (
+                    SELECT COUNT(*)
+                    FROM characters
+                    WHERE characters.community_id = communities.id
+                ) AS roster_count,
+                (
+                    SELECT COUNT(*)
+                    FROM wanted_ads
+                    WHERE wanted_ads.community_id = communities.id
+                      AND wanted_ads.status = 'open'
+                ) AS open_wanted_count,
+                (
+                    SELECT COUNT(*)
+                    FROM materials
+                    WHERE materials.community_id = communities.id
+                      AND materials.material_type = 'application'
+                ) AS application_material_count,
+                (
+                    SELECT COUNT(*)
+                    FROM claim_types
+                    WHERE claim_types.community_id = communities.id
+                ) AS claim_type_count
+            FROM communities
+            WHERE communities.id IN (SELECT value FROM json_each(?))
+            """,
+            (json.dumps(community_ids),),
+        ).fetchall()
+        return {
+            int(row["community_id"]): {
+                "roster_count": int(row["roster_count"]),
+                "open_wanted_count": int(row["open_wanted_count"]),
+                "application_material_count": int(row["application_material_count"]),
+                "claim_type_count": int(row["claim_type_count"]),
+            }
+            for row in rows
+        }
 
     def update_community_launch_status(self, community_id: int, launch_status: str) -> Community:
         status = launch_status.strip().lower()

--- a/src/elbysodic/db/repositories/posts.py
+++ b/src/elbysodic/db/repositories/posts.py
@@ -275,6 +275,25 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
             posts_by_thread[post.thread_id].append(post)
         return dict(posts_by_thread)
 
+    def post_counts_by_thread(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+    ) -> dict[int, int]:
+        if not thread_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT thread_id, COUNT(*) AS post_count
+            FROM posts
+            WHERE community_id = ?
+              AND thread_id IN (SELECT value FROM json_each(?))
+            GROUP BY thread_id
+            """,
+            (community_id, json.dumps(thread_ids)),
+        ).fetchall()
+        return {int(row["thread_id"]): int(row["post_count"]) for row in rows}
+
     def list_posts_by_character(self, community_id: int, character_id: int) -> list[Post]:
         self.get_character(community_id, character_id)
         rows = self.connection.execute(

--- a/src/elbysodic/db/repositories/posts.py
+++ b/src/elbysodic/db/repositories/posts.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from collections import defaultdict
+
 from elbysodic.db.repositories.base import (
     _last_id,
     _next_update_stamp,
@@ -239,6 +242,38 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
             (community_id, thread_id),
         ).fetchall()
         return [_post_from_row(row) for row in rows]
+
+    def list_posts_for_threads(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+    ) -> dict[int, list[Post]]:
+        if not thread_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                id,
+                community_id,
+                thread_id,
+                post_number,
+                author_membership_id,
+                author_character_id,
+                body,
+                created_at,
+                updated_at
+            FROM posts
+            WHERE community_id = ?
+              AND thread_id IN (SELECT value FROM json_each(?))
+            ORDER BY thread_id, post_number
+            """,
+            (community_id, json.dumps(thread_ids)),
+        ).fetchall()
+        posts_by_thread: dict[int, list[Post]] = defaultdict(list)
+        for row in rows:
+            post = _post_from_row(row)
+            posts_by_thread[post.thread_id].append(post)
+        return dict(posts_by_thread)
 
     def list_posts_by_character(self, community_id: int, character_id: int) -> list[Post]:
         self.get_character(community_id, character_id)

--- a/src/elbysodic/db/repositories/threads.py
+++ b/src/elbysodic/db/repositories/threads.py
@@ -336,6 +336,37 @@ class ThreadRepositoryMixin(ReserveRepositoryMixin):
             ).fetchone()
         return int(row["thread_count"]) if row is not None else 0
 
+    def unread_thread_counts_by_board(
+        self,
+        community_id: int,
+        board_ids: list[int],
+        membership_id: int,
+    ) -> dict[int, int]:
+        if not board_ids:
+            return {}
+        placeholders = ", ".join("?" for _ in board_ids)
+        rows = self.connection.execute(
+            f"""
+            SELECT
+                threads.board_id,
+                COUNT(*) AS unread_count
+            FROM threads
+            LEFT JOIN thread_reads
+              ON thread_reads.community_id = threads.community_id
+             AND thread_reads.thread_id = threads.id
+             AND thread_reads.membership_id = ?
+            WHERE threads.community_id = ?
+              AND threads.board_id IN ({placeholders})
+              AND (
+                    thread_reads.read_at IS NULL
+                 OR thread_reads.read_at < threads.updated_at
+              )
+            GROUP BY threads.board_id
+            """,
+            (membership_id, community_id, *board_ids),
+        ).fetchall()
+        return {int(row["board_id"]): int(row["unread_count"]) for row in rows}
+
     def list_threads_by_character(self, community_id: int, character_id: int) -> list[Thread]:
         self.get_character(community_id, character_id)
         rows = self.connection.execute(

--- a/src/elbysodic/db/repositories/threads.py
+++ b/src/elbysodic/db/repositories/threads.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from collections import defaultdict
+
 from elbysodic.db.repositories.base import _last_id, _utc_now
 from elbysodic.db.repositories.reserves import ReserveRepositoryMixin
 from elbysodic.db.repositories.rows import (
@@ -514,6 +517,54 @@ class ThreadRepositoryMixin(ReserveRepositoryMixin):
             (community_id, thread_id),
         ).fetchall()
         return [_character_from_row(row) for row in rows]
+
+    def list_thread_participants_for_threads(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+    ) -> dict[int, list[Character]]:
+        if not thread_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                thread_participants.thread_id,
+                characters.id,
+                characters.community_id,
+                characters.membership_id,
+                characters.name,
+                characters.slug,
+                characters.avatar_url,
+                characters.poster_url,
+                characters.poster_alt,
+                characters.tagline,
+                characters.accent_color,
+                characters.summary,
+                characters.post_profile_variant,
+                characters.post_accent_style,
+                characters.post_border_style,
+                characters.post_title_style,
+                characters.post_density,
+                characters.application_status,
+                characters.created_at,
+                characters.updated_at
+            FROM thread_participants
+            JOIN characters
+              ON characters.community_id = thread_participants.community_id
+             AND characters.id = thread_participants.character_id
+            WHERE thread_participants.community_id = ?
+              AND thread_participants.thread_id IN (SELECT value FROM json_each(?))
+            ORDER BY thread_participants.thread_id,
+                     thread_participants.added_at,
+                     characters.name,
+                     characters.id
+            """,
+            (community_id, json.dumps(thread_ids)),
+        ).fetchall()
+        participants_by_thread: dict[int, list[Character]] = defaultdict(list)
+        for row in rows:
+            participants_by_thread[int(row["thread_id"])].append(_character_from_row(row))
+        return dict(participants_by_thread)
 
     def list_thread_participant_ids(self, community_id: int, thread_id: int) -> set[int]:
         rows = self.connection.execute(

--- a/src/elbysodic/db/repositories/threads.py
+++ b/src/elbysodic/db/repositories/threads.py
@@ -318,6 +318,45 @@ class ThreadRepositoryMixin(ReserveRepositoryMixin):
             ).fetchall()
         return [_thread_from_row(row) for row in rows]
 
+    def list_threads_for_boards(
+        self,
+        community_id: int,
+        board_ids: list[int],
+    ) -> dict[int, list[Thread]]:
+        if not board_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                id,
+                community_id,
+                board_id,
+                author_membership_id,
+                author_character_id,
+                slug,
+                title,
+                status,
+                location,
+                timeline,
+                summary,
+                posting_mode,
+                is_locked,
+                is_pinned,
+                created_at,
+                updated_at
+            FROM threads
+            WHERE community_id = ?
+              AND board_id IN (SELECT value FROM json_each(?))
+            ORDER BY board_id, is_pinned DESC, updated_at DESC, id DESC
+            """,
+            (community_id, json.dumps(board_ids)),
+        ).fetchall()
+        threads_by_board: dict[int, list[Thread]] = defaultdict(list)
+        for row in rows:
+            thread = _thread_from_row(row)
+            threads_by_board[thread.board_id].append(thread)
+        return dict(threads_by_board)
+
     def count_threads(self, community_id: int, board_id: int | None = None) -> int:
         if board_id is None:
             row = self.connection.execute(
@@ -594,6 +633,26 @@ class ThreadRepositoryMixin(ReserveRepositoryMixin):
         if row is None:
             return None
         return str(row["read_at"])
+
+    def thread_read_at_for_threads(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+        membership_id: int,
+    ) -> dict[int, str]:
+        if not thread_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT thread_id, read_at
+            FROM thread_reads
+            WHERE community_id = ?
+              AND membership_id = ?
+              AND thread_id IN (SELECT value FROM json_each(?))
+            """,
+            (community_id, membership_id, json.dumps(thread_ids)),
+        ).fetchall()
+        return {int(row["thread_id"]): str(row["read_at"]) for row in rows}
 
     def mark_thread_read(
         self,

--- a/src/elbysodic/db/schema.py
+++ b/src/elbysodic/db/schema.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from threading import RLock
+from typing import Any
 
 from elbysodic.db.migrations import apply_migrations
 from elbysodic.domain.boards import DEFAULT_SIDEBAR_SECTION_CONFIGS
@@ -800,14 +802,84 @@ END;
 """
 
 
-def connect(path: str | Path = ":memory:", *, check_same_thread: bool = True) -> sqlite3.Connection:
+class SynchronizedCursor:
+    """Serialize cursor reads that share one SQLite connection."""
+
+    def __init__(self, cursor: sqlite3.Cursor, lock: RLock) -> None:
+        self._cursor = cursor
+        self._lock = lock
+
+    def fetchone(self) -> sqlite3.Row | None:
+        with self._lock:
+            return self._cursor.fetchone()
+
+    def fetchall(self) -> list[sqlite3.Row]:
+        with self._lock:
+            return self._cursor.fetchall()
+
+    def __iter__(self) -> Any:
+        return iter(self.fetchall())
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cursor, name)
+
+
+class SynchronizedConnection:
+    """Thin synchronized wrapper for SQLite access in local threaded servers."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._connection = connection
+        self._lock = RLock()
+
+    def execute(self, *args: Any, **kwargs: Any) -> SynchronizedCursor:
+        with self._lock:
+            return SynchronizedCursor(self._connection.execute(*args, **kwargs), self._lock)
+
+    def executemany(self, *args: Any, **kwargs: Any) -> SynchronizedCursor:
+        with self._lock:
+            return SynchronizedCursor(self._connection.executemany(*args, **kwargs), self._lock)
+
+    def executescript(self, *args: Any, **kwargs: Any) -> SynchronizedCursor:
+        with self._lock:
+            return SynchronizedCursor(self._connection.executescript(*args, **kwargs), self._lock)
+
+    def commit(self) -> None:
+        with self._lock:
+            self._connection.commit()
+
+    def rollback(self) -> None:
+        with self._lock:
+            self._connection.rollback()
+
+    def close(self) -> None:
+        with self._lock:
+            self._connection.close()
+
+    def set_trace_callback(self, trace_callback: Any) -> None:
+        with self._lock:
+            self._connection.set_trace_callback(trace_callback)
+
+    @property
+    def in_transaction(self) -> bool:
+        with self._lock:
+            return self._connection.in_transaction
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._connection, name)
+
+
+def connect(
+    path: str | Path = ":memory:",
+    *,
+    check_same_thread: bool = True,
+) -> sqlite3.Connection:
     connection = sqlite3.connect(path, check_same_thread=check_same_thread)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON")
     connection.execute("PRAGMA busy_timeout = 5000")
     if str(path) != ":memory:":
         connection.execute("PRAGMA journal_mode = WAL")
-    return connection
+    return SynchronizedConnection(connection)
 
 
 def create_schema(connection: sqlite3.Connection) -> None:

--- a/src/elbysodic/db/schema.py
+++ b/src/elbysodic/db/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 from threading import RLock
-from typing import Any
+from typing import Any, cast
 
 from elbysodic.db.migrations import apply_migrations
 from elbysodic.domain.boards import DEFAULT_SIDEBAR_SECTION_CONFIGS
@@ -879,7 +879,7 @@ def connect(
     connection.execute("PRAGMA busy_timeout = 5000")
     if str(path) != ":memory:":
         connection.execute("PRAGMA journal_mode = WAL")
-    return SynchronizedConnection(connection)
+    return cast(sqlite3.Connection, SynchronizedConnection(connection))
 
 
 def create_schema(connection: sqlite3.Connection) -> None:

--- a/src/elbysodic/db/session.py
+++ b/src/elbysodic/db/session.py
@@ -1,0 +1,40 @@
+"""Database connection provider for repository-scoped work."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from elbysodic.db.repository import ForumRepository
+from elbysodic.db.schema import connect, create_schema
+
+
+class Database:
+    """Open initialized SQLite connections for repository operations."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = path
+
+    def initialize(self) -> None:
+        database_path = self.path
+        if database_path != ":memory:":
+            Path(database_path).parent.mkdir(parents=True, exist_ok=True)
+        connection = connect(database_path, check_same_thread=False)
+        try:
+            create_schema(connection)
+        finally:
+            connection.close()
+
+    @contextmanager
+    def connection(self) -> Iterator[object]:
+        connection = connect(self.path, check_same_thread=False)
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    @contextmanager
+    def repository(self) -> Iterator[ForumRepository]:
+        with self.connection() as connection:
+            yield ForumRepository(connection)

--- a/src/elbysodic/db/session.py
+++ b/src/elbysodic/db/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -27,7 +28,7 @@ class Database:
             connection.close()
 
     @contextmanager
-    def connection(self) -> Iterator[object]:
+    def connection(self) -> Iterator[sqlite3.Connection]:
         connection = connect(self.path, check_same_thread=False)
         try:
             yield connection

--- a/src/elbysodic/services/facets.py
+++ b/src/elbysodic/services/facets.py
@@ -128,7 +128,14 @@ def current_character_facet_ids(repo: FacetReadRepository, viewer: ForumView) ->
 
 
 def facet_tags(repo: FacetReadRepository, community_id: int, facets: list[Facet]) -> list[FacetTag]:
-    groups = {group.id: group for group in repo.list_facet_groups(community_id)}
+    return facet_tags_with_groups(repo.list_facet_groups(community_id), facets)
+
+
+def facet_tags_with_groups(
+    facet_groups: list[FacetGroup],
+    facets: list[Facet],
+) -> list[FacetTag]:
+    groups = {group.id: group for group in facet_groups}
     return [
         FacetTag(group=groups[facet.facet_group_id], facet=facet)
         for facet in facets

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -179,6 +179,7 @@ from elbysodic.services.posting import search_mentionables as _search_mentionabl
 from elbysodic.services.posting import start_thread as _start_thread
 from elbysodic.services.posting import update_post as _update_post
 from elbysodic.services.posting import update_thread_scene as _update_thread_scene
+from elbysodic.services.posts import PostViewContextBuilder
 from elbysodic.services.posts import post_view as _post_view
 from elbysodic.services.read_models import (
     MATERIAL_STATUSES,
@@ -1282,12 +1283,12 @@ class AppServices:
     def list_boards(self) -> list[BoardSummary]:
         viewer = self.viewer()
         current_facet_ids = _current_character_facet_ids(self.repo, viewer)
-        summaries: list[BoardSummary] = []
-        for board in self.repo.list_boards(viewer.community.id):
-            if not policies.can_view_board(viewer.membership, board, viewer.role):
-                continue
-            summaries.append(_board_summary(self.repo, viewer, board, current_facet_ids))
-        return summaries
+        visible_boards = [
+            board
+            for board in self.repo.list_boards(viewer.community.id)
+            if policies.can_view_board(viewer.membership, board, viewer.role)
+        ]
+        return _board_summaries(self.repo, viewer, visible_boards, current_facet_ids)
 
     def child_board_summaries(self, board: Board) -> list[BoardSummary]:
         viewer = self.viewer()
@@ -3309,6 +3310,108 @@ def _board_summary(
             and {tag.facet.id for tag in board_facets}.intersection(current_facet_ids)
         ),
     )
+
+
+def _board_summaries(
+    repo: ForumRepository,
+    viewer: ForumView,
+    boards: list[Board],
+    current_facet_ids: set[int],
+) -> list[BoardSummary]:
+    if not boards:
+        return []
+    board_ids = [board.id for board in boards]
+    children_by_board = repo.list_child_boards_for_boards(viewer.community.id, board_ids)
+    visible_children_by_board = {
+        board_id: [
+            child
+            for child in children
+            if policies.can_view_board(viewer.membership, child, viewer.role)
+        ]
+        for board_id, children in children_by_board.items()
+    }
+    activity_boards_by_summary = {
+        board.id: [board, *visible_children_by_board.get(board.id, [])] for board in boards
+    }
+    activity_board_ids = list(
+        {
+            activity_board.id
+            for activity_boards in activity_boards_by_summary.values()
+            for activity_board in activity_boards
+        }
+    )
+    threads_by_board = repo.list_threads_for_boards(viewer.community.id, activity_board_ids)
+    all_thread_ids = [thread.id for threads in threads_by_board.values() for thread in threads]
+    posts_by_thread = repo.list_posts_for_threads(viewer.community.id, all_thread_ids)
+    thread_read_at = repo.thread_read_at_for_threads(
+        viewer.community.id,
+        all_thread_ids,
+        viewer.membership.id,
+    )
+    all_posts = [post for posts in posts_by_thread.values() for post in posts]
+    post_context = (
+        PostViewContextBuilder(repo, viewer.community.id).context(all_posts)
+        if all_posts
+        else None
+    )
+    summaries: list[BoardSummary] = []
+    for board in boards:
+        threads_with_boards = [
+            (activity_board, thread)
+            for activity_board in activity_boards_by_summary[board.id]
+            for thread in threads_by_board.get(activity_board.id, [])
+        ]
+        latest_board: Board | None = None
+        latest_thread: Thread | None = None
+        if threads_with_boards:
+            latest_board, latest_thread = max(
+                threads_with_boards,
+                key=lambda item: (_timestamp_key(item[1].updated_at), item[1].id),
+            )
+        latest_thread_posts = posts_by_thread.get(latest_thread.id, []) if latest_thread else []
+        latest_post = (
+            _post_view(
+                repo,
+                viewer.community.id,
+                latest_thread_posts[-1],
+                context=post_context,
+            )
+            if latest_thread_posts
+            else None
+        )
+        threads = [thread for _, thread in threads_with_boards]
+        board_facets = _facet_tags(
+            repo,
+            viewer.community.id,
+            repo.list_board_facets(viewer.community.id, board.id),
+        )
+        summaries.append(
+            BoardSummary(
+                board=board,
+                child_boards=visible_children_by_board.get(board.id, []),
+                thread_count=len(threads),
+                post_count=sum(len(posts_by_thread.get(thread.id, [])) for thread in threads),
+                unread_thread_count=sum(
+                    1 for thread in threads if _is_unread_from_map(thread, thread_read_at)
+                ),
+                latest_thread=latest_thread,
+                latest_board=latest_board,
+                latest_post=latest_post,
+                facets=board_facets,
+                is_relevant_to_current_face=bool(
+                    current_facet_ids
+                    and {tag.facet.id for tag in board_facets}.intersection(current_facet_ids)
+                ),
+            )
+        )
+    return summaries
+
+
+def _is_unread_from_map(thread: Thread, read_at_by_thread: dict[int, str]) -> bool:
+    read_at = read_at_by_thread.get(thread.id)
+    if read_at is None:
+        return True
+    return _timestamp_key(read_at) < _timestamp_key(thread.updated_at)
 
 
 def _latest_thread(threads: list[Thread]) -> Thread | None:

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -1057,14 +1057,18 @@ class AppServices:
         counts_by_community = self.repo.network_program_counts(
             [membership.community_id for membership in memberships]
         )
+        counts_by_membership = self.repo.network_membership_counts(
+            [membership.id for membership in memberships]
+        )
         for membership in memberships:
             community = self.repo.get_community(membership.community_id)
             role = self.repo.get_role(community.id, membership.role_id)
             roster = self.repo.list_characters(community.id, membership.id)
             materials = self.repo.list_materials(community.id)
-            community_characters = self.repo.list_community_characters(community.id)
             theme = community_theme_view(self.repo.get_default_theme(community.id))
             counts = counts_by_community.get(community.id, {})
+            membership_counts = counts_by_membership.get(membership.id, {})
+            can_review_applications = policies.can_manage_applications(membership, role)
             programs.append(
                 StudioNetworkProgramView(
                     community=community,
@@ -1078,21 +1082,19 @@ class AppServices:
                         self.repo,
                         community.id,
                     ),
-                    roster_count=len(community_characters),
+                    roster_count=counts.get("roster_count", 0),
                     open_wanted_count=counts.get("open_wanted_count", 0),
                     application_material_count=counts.get("application_material_count", 0),
                     claim_type_count=counts.get("claim_type_count", 0),
-                    application_count=_network_application_count(
-                        community_characters,
-                        can_review=policies.can_manage_applications(membership, role),
-                        membership_id=membership.id,
+                    application_count=membership_counts.get(
+                        (
+                            "reviewable_application_count"
+                            if can_review_applications
+                            else "own_application_count"
+                        ),
+                        0,
                     ),
-                    plotting_room_count=len(
-                        self.repo.list_plotting_rooms_for_membership(
-                            community.id,
-                            membership.id,
-                        )
-                    ),
+                    plotting_room_count=membership_counts.get("plotting_room_count", 0),
                     unread_notification_count=_count_visible_unread_notifications(
                         self.repo,
                         community.id,
@@ -4082,22 +4084,6 @@ def _network_explore_lanes() -> list[NetworkExploreLane]:
             "story",
         ),
     ]
-
-
-def _network_application_count(
-    characters: list[Character],
-    *,
-    can_review: bool,
-    membership_id: int,
-) -> int:
-    statuses = {"draft", "submitted", "revision_requested"}
-    if can_review:
-        return sum(1 for character in characters if character.application_status in statuses)
-    return sum(
-        1
-        for character in characters
-        if character.membership_id == membership_id and character.application_status in statuses
-    )
 
 
 def _network_theme_preview(theme: object | None) -> StudioNetworkThemePreview:

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -3352,9 +3352,7 @@ def _board_summaries(
     )
     all_posts = [post for posts in posts_by_thread.values() for post in posts]
     post_context = (
-        PostViewContextBuilder(repo, viewer.community.id).context(all_posts)
-        if all_posts
-        else None
+        PostViewContextBuilder(repo, viewer.community.id).context(all_posts) if all_posts else None
     )
     summaries: list[BoardSummary] = []
     for board in boards:

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 import re
 import secrets
+import sqlite3
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -361,6 +363,7 @@ class AppServices:
         )
         self._identity_context = identity_context
         self._viewer: ForumView | None = None
+        self._closed = False
 
     @property
     def seed(self) -> DemoSeed:
@@ -391,6 +394,22 @@ class AppServices:
                 require_session=production,
             ),
         )
+
+    def close(self) -> None:
+        """Release the shared repository connection owned by this service facade."""
+
+        if self._closed:
+            return
+        self._closed = True
+        connection = self.repo.connection
+        with suppress(sqlite3.Error):
+            if connection.in_transaction:
+                connection.rollback()
+        with suppress(sqlite3.Error):
+            if _connection_has_filesystem_database(connection):
+                connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        with suppress(sqlite3.Error):
+            connection.close()
 
     def viewer(self) -> ForumView:
         if self._identity_context is not None and self._viewer is not None:
@@ -3021,6 +3040,10 @@ def create_services(path: str | Path | None = None, *, seed_demo: bool = True) -
     repo = ForumRepository(connection)
     seed = seed_demo_forum(repo) if seed_demo else None
     return AppServices(repo, seed)
+
+
+def _connection_has_filesystem_database(connection: sqlite3.Connection) -> bool:
+    return any(row["file"] for row in connection.execute("PRAGMA database_list").fetchall())
 
 
 def initialize_database(path: str | Path | None = None, *, seed_demo: bool = False) -> Path:

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -1048,16 +1048,22 @@ class AppServices:
     def studio_network(self) -> StudioNetworkDirectory:
         identity = self._identity_context or self._identity_resolver.resolve()
         programs: list[StudioNetworkProgramView] = []
-        for membership in self.repo.list_memberships_for_user(identity.user_id):
-            if not membership.is_active:
-                continue
+        memberships = [
+            membership
+            for membership in self.repo.list_memberships_for_user(identity.user_id)
+            if membership.is_active
+        ]
+        counts_by_community = self.repo.network_program_counts(
+            [membership.community_id for membership in memberships]
+        )
+        for membership in memberships:
             community = self.repo.get_community(membership.community_id)
             role = self.repo.get_role(community.id, membership.role_id)
             roster = self.repo.list_characters(community.id, membership.id)
             materials = self.repo.list_materials(community.id)
-            wanted_ads = self.repo.list_wanted_ads(community.id)
             community_characters = self.repo.list_community_characters(community.id)
             theme = community_theme_view(self.repo.get_default_theme(community.id))
+            counts = counts_by_community.get(community.id, {})
             programs.append(
                 StudioNetworkProgramView(
                     community=community,
@@ -1072,13 +1078,9 @@ class AppServices:
                         community.id,
                     ),
                     roster_count=len(community_characters),
-                    open_wanted_count=sum(
-                        1 for wanted_ad in wanted_ads if wanted_ad.status == "open"
-                    ),
-                    application_material_count=sum(
-                        1 for material in materials if material.material_type == "application"
-                    ),
-                    claim_type_count=len(self.repo.list_claim_types(community.id)),
+                    open_wanted_count=counts.get("open_wanted_count", 0),
+                    application_material_count=counts.get("application_material_count", 0),
+                    claim_type_count=counts.get("claim_type_count", 0),
                     application_count=_network_application_count(
                         community_characters,
                         can_review=policies.can_manage_applications(membership, role),
@@ -1117,13 +1119,16 @@ class AppServices:
 
     def public_studio_network(self) -> StudioNetworkDirectory:
         programs: list[StudioNetworkProgramView] = []
-        for community in self.repo.list_communities():
+        communities = self.repo.list_communities()
+        counts_by_community = self.repo.network_program_counts(
+            [community.id for community in communities]
+        )
+        for community in communities:
             materials = self.repo.list_materials(community.id, status="published")
             if not _is_public_network_ready(self.repo, community, materials):
                 continue
-            wanted_ads = self.repo.list_wanted_ads(community.id)
-            community_characters = self.repo.list_community_characters(community.id)
             theme = community_theme_view(self.repo.get_default_theme(community.id))
+            counts = counts_by_community.get(community.id, {})
             programs.append(
                 StudioNetworkProgramView(
                     community=community,
@@ -1137,14 +1142,10 @@ class AppServices:
                         self.repo,
                         community.id,
                     ),
-                    roster_count=len(community_characters),
-                    open_wanted_count=sum(
-                        1 for wanted_ad in wanted_ads if wanted_ad.status == "open"
-                    ),
-                    application_material_count=sum(
-                        1 for material in materials if material.material_type == "application"
-                    ),
-                    claim_type_count=len(self.repo.list_claim_types(community.id)),
+                    roster_count=counts.get("roster_count", 0),
+                    open_wanted_count=counts.get("open_wanted_count", 0),
+                    application_material_count=counts.get("application_material_count", 0),
+                    claim_type_count=counts.get("claim_type_count", 0),
                     application_count=0,
                     plotting_room_count=0,
                     unread_notification_count=0,

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -3199,15 +3199,18 @@ def _board_navigation(
         repo.list_boards(community_id),
         key=lambda board: (board.navigation_order, board.name, board.id),
     )
-    for board in boards:
-        if not board.show_in_navigation:
-            continue
-        if not policies.can_view_board(membership, board, role):
-            continue
-        threads = repo.list_threads(community_id, board.id)
-        unread_thread_count = sum(
-            1 for thread in threads if _is_unread(repo, community_id, membership.id, thread)
-        )
+    visible_boards = [
+        board
+        for board in boards
+        if board.show_in_navigation and policies.can_view_board(membership, board, role)
+    ]
+    unread_counts = repo.unread_thread_counts_by_board(
+        community_id,
+        [board.id for board in visible_boards],
+        membership.id,
+    )
+    for board in visible_boards:
+        unread_thread_count = unread_counts.get(board.id, 0)
         items.append(BoardNavigationItem(board=board, unread_thread_count=unread_thread_count))
     return items
 

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -6,13 +6,13 @@ import os
 import re
 import secrets
 import sqlite3
-from contextlib import suppress
+from contextlib import AbstractContextManager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from elbysodic.blueprints import ProgramBlueprintPreview
-from elbysodic.db import ForumRepository, connect, create_schema
+from elbysodic.db import Database, ForumRepository, connect, create_schema
 from elbysodic.db.seed import (
     SEED_PERSONAS,
     DemoSeed,
@@ -352,17 +352,29 @@ class AppServices:
         repo: ForumRepository,
         seed: DemoSeed | None,
         *,
+        database: Database | None = None,
         identity_resolver: RequestIdentityResolver | None = None,
         identity_context: RequestIdentityContext | None = None,
+        allow_development_identity: bool = True,
+        require_session: bool = False,
+        repo_context: AbstractContextManager[ForumRepository] | None = None,
+        owns_repo: bool = True,
     ) -> None:
         self.repo = repo
+        self._database = database
         self._seed = seed
+        self._allow_development_identity = allow_development_identity
+        self._require_session = require_session
         self._identity_resolver = identity_resolver or RequestIdentityResolver(
             repo,
             _default_request_identity(seed),
+            allow_development_identity=allow_development_identity,
+            require_session=require_session,
         )
         self._identity_context = identity_context
         self._viewer: ForumView | None = None
+        self._repo_context = repo_context
+        self._owns_repo = owns_repo
         self._closed = False
 
     @property
@@ -372,13 +384,35 @@ class AppServices:
         return self._seed
 
     def for_request(self, request: object) -> AppServices:
-        """Return a request-scoped facade sharing the same repository."""
+        """Return a request-scoped facade."""
 
+        if self._database is not None:
+            repo_context = self._database.repository()
+            repo = repo_context.__enter__()
+            identity_resolver = RequestIdentityResolver(
+                repo,
+                _default_request_identity(self._seed),
+                allow_development_identity=self._allow_development_identity,
+                require_session=self._require_session,
+            )
+            return AppServices(
+                repo,
+                self._seed,
+                database=self._database,
+                identity_resolver=identity_resolver,
+                identity_context=identity_resolver.resolve(request),
+                allow_development_identity=self._allow_development_identity,
+                require_session=self._require_session,
+                repo_context=repo_context,
+            )
         return AppServices(
             self.repo,
             self._seed,
             identity_resolver=self._identity_resolver,
             identity_context=self._identity_resolver.resolve(request),
+            allow_development_identity=self._allow_development_identity,
+            require_session=self._require_session,
+            owns_repo=False,
         )
 
     def with_request_auth(self, *, production: bool) -> AppServices:
@@ -387,12 +421,16 @@ class AppServices:
         return AppServices(
             self.repo,
             self._seed,
+            database=self._database,
             identity_resolver=RequestIdentityResolver(
                 self.repo,
                 _default_request_identity(self._seed),
                 allow_development_identity=not production,
                 require_session=production,
             ),
+            allow_development_identity=not production,
+            require_session=production,
+            owns_repo=self._owns_repo,
         )
 
     def close(self) -> None:
@@ -401,6 +439,11 @@ class AppServices:
         if self._closed:
             return
         self._closed = True
+        if self._repo_context is not None:
+            self._repo_context.__exit__(None, None, None)
+            return
+        if not self._owns_repo:
+            return
         connection = self.repo.connection
         with suppress(sqlite3.Error):
             if connection.in_transaction:
@@ -3039,7 +3082,8 @@ def create_services(path: str | Path | None = None, *, seed_demo: bool = True) -
     create_schema(connection)
     repo = ForumRepository(connection)
     seed = seed_demo_forum(repo) if seed_demo else None
-    return AppServices(repo, seed)
+    database = None if database_path == ":memory:" else Database(database_path)
+    return AppServices(repo, seed, database=database, owns_repo=True)
 
 
 def _connection_has_filesystem_database(connection: sqlite3.Connection) -> bool:

--- a/src/elbysodic/services/posts.py
+++ b/src/elbysodic/services/posts.py
@@ -53,33 +53,56 @@ class PostViewContext:
     mention_links: list[MentionLink]
 
 
+@dataclass(slots=True)
+class PostViewContextBuilder:
+    """Build post views with request-local lookup reuse."""
+
+    repo: PostViewRepository
+    community_id: int
+    _community: Community | None = None
+    _mention_links: list[MentionLink] | None = None
+
+    def context(self, posts: list[Post]) -> PostViewContext:
+        community = self.community()
+        author_ids = {post.author_character_id for post in posts}
+        membership_ids = {post.author_membership_id for post in posts}
+        authors = {
+            character_id: self.repo.get_character(self.community_id, character_id)
+            for character_id in sorted(author_ids)
+        }
+        memberships = {
+            membership_id: self.repo.get_membership(self.community_id, membership_id)
+            for membership_id in sorted(membership_ids)
+        }
+        accent_colors = {
+            character_id: resolve_character_accent(self.repo, community, character)
+            for character_id, character in authors.items()
+        }
+        return PostViewContext(
+            community=community,
+            authors=authors,
+            memberships=memberships,
+            accent_colors=accent_colors,
+            mention_links=self.mention_links(),
+        )
+
+    def community(self) -> Community:
+        if self._community is None:
+            self._community = self.repo.get_community(self.community_id)
+        return self._community
+
+    def mention_links(self) -> list[MentionLink]:
+        if self._mention_links is None:
+            self._mention_links = post_mention_links(self.repo, self.community_id)
+        return self._mention_links
+
+
 def build_post_view_context(
     repo: PostViewRepository,
     community_id: int,
     posts: list[Post],
 ) -> PostViewContext:
-    community = repo.get_community(community_id)
-    author_ids = {post.author_character_id for post in posts}
-    membership_ids = {post.author_membership_id for post in posts}
-    authors = {
-        character_id: repo.get_character(community_id, character_id)
-        for character_id in sorted(author_ids)
-    }
-    memberships = {
-        membership_id: repo.get_membership(community_id, membership_id)
-        for membership_id in sorted(membership_ids)
-    }
-    accent_colors = {
-        character_id: resolve_character_accent(repo, community, character)
-        for character_id, character in authors.items()
-    }
-    return PostViewContext(
-        community=community,
-        authors=authors,
-        memberships=memberships,
-        accent_colors=accent_colors,
-        mention_links=post_mention_links(repo, community_id),
-    )
+    return PostViewContextBuilder(repo, community_id).context(posts)
 
 
 def post_view(

--- a/src/elbysodic/services/posts.py
+++ b/src/elbysodic/services/posts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import Protocol
 
 from elbysodic.domain.models import (
@@ -43,6 +44,44 @@ class PostViewRepository(Protocol):
     def list_memberships(self, community_id: int) -> list[CommunityMembership]: ...
 
 
+@dataclass(frozen=True, slots=True)
+class PostViewContext:
+    community: Community
+    authors: dict[int, Character]
+    memberships: dict[int, CommunityMembership]
+    accent_colors: dict[int, str]
+    mention_links: list[MentionLink]
+
+
+def build_post_view_context(
+    repo: PostViewRepository,
+    community_id: int,
+    posts: list[Post],
+) -> PostViewContext:
+    community = repo.get_community(community_id)
+    author_ids = {post.author_character_id for post in posts}
+    membership_ids = {post.author_membership_id for post in posts}
+    authors = {
+        character_id: repo.get_character(community_id, character_id)
+        for character_id in sorted(author_ids)
+    }
+    memberships = {
+        membership_id: repo.get_membership(community_id, membership_id)
+        for membership_id in sorted(membership_ids)
+    }
+    accent_colors = {
+        character_id: resolve_character_accent(repo, community, character)
+        for character_id, character in authors.items()
+    }
+    return PostViewContext(
+        community=community,
+        authors=authors,
+        memberships=memberships,
+        accent_colors=accent_colors,
+        mention_links=post_mention_links(repo, community_id),
+    )
+
+
 def post_view(
     repo: PostViewRepository,
     community_id: int,
@@ -50,20 +89,18 @@ def post_view(
     *,
     viewer_membership: CommunityMembership | None = None,
     viewer_role: Role | None = None,
+    context: PostViewContext | None = None,
 ) -> PostView:
-    community = repo.get_community(community_id)
-    author = repo.get_character(community_id, post.author_character_id)
+    context = context or build_post_view_context(repo, community_id, [post])
+    author = context.authors[post.author_character_id]
     return PostView(
         post=post,
         author=author,
-        author_accent_color=resolve_character_accent(repo, community, author),
-        author_membership=repo.get_membership(
-            community_id,
-            post.author_membership_id,
-        ),
+        author_accent_color=context.accent_colors.get(author.id, ""),
+        author_membership=context.memberships[post.author_membership_id],
         rendered_body=render_post_body(
             post.body,
-            mentions=post_mention_links(repo, community_id),
+            mentions=context.mention_links,
         ),
         snippet=post_snippet(post.body),
         can_edit=(

--- a/src/elbysodic/services/read_session.py
+++ b/src/elbysodic/services/read_session.py
@@ -1,0 +1,66 @@
+"""Request-local read model lookup helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from elbysodic.domain.models import Character, CommunityMembership, Role
+
+
+class ReadSessionRepository(Protocol):
+    def get_character(self, community_id: int, character_id: int) -> Character: ...
+
+    def get_membership(self, community_id: int, membership_id: int) -> CommunityMembership: ...
+
+    def get_role(self, community_id: int, role_id: int) -> Role: ...
+
+    def get_thread_read_at(
+        self,
+        community_id: int,
+        thread_id: int,
+        membership_id: int,
+    ) -> str | None: ...
+
+
+@dataclass(slots=True)
+class ReadModelSession:
+    """Cache repeated lookups only for one request/read-model assembly."""
+
+    repo: ReadSessionRepository
+    community_id: int
+    _characters: dict[int, Character] = field(default_factory=dict)
+    _memberships: dict[int, CommunityMembership] = field(default_factory=dict)
+    _roles: dict[int, Role] = field(default_factory=dict)
+    _thread_reads: dict[tuple[int, int], str | None] = field(default_factory=dict)
+
+    def character(self, character_id: int) -> Character:
+        if character_id not in self._characters:
+            self._characters[character_id] = self.repo.get_character(
+                self.community_id,
+                character_id,
+            )
+        return self._characters[character_id]
+
+    def membership(self, membership_id: int) -> CommunityMembership:
+        if membership_id not in self._memberships:
+            self._memberships[membership_id] = self.repo.get_membership(
+                self.community_id,
+                membership_id,
+            )
+        return self._memberships[membership_id]
+
+    def role(self, role_id: int) -> Role:
+        if role_id not in self._roles:
+            self._roles[role_id] = self.repo.get_role(self.community_id, role_id)
+        return self._roles[role_id]
+
+    def thread_read_at(self, thread_id: int, membership_id: int) -> str | None:
+        key = (thread_id, membership_id)
+        if key not in self._thread_reads:
+            self._thread_reads[key] = self.repo.get_thread_read_at(
+                self.community_id,
+                thread_id,
+                membership_id,
+            )
+        return self._thread_reads[key]

--- a/src/elbysodic/services/threads.py
+++ b/src/elbysodic/services/threads.py
@@ -340,13 +340,22 @@ def thread_obligations(
         for board in repo.list_boards(viewer.community.id)
         if policies.can_view_board(viewer.membership, board, viewer.role)
     }
+    candidate_threads = [
+        thread
+        for thread in repo.list_threads(viewer.community.id)
+        if thread.board_id in visible_boards and is_live_queue_thread(thread)
+    ]
+    thread_ids = [thread.id for thread in candidate_threads]
+    posts_by_thread = repo.list_posts_for_threads(viewer.community.id, thread_ids)
+    participants_by_thread = repo.list_thread_participants_for_threads(
+        viewer.community.id,
+        thread_ids,
+    )
     items = []
-    for thread in repo.list_threads(viewer.community.id):
-        board = visible_boards.get(thread.board_id)
-        if board is None or not is_live_queue_thread(thread):
-            continue
-        posts = repo.list_posts(viewer.community.id, thread.id)
-        participants = repo.list_thread_participants(viewer.community.id, thread.id)
+    for thread in candidate_threads:
+        board = visible_boards[thread.board_id]
+        posts = posts_by_thread.get(thread.id, [])
+        participants = participants_by_thread.get(thread.id, [])
         participant_ids = {character.id for character in participants}
         if not thread_belongs_to_roster(
             thread,

--- a/src/elbysodic/services/threads.py
+++ b/src/elbysodic/services/threads.py
@@ -66,11 +66,23 @@ class ThreadReadRepository(
 
     def get_character(self, community_id: int, character_id: int) -> Character: ...
 
+    def list_characters_by_ids(
+        self,
+        community_id: int,
+        character_ids: list[int],
+    ) -> dict[int, Character]: ...
+
     def get_membership(
         self,
         community_id: int,
         membership_id: int,
     ) -> CommunityMembership: ...
+
+    def list_memberships_by_ids(
+        self,
+        community_id: int,
+        membership_ids: list[int],
+    ) -> dict[int, CommunityMembership]: ...
 
     def list_thread_participants(self, community_id: int, thread_id: int) -> list[Character]: ...
 
@@ -125,6 +137,14 @@ def board_thread_summaries(
     )
     facet_groups = repo.list_facet_groups(viewer.community.id)
     facets_by_thread = repo.list_thread_facets_for_threads(viewer.community.id, thread_ids)
+    authors = repo.list_characters_by_ids(
+        viewer.community.id,
+        list({thread.author_character_id for thread in threads}),
+    )
+    author_memberships = repo.list_memberships_by_ids(
+        viewer.community.id,
+        list({thread.author_membership_id for thread in threads}),
+    )
     for thread in threads:
         summary = thread_summary(
             repo,
@@ -136,6 +156,8 @@ def board_thread_summaries(
             participants=participants_by_thread.get(thread.id, []),
             facet_groups=facet_groups,
             thread_facets=facets_by_thread.get(thread.id, []),
+            authors=authors,
+            author_memberships=author_memberships,
         )
         if thread_matches_filter(summary, filter_by):
             summaries.append(summary)
@@ -153,6 +175,8 @@ def thread_summary(
     participants: list[Character] | None = None,
     facet_groups: list[FacetGroup] | None = None,
     thread_facets: list[Facet] | None = None,
+    authors: dict[int, Character] | None = None,
+    author_memberships: dict[int, CommunityMembership] | None = None,
 ) -> ThreadSummary:
     posts = repo.list_posts(viewer.community.id, thread.id) if posts is None else posts
     participants = (
@@ -177,13 +201,23 @@ def thread_summary(
         thread,
         posts,
     )
-    return ThreadSummary(
-        thread=thread,
-        author=repo.get_character(viewer.community.id, thread.author_character_id),
-        author_membership=repo.get_membership(
+    author = (
+        repo.get_character(viewer.community.id, thread.author_character_id)
+        if authors is None
+        else authors[thread.author_character_id]
+    )
+    author_membership = (
+        repo.get_membership(
             viewer.community.id,
             thread.author_membership_id,
-        ),
+        )
+        if author_memberships is None
+        else author_memberships[thread.author_membership_id]
+    )
+    return ThreadSummary(
+        thread=thread,
+        author=author,
+        author_membership=author_membership,
         participants=participants,
         facets=thread_facet_tags,
         is_relevant_to_current_face=bool(
@@ -367,6 +401,14 @@ def thread_obligations(
         viewer.community.id,
         thread_ids,
     )
+    authors = repo.list_characters_by_ids(
+        viewer.community.id,
+        list({thread.author_character_id for thread in candidate_threads}),
+    )
+    author_memberships = repo.list_memberships_by_ids(
+        viewer.community.id,
+        list({thread.author_membership_id for thread in candidate_threads}),
+    )
     items = []
     for thread in candidate_threads:
         board = visible_boards[thread.board_id]
@@ -403,14 +445,8 @@ def thread_obligations(
             ThreadObligationItem(
                 board=board,
                 thread=thread,
-                author=repo.get_character(
-                    viewer.community.id,
-                    thread.author_character_id,
-                ),
-                author_membership=repo.get_membership(
-                    viewer.community.id,
-                    thread.author_membership_id,
-                ),
+                author=authors[thread.author_character_id],
+                author_membership=author_memberships[thread.author_membership_id],
                 participants=participants,
                 latest_post=(
                     post_view(repo, viewer.community.id, latest_post) if latest_post else None

--- a/src/elbysodic/services/threads.py
+++ b/src/elbysodic/services/threads.py
@@ -57,6 +57,12 @@ class ThreadReadRepository(
 
     def list_posts(self, community_id: int, thread_id: int) -> list[Post]: ...
 
+    def list_posts_for_threads(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+    ) -> dict[int, list[Post]]: ...
+
     def get_character(self, community_id: int, character_id: int) -> Character: ...
 
     def get_membership(
@@ -66,6 +72,12 @@ class ThreadReadRepository(
     ) -> CommunityMembership: ...
 
     def list_thread_participants(self, community_id: int, thread_id: int) -> list[Character]: ...
+
+    def list_thread_participants_for_threads(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+    ) -> dict[int, list[Character]]: ...
 
     def list_thread_participant_ids(self, community_id: int, thread_id: int) -> set[int]: ...
 
@@ -97,13 +109,22 @@ def board_thread_summaries(
     summaries = []
     current_facet_ids = current_character_facet_ids(repo, viewer)
     roster_character_ids = {character.id for character in viewer.roster}
-    for thread in repo.list_threads(viewer.community.id, board.id):
+    threads = repo.list_threads(viewer.community.id, board.id)
+    thread_ids = [thread.id for thread in threads]
+    posts_by_thread = repo.list_posts_for_threads(viewer.community.id, thread_ids)
+    participants_by_thread = repo.list_thread_participants_for_threads(
+        viewer.community.id,
+        thread_ids,
+    )
+    for thread in threads:
         summary = thread_summary(
             repo,
             viewer,
             thread,
             current_facet_ids=current_facet_ids,
             roster_character_ids=roster_character_ids,
+            posts=posts_by_thread.get(thread.id, []),
+            participants=participants_by_thread.get(thread.id, []),
         )
         if thread_matches_filter(summary, filter_by):
             summaries.append(summary)
@@ -117,9 +138,15 @@ def thread_summary(
     *,
     current_facet_ids: set[int],
     roster_character_ids: set[int],
+    posts: list[Post] | None = None,
+    participants: list[Character] | None = None,
 ) -> ThreadSummary:
-    posts = repo.list_posts(viewer.community.id, thread.id)
-    participants = repo.list_thread_participants(viewer.community.id, thread.id)
+    posts = repo.list_posts(viewer.community.id, thread.id) if posts is None else posts
+    participants = (
+        repo.list_thread_participants(viewer.community.id, thread.id)
+        if participants is None
+        else participants
+    )
     participant_ids = {character.id for character in participants}
     thread_facets = facet_tags(
         repo,

--- a/src/elbysodic/services/threads.py
+++ b/src/elbysodic/services/threads.py
@@ -21,7 +21,12 @@ from elbysodic.services.facets import (
     facet_tags,
     facet_tags_with_groups,
 )
-from elbysodic.services.posts import PostViewRepository, post_view
+from elbysodic.services.posts import (
+    PostViewContext,
+    PostViewContextBuilder,
+    PostViewRepository,
+    post_view,
+)
 from elbysodic.services.read_models import (
     POSTING_MODES,
     THREAD_STATUSES,
@@ -145,6 +150,10 @@ def board_thread_summaries(
         viewer.community.id,
         list({thread.author_membership_id for thread in threads}),
     )
+    post_context = PostViewContextBuilder(
+        repo,
+        viewer.community.id,
+    ).context([post for posts in posts_by_thread.values() for post in posts])
     for thread in threads:
         summary = thread_summary(
             repo,
@@ -158,6 +167,7 @@ def board_thread_summaries(
             thread_facets=facets_by_thread.get(thread.id, []),
             authors=authors,
             author_memberships=author_memberships,
+            post_context=post_context,
         )
         if thread_matches_filter(summary, filter_by):
             summaries.append(summary)
@@ -177,6 +187,7 @@ def thread_summary(
     thread_facets: list[Facet] | None = None,
     authors: dict[int, Character] | None = None,
     author_memberships: dict[int, CommunityMembership] | None = None,
+    post_context: PostViewContext | None = None,
 ) -> ThreadSummary:
     posts = repo.list_posts(viewer.community.id, thread.id) if posts is None else posts
     participants = (
@@ -225,9 +236,15 @@ def thread_summary(
             and {tag.facet.id for tag in thread_facet_tags}.intersection(current_facet_ids)
         ),
         reply_count=max(0, len(posts) - 1),
-        latest_post=post_view(repo, viewer.community.id, latest_post) if latest_post else None,
+        latest_post=(
+            post_view(repo, viewer.community.id, latest_post, context=post_context)
+            if latest_post
+            else None
+        ),
         first_unread_post=(
-            post_view(repo, viewer.community.id, first_unread) if first_unread else None
+            post_view(repo, viewer.community.id, first_unread, context=post_context)
+            if first_unread
+            else None
         ),
         episode=episode_credits(repo, viewer.community.id, posts),
         is_unread=is_unread(
@@ -409,6 +426,10 @@ def thread_obligations(
         viewer.community.id,
         list({thread.author_membership_id for thread in candidate_threads}),
     )
+    post_context = PostViewContextBuilder(
+        repo,
+        viewer.community.id,
+    ).context([post for posts in posts_by_thread.values() for post in posts])
     items = []
     for thread in candidate_threads:
         board = visible_boards[thread.board_id]
@@ -449,13 +470,19 @@ def thread_obligations(
                 author_membership=author_memberships[thread.author_membership_id],
                 participants=participants,
                 latest_post=(
-                    post_view(repo, viewer.community.id, latest_post) if latest_post else None
+                    post_view(repo, viewer.community.id, latest_post, context=post_context)
+                    if latest_post
+                    else None
                 ),
                 first_unread_post=(
-                    post_view(repo, viewer.community.id, first_unread) if first_unread else None
+                    post_view(repo, viewer.community.id, first_unread, context=post_context)
+                    if first_unread
+                    else None
                 ),
                 last_own_post=(
-                    post_view(repo, viewer.community.id, last_own_post) if last_own_post else None
+                    post_view(repo, viewer.community.id, last_own_post, context=post_context)
+                    if last_own_post
+                    else None
                 ),
                 episode=episode_credits(repo, viewer.community.id, posts),
                 reply_count=max(0, len(posts) - 1),

--- a/src/elbysodic/services/threads.py
+++ b/src/elbysodic/services/threads.py
@@ -19,6 +19,7 @@ from elbysodic.services.facets import (
     FacetReadRepository,
     current_character_facet_ids,
     facet_tags,
+    facet_tags_with_groups,
 )
 from elbysodic.services.posts import PostViewRepository, post_view
 from elbysodic.services.read_models import (
@@ -87,6 +88,12 @@ class ThreadReadRepository(
 
     def list_thread_facets(self, community_id: int, thread_id: int) -> list[Facet]: ...
 
+    def list_thread_facets_for_threads(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+    ) -> dict[int, list[Facet]]: ...
+
     def list_board_facets(self, community_id: int, board_id: int) -> list[Facet]: ...
 
     def list_community_characters(self, community_id: int) -> list[Character]: ...
@@ -116,6 +123,8 @@ def board_thread_summaries(
         viewer.community.id,
         thread_ids,
     )
+    facet_groups = repo.list_facet_groups(viewer.community.id)
+    facets_by_thread = repo.list_thread_facets_for_threads(viewer.community.id, thread_ids)
     for thread in threads:
         summary = thread_summary(
             repo,
@@ -125,6 +134,8 @@ def board_thread_summaries(
             roster_character_ids=roster_character_ids,
             posts=posts_by_thread.get(thread.id, []),
             participants=participants_by_thread.get(thread.id, []),
+            facet_groups=facet_groups,
+            thread_facets=facets_by_thread.get(thread.id, []),
         )
         if thread_matches_filter(summary, filter_by):
             summaries.append(summary)
@@ -140,6 +151,8 @@ def thread_summary(
     roster_character_ids: set[int],
     posts: list[Post] | None = None,
     participants: list[Character] | None = None,
+    facet_groups: list[FacetGroup] | None = None,
+    thread_facets: list[Facet] | None = None,
 ) -> ThreadSummary:
     posts = repo.list_posts(viewer.community.id, thread.id) if posts is None else posts
     participants = (
@@ -148,11 +161,14 @@ def thread_summary(
         else participants
     )
     participant_ids = {character.id for character in participants}
-    thread_facets = facet_tags(
-        repo,
-        viewer.community.id,
-        repo.list_thread_facets(viewer.community.id, thread.id),
-    )
+    if facet_groups is None or thread_facets is None:
+        thread_facet_tags = facet_tags(
+            repo,
+            viewer.community.id,
+            repo.list_thread_facets(viewer.community.id, thread.id),
+        )
+    else:
+        thread_facet_tags = facet_tags_with_groups(facet_groups, thread_facets)
     latest_post = posts[-1] if posts else None
     first_unread = first_unread_post(
         repo,
@@ -169,10 +185,10 @@ def thread_summary(
             thread.author_membership_id,
         ),
         participants=participants,
-        facets=thread_facets,
+        facets=thread_facet_tags,
         is_relevant_to_current_face=bool(
             current_facet_ids
-            and {tag.facet.id for tag in thread_facets}.intersection(current_facet_ids)
+            and {tag.facet.id for tag in thread_facet_tags}.intersection(current_facet_ids)
         ),
         reply_count=max(0, len(posts) - 1),
         latest_post=post_view(repo, viewer.community.id, latest_post) if latest_post else None,

--- a/src/elbysodic/web/app.py
+++ b/src/elbysodic/web/app.py
@@ -59,9 +59,11 @@ def create_app(
     )
     app = App(config=config)
     register_error_handlers(app, include_internal=not debug)
-    configured_services = (
-        services or create_services(db_path, seed_demo=seed_demo)
-    ).with_request_auth(production=security.production)
+    owns_services = services is None
+    base_services = services or create_services(db_path, seed_demo=seed_demo)
+    configured_services = base_services.with_request_auth(production=security.production)
+    if owns_services:
+        app.on_shutdown(configured_services.close)
 
     configure_services(
         configured_services,

--- a/src/elbysodic/web/app.py
+++ b/src/elbysodic/web/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 
 from chirp.app import App
 from chirp.config import AppConfig
@@ -31,7 +32,12 @@ from elbysodic.web.security import (
     resolve_web_security_config,
 )
 from elbysodic.web.shell import sidebar_is_hidden
-from elbysodic.web.state import configure_services, dev_tools_enabled, get_services
+from elbysodic.web.state import (
+    close_request_services,
+    configure_services,
+    dev_tools_enabled,
+    get_services,
+)
 from elbysodic.web.tenant import TenantPrefixMiddleware
 from elbysodic.web.timing import RequestTimingMiddleware
 
@@ -102,6 +108,7 @@ def create_app(
         app.template_global("csrf_field")(_empty_csrf_field)
         app.template_global("csrf_token")(_empty_csrf_token)
     app.add_middleware(RequestTimingMiddleware())
+    app.add_middleware(RequestServicesCleanupMiddleware())
     app.add_middleware(TenantPrefixMiddleware())
     if security.production:
         app.add_middleware(
@@ -158,3 +165,13 @@ def _empty_csrf_field() -> str:
 
 def _empty_csrf_token() -> str:
     return ""
+
+
+class RequestServicesCleanupMiddleware:
+    """Close request-scoped service repositories after each response."""
+
+    async def __call__(self, request: object, call_next: Any) -> object:
+        try:
+            return await call_next(request)
+        finally:
+            close_request_services(request)

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -116,6 +116,9 @@
     {% end %}
     <script defer src="/elbysodic-static/elbysodic-shell.js?v=sidebar-cookie-2"></script>
     <script defer src="/elbysodic-static/elbysodic-composer.js?v=sidebar-cookie-1"></script>
+    {% if dev_tools_enabled() %}
+    <script defer src="/elbysodic-static/elbysodic-htmx-timing.js?v=1"></script>
+    {% end %}
 {% end %}
 
 {% block title_oob %}

--- a/src/elbysodic/web/pages/page.py
+++ b/src/elbysodic/web/pages/page.py
@@ -53,10 +53,10 @@ def get(request: Request) -> Page:
         )
 
     try:
-        services = get_services().for_request(request)
+        services = get_services(request)
         viewer = services.viewer()
     except LookupError, PermissionError:
-        services = get_services()
+        services = get_services(request)
         try:
             program = services.public_studio_program(tenant_slug)
             hub = services.public_world_hub(tenant_slug)

--- a/src/elbysodic/web/pages/page.py
+++ b/src/elbysodic/web/pages/page.py
@@ -56,7 +56,7 @@ def get(request: Request) -> Page:
         services = get_services(request)
         viewer = services.viewer()
     except LookupError, PermissionError:
-        services = get_services(request)
+        services = get_services()
         try:
             program = services.public_studio_program(tenant_slug)
             hub = services.public_world_hub(tenant_slug)

--- a/src/elbysodic/web/pages/wanted/page.py
+++ b/src/elbysodic/web/pages/wanted/page.py
@@ -13,14 +13,14 @@ from elbysodic.web.tenant import request_tenant_slug
 def get(request: Request) -> Page:
     tenant_slug = request_tenant_slug(request)
     try:
-        services = get_services().for_request(request)
+        services = get_services(request)
         viewer = services.viewer()
         board = services.wanted_ads()
         community = viewer.community
     except LookupError, PermissionError:
         if tenant_slug is None:
             raise
-        services = get_services()
+        services = get_services(request)
         viewer = None
         try:
             board = services.public_wanted_ads(tenant_slug)

--- a/src/elbysodic/web/pages/wanted/page.py
+++ b/src/elbysodic/web/pages/wanted/page.py
@@ -20,7 +20,7 @@ def get(request: Request) -> Page:
     except LookupError, PermissionError:
         if tenant_slug is None:
             raise
-        services = get_services(request)
+        services = get_services()
         viewer = None
         try:
             board = services.public_wanted_ads(tenant_slug)

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
@@ -120,7 +120,7 @@ def _render_wanted(request: Request, wanted_slug: str) -> Page:
     except LookupError, PermissionError:
         if tenant_slug is None:
             raise
-        services = get_services(request)
+        services = get_services()
         try:
             wanted = services.public_read_wanted_ad(tenant_slug, wanted_slug)
             community = services.public_studio_program(tenant_slug).community

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
@@ -115,12 +115,12 @@ async def post(request: Request, wanted_slug: str) -> Page | Redirect:
 def _render_wanted(request: Request, wanted_slug: str) -> Page:
     tenant_slug = request_tenant_slug(request)
     try:
-        services = get_services().for_request(request)
+        services = get_services(request)
         viewer = services.viewer()
     except LookupError, PermissionError:
         if tenant_slug is None:
             raise
-        services = get_services()
+        services = get_services(request)
         try:
             wanted = services.public_read_wanted_ad(tenant_slug, wanted_slug)
             community = services.public_studio_program(tenant_slug).community

--- a/src/elbysodic/web/pages/world/page.py
+++ b/src/elbysodic/web/pages/world/page.py
@@ -20,7 +20,7 @@ def get(request: Request) -> Page:
     except LookupError, PermissionError:
         if tenant_slug is None:
             raise
-        services = get_services(request)
+        services = get_services()
         viewer = None
         try:
             hub = services.public_world_hub(tenant_slug)

--- a/src/elbysodic/web/pages/world/page.py
+++ b/src/elbysodic/web/pages/world/page.py
@@ -13,14 +13,14 @@ from elbysodic.web.tenant import request_tenant_slug
 def get(request: Request) -> Page:
     tenant_slug = request_tenant_slug(request)
     try:
-        services = get_services().for_request(request)
+        services = get_services(request)
         viewer = services.viewer()
         hub = services.world_hub()
         community = viewer.community
     except LookupError, PermissionError:
         if tenant_slug is None:
             raise
-        services = get_services()
+        services = get_services(request)
         viewer = None
         try:
             hub = services.public_world_hub(tenant_slug)

--- a/src/elbysodic/web/pages/world/{material_slug}/page.py
+++ b/src/elbysodic/web/pages/world/{material_slug}/page.py
@@ -82,7 +82,7 @@ def _render_material(
     except LookupError, PermissionError:
         if tenant_slug is None:
             raise
-        services = get_services(request)
+        services = get_services()
         try:
             material = services.public_read_material(tenant_slug, material_slug)
             guidebook = services.public_world_hub(tenant_slug)

--- a/src/elbysodic/web/pages/world/{material_slug}/page.py
+++ b/src/elbysodic/web/pages/world/{material_slug}/page.py
@@ -77,12 +77,12 @@ def _render_material(
 ) -> Page:
     tenant_slug = request_tenant_slug(request)
     try:
-        services = get_services().for_request(request)
+        services = get_services(request)
         viewer = services.viewer()
     except LookupError, PermissionError:
         if tenant_slug is None:
             raise
-        services = get_services()
+        services = get_services(request)
         try:
             material = services.public_read_material(tenant_slug, material_slug)
             guidebook = services.public_world_hub(tenant_slug)

--- a/src/elbysodic/web/state.py
+++ b/src/elbysodic/web/state.py
@@ -8,6 +8,7 @@ from elbysodic.web.security import WebSecurityConfig
 _services: AppServices | None = None
 _dev_tools_enabled = False
 _web_security_config: WebSecurityConfig | None = None
+_REQUEST_SERVICES_CACHE_KEY = "elbysodic.request_services"
 
 
 def configure_services(
@@ -28,8 +29,25 @@ def get_services(request: object | None = None) -> AppServices:
     if _services is None:
         raise RuntimeError("Elbysodic services have not been configured")
     if request is not None:
+        cache = getattr(request, "_cache", None)
+        if isinstance(cache, dict):
+            services = cache.get(_REQUEST_SERVICES_CACHE_KEY)
+            if isinstance(services, AppServices):
+                return services
+            services = _services.for_request(request)
+            cache[_REQUEST_SERVICES_CACHE_KEY] = services
+            return services
         return _services.for_request(request)
     return _services
+
+
+def close_request_services(request: object) -> None:
+    cache = getattr(request, "_cache", None)
+    if not isinstance(cache, dict):
+        return
+    services = cache.pop(_REQUEST_SERVICES_CACHE_KEY, None)
+    if isinstance(services, AppServices):
+        services.close()
 
 
 def dev_tools_enabled() -> bool:

--- a/src/elbysodic/web/static/elbysodic-htmx-timing.js
+++ b/src/elbysodic/web/static/elbysodic-htmx-timing.js
@@ -1,0 +1,33 @@
+(function () {
+  var timings = (window.__elbysodicHtmxTimings = window.__elbysodicHtmxTimings || []);
+
+  function pathFor(event) {
+    var detail = event.detail || {};
+    var requestConfig = detail.requestConfig || {};
+    return requestConfig.path || requestConfig.url || window.location.pathname;
+  }
+
+  document.body.addEventListener("htmx:beforeRequest", function (event) {
+    event.detail.__elbysodicStartedAt = performance.now();
+  });
+
+  document.body.addEventListener("htmx:afterRequest", function (event) {
+    var detail = event.detail || {};
+    var startedAt = detail.__elbysodicStartedAt;
+    if (typeof startedAt !== "number") {
+      return;
+    }
+    var duration = Math.round((performance.now() - startedAt) * 10) / 10;
+    var entry = {
+      path: pathFor(event),
+      durationMs: duration,
+      status: detail.xhr ? detail.xhr.status : 0,
+      boosted: Boolean(detail.boosted),
+      timestamp: new Date().toISOString()
+    };
+    timings.push(entry);
+    if (window.console && window.console.debug) {
+      window.console.debug("[elbysodic] htmx", entry);
+    }
+  });
+})();

--- a/tests/_sql_probe.py
+++ b/tests/_sql_probe.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+_LITERAL_RE = re.compile(r"'[^']*'|\b\d+\b")
+_WRITE_PREFIXES = ("INSERT", "UPDATE", "DELETE", "REPLACE", "BEGIN", "COMMIT", "ROLLBACK")
+
+
+def normalize_sql(sql: str) -> str:
+    compact = " ".join(sql.strip().split())
+    return _LITERAL_RE.sub("?", compact)
+
+
+def sql_kind(sql: str) -> str:
+    compact = " ".join(sql.strip().split())
+    if not compact:
+        return ""
+    return compact.split(" ", 1)[0].upper()
+
+
+def is_write_sql(sql: str) -> bool:
+    return sql_kind(sql) in _WRITE_PREFIXES
+
+
+class SqlTrace:
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    def __call__(self, statement: str) -> None:
+        self.statements.append(statement)
+
+    @property
+    def count(self) -> int:
+        return len(self.statements)
+
+    @property
+    def writes(self) -> list[str]:
+        return [statement for statement in self.statements if is_write_sql(statement)]
+
+    def normalized_counts(self) -> Counter[str]:
+        return Counter(normalize_sql(statement) for statement in self.statements)
+
+
+@contextmanager
+def trace_sql(connection: sqlite3.Connection) -> Iterator[SqlTrace]:
+    trace = SqlTrace()
+    connection.set_trace_callback(trace)
+    try:
+        yield trace
+    finally:
+        connection.set_trace_callback(None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import asyncio
+import sqlite3
 from pathlib import Path
 
 import pytest
+from chirp.testing import TestClient
 
 from elbysodic import cli
 from elbysodic.db import ForumRepository, connect, create_schema
 from elbysodic.services import AppServices, initialize_database
+from elbysodic.web import app as web_app
 
 RAILWAY_HOST = ".".join(("0", "0", "0", "0"))
 
@@ -20,15 +24,28 @@ class _FakeApp:
         self._calls["port"] = port
 
 
+class _FakeServices:
+    def __init__(self, calls: dict[str, object]) -> None:
+        self._calls = calls
+
+    def close(self) -> None:
+        self._calls["services_closed"] = True
+
+
 def test_cli_can_start_production_server_on_railway_host_and_port(monkeypatch) -> None:
     calls: dict[str, object] = {}
 
-    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
-        calls["debug"] = debug
-        calls["db_path"] = db_path
+    def fake_create_services(path: Path, *, seed_demo: bool) -> _FakeServices:
+        calls["db_path"] = path
         calls["seed_demo"] = seed_demo
+        return _FakeServices(calls)
+
+    def fake_create_app(*, debug: bool, services: _FakeServices) -> _FakeApp:
+        calls["debug"] = debug
+        calls["services"] = services
         return _FakeApp(calls)
 
+    monkeypatch.setattr(cli, "create_services", fake_create_services)
     monkeypatch.setattr(cli, "create_app", fake_create_app)
 
     cli.main(["--host", RAILWAY_HOST, "--port", "1234", "--no-debug"])
@@ -37,17 +54,23 @@ def test_cli_can_start_production_server_on_railway_host_and_port(monkeypatch) -
     assert calls["seed_demo"] is False
     assert calls["host"] == RAILWAY_HOST
     assert calls["port"] == 1234
+    assert calls["services_closed"] is True
 
 
 def test_cli_serve_subcommand_accepts_same_server_options(monkeypatch) -> None:
     calls: dict[str, object] = {}
 
-    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
-        calls["debug"] = debug
-        calls["db_path"] = db_path
+    def fake_create_services(path: Path, *, seed_demo: bool) -> _FakeServices:
+        calls["db_path"] = path
         calls["seed_demo"] = seed_demo
+        return _FakeServices(calls)
+
+    def fake_create_app(*, debug: bool, services: _FakeServices) -> _FakeApp:
+        calls["debug"] = debug
+        calls["services"] = services
         return _FakeApp(calls)
 
+    monkeypatch.setattr(cli, "create_services", fake_create_services)
     monkeypatch.setattr(cli, "create_app", fake_create_app)
 
     cli.main(["serve", "--host", RAILWAY_HOST, "--port", "5678", "--no-debug"])
@@ -61,12 +84,17 @@ def test_cli_serve_subcommand_accepts_same_server_options(monkeypatch) -> None:
 def test_cli_serve_can_explicitly_seed_demo_data(monkeypatch) -> None:
     calls: dict[str, object] = {}
 
-    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
-        calls["debug"] = debug
-        calls["db_path"] = db_path
+    def fake_create_services(path: Path, *, seed_demo: bool) -> _FakeServices:
+        calls["db_path"] = path
         calls["seed_demo"] = seed_demo
+        return _FakeServices(calls)
+
+    def fake_create_app(*, debug: bool, services: _FakeServices) -> _FakeApp:
+        calls["debug"] = debug
+        calls["services"] = services
         return _FakeApp(calls)
 
+    monkeypatch.setattr(cli, "create_services", fake_create_services)
     monkeypatch.setattr(cli, "create_app", fake_create_app)
 
     cli.main(["serve", "--seed-demo"])
@@ -83,13 +111,18 @@ def test_cli_dev_preview_seeds_demo_and_runs_standard_preview_port(monkeypatch, 
         calls["initialize_seed_demo"] = seed_demo
         return path
 
-    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
-        calls["debug"] = debug
-        calls["db_path"] = db_path
+    def fake_create_services(path: Path, *, seed_demo: bool) -> _FakeServices:
+        calls["db_path"] = path
         calls["create_seed_demo"] = seed_demo
+        return _FakeServices(calls)
+
+    def fake_create_app(*, debug: bool, services: _FakeServices) -> _FakeApp:
+        calls["debug"] = debug
+        calls["services"] = services
         return _FakeApp(calls)
 
     monkeypatch.setattr(cli, "initialize_database", fake_initialize_database)
+    monkeypatch.setattr(cli, "create_services", fake_create_services)
     monkeypatch.setattr(cli, "create_app", fake_create_app)
 
     cli.main(["dev", "preview", "--db-path", str(db_path)])
@@ -112,13 +145,18 @@ def test_cli_dev_preview_accepts_server_options(monkeypatch, tmp_path) -> None:
         calls["initialize_seed_demo"] = seed_demo
         return path
 
-    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
-        calls["debug"] = debug
-        calls["db_path"] = db_path
+    def fake_create_services(path: Path, *, seed_demo: bool) -> _FakeServices:
+        calls["db_path"] = path
         calls["create_seed_demo"] = seed_demo
+        return _FakeServices(calls)
+
+    def fake_create_app(*, debug: bool, services: _FakeServices) -> _FakeApp:
+        calls["debug"] = debug
+        calls["services"] = services
         return _FakeApp(calls)
 
     monkeypatch.setattr(cli, "initialize_database", fake_initialize_database)
+    monkeypatch.setattr(cli, "create_services", fake_create_services)
     monkeypatch.setattr(cli, "create_app", fake_create_app)
 
     cli.main(
@@ -145,12 +183,85 @@ def test_cli_dev_preview_accepts_server_options(monkeypatch, tmp_path) -> None:
     assert calls["port"] == 9001
 
 
+def test_cli_closes_services_when_server_run_raises(monkeypatch, tmp_path) -> None:
+    calls: dict[str, object] = {}
+
+    class FailingApp(_FakeApp):
+        def run(self, *, host: str | None = None, port: int | None = None) -> None:
+            super().run(host=host, port=port)
+            raise RuntimeError("server failed")
+
+    def fake_create_services(path: Path, *, seed_demo: bool) -> _FakeServices:
+        calls["db_path"] = path
+        calls["seed_demo"] = seed_demo
+        return _FakeServices(calls)
+
+    def fake_create_app(*, debug: bool, services: _FakeServices) -> FailingApp:
+        calls["debug"] = debug
+        calls["services"] = services
+        return FailingApp(calls)
+
+    monkeypatch.setattr(cli, "create_services", fake_create_services)
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+
+    with pytest.raises(RuntimeError, match="server failed"):
+        cli.main(["serve", "--db-path", str(tmp_path / "forum.sqlite3")])
+
+    assert calls["services_closed"] is True
+
+
 def test_dev_cli_exposes_preview_to_milo_discovery() -> None:
     result = cli.build_dev_cli().invoke(["--llms-txt"])
 
     assert result.exit_code == 0
     assert "preview" in result.output
     assert "local preview" in result.output
+
+
+def test_app_services_close_releases_filesystem_database(tmp_path) -> None:
+    db_path = tmp_path / "forum.sqlite3"
+    initialize_database(db_path)
+    connection = connect(db_path)
+    services = AppServices(ForumRepository(connection), None)
+
+    services.close()
+    services.close()
+
+    with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+        connection.execute("SELECT 1")
+
+    reopened = connect(db_path)
+    try:
+        reopened.execute("BEGIN IMMEDIATE")
+        reopened.rollback()
+    finally:
+        reopened.close()
+
+
+def test_create_app_closes_internally_created_services_on_shutdown(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    class FakeAppServices(_FakeServices):
+        def with_request_auth(self, *, production: bool) -> FakeAppServices:
+            calls["production"] = production
+            return self
+
+    def fake_create_services(path: Path, *, seed_demo: bool) -> FakeAppServices:
+        calls["db_path"] = path
+        calls["seed_demo"] = seed_demo
+        return FakeAppServices(calls)
+
+    async def run_lifespan() -> None:
+        app = web_app.create_app(debug=True, db_path=Path(":memory:"), seed_demo=False)
+        async with TestClient(app):
+            pass
+
+    monkeypatch.setattr(web_app, "create_services", fake_create_services)
+
+    asyncio.run(run_lifespan())
+
+    assert calls["seed_demo"] is False
+    assert calls["services_closed"] is True
 
 
 def test_cli_init_db_creates_schema_without_demo_seed_by_default(monkeypatch, tmp_path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -300,7 +300,7 @@ def test_app_services_close_releases_filesystem_database(tmp_path) -> None:
     db_path = tmp_path / "forum.sqlite3"
     initialize_database(db_path)
     connection = connect(db_path)
-    services = AppServices(ForumRepository(connection), None)
+    services = AppServices(ForumRepository(connection), None, owns_repo=True)
 
     services.close()
     services.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,9 +293,54 @@ def test_dev_cli_exposes_preview_to_milo_discovery() -> None:
 
     assert result.exit_code == 0
     assert "preview" in result.output
+    assert "check" in result.output
     assert "local preview" in result.output
     assert "checkpoint" in result.output
     assert "backup" in result.output
+
+
+def test_dev_check_runs_standard_gate(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    cli.main(["dev", "check"])
+
+    assert calls == cli.developer_check_commands(quick=False)
+
+
+def test_dev_check_quick_runs_focused_pytest(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    cli.main(["dev", "check", "--quick"])
+
+    assert ["uv", "run", "pytest", "tests/test_cli.py", "-q", "--tb=short"] in calls
+
+
+def test_dev_check_exits_on_first_failure(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 2)
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.run_developer_checks()
+
+    assert exc_info.value.code == 2
+    assert calls == [cli.developer_check_commands(quick=False)[0]]
 
 
 def test_dev_db_checkpoint_requires_existing_filesystem_database(tmp_path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,85 @@ def test_cli_serve_can_explicitly_seed_demo_data(monkeypatch) -> None:
     assert calls["seed_demo"] is True
 
 
+def test_cli_dev_preview_seeds_demo_and_runs_standard_preview_port(monkeypatch, tmp_path) -> None:
+    calls: dict[str, object] = {}
+    db_path = tmp_path / "preview.sqlite3"
+
+    def fake_initialize_database(path: Path, *, seed_demo: bool) -> Path:
+        calls["initialize_path"] = path
+        calls["initialize_seed_demo"] = seed_demo
+        return path
+
+    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
+        calls["debug"] = debug
+        calls["db_path"] = db_path
+        calls["create_seed_demo"] = seed_demo
+        return _FakeApp(calls)
+
+    monkeypatch.setattr(cli, "initialize_database", fake_initialize_database)
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+
+    cli.main(["dev", "preview", "--db-path", str(db_path)])
+
+    assert calls["initialize_path"] == db_path
+    assert calls["initialize_seed_demo"] is True
+    assert calls["debug"] is True
+    assert calls["db_path"] == db_path
+    assert calls["create_seed_demo"] is False
+    assert calls["host"] == "127.0.0.1"
+    assert calls["port"] == 8001
+
+
+def test_cli_dev_preview_accepts_server_options(monkeypatch, tmp_path) -> None:
+    calls: dict[str, object] = {}
+    db_path = tmp_path / "preview.sqlite3"
+
+    def fake_initialize_database(path: Path, *, seed_demo: bool) -> Path:
+        calls["initialize_path"] = path
+        calls["initialize_seed_demo"] = seed_demo
+        return path
+
+    def fake_create_app(*, debug: bool, db_path: Path, seed_demo: bool) -> _FakeApp:
+        calls["debug"] = debug
+        calls["db_path"] = db_path
+        calls["create_seed_demo"] = seed_demo
+        return _FakeApp(calls)
+
+    monkeypatch.setattr(cli, "initialize_database", fake_initialize_database)
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+
+    cli.main(
+        [
+            "dev",
+            "preview",
+            "--db-path",
+            str(db_path),
+            "--host",
+            RAILWAY_HOST,
+            "--port",
+            "9001",
+            "--no-debug",
+            "--no-seed-demo",
+        ]
+    )
+
+    assert calls["initialize_path"] == db_path
+    assert calls["initialize_seed_demo"] is False
+    assert calls["debug"] is False
+    assert calls["db_path"] == db_path
+    assert calls["create_seed_demo"] is False
+    assert calls["host"] == RAILWAY_HOST
+    assert calls["port"] == 9001
+
+
+def test_dev_cli_exposes_preview_to_milo_discovery() -> None:
+    result = cli.build_dev_cli().invoke(["--llms-txt"])
+
+    assert result.exit_code == 0
+    assert "preview" in result.output
+    assert "local preview" in result.output
+
+
 def test_cli_init_db_creates_schema_without_demo_seed_by_default(monkeypatch, tmp_path) -> None:
     calls: dict[str, object] = {}
     db_path = tmp_path / "forum.sqlite3"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import signal
+import socket
 import sqlite3
+import subprocess
+import sys
+import time
 from pathlib import Path
+from typing import IO
+from urllib.error import URLError
+from urllib.request import urlopen
 
 import pytest
 from chirp.testing import TestClient
@@ -13,6 +22,7 @@ from elbysodic.services import AppServices, initialize_database
 from elbysodic.web import app as web_app
 
 RAILWAY_HOST = ".".join(("0", "0", "0", "0"))
+LOCAL_HOST = "127.0.0.1"
 
 
 class _FakeApp:
@@ -30,6 +40,74 @@ class _FakeServices:
 
     def close(self) -> None:
         self._calls["services_closed"] = True
+
+
+def _unused_port() -> int:
+    with socket.socket() as sock:
+        sock.bind((LOCAL_HOST, 0))
+        return int(sock.getsockname()[1])
+
+
+def _start_cli_subprocess(args: list[str]) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    return subprocess.Popen(  # noqa: S603 - argv is built by these tests, not user input.
+        [sys.executable, "-c", "from elbysodic.cli import main; main()", *args],
+        cwd=Path(__file__).parents[1],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _read_process_output(stream: IO[str] | None) -> str:
+    return "" if stream is None else stream.read()
+
+
+def _wait_for_health(port: int, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 20
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            output = _read_process_output(process.stdout)
+            raise AssertionError(f"server exited before health check: {output}")
+        try:
+            with urlopen(f"http://{LOCAL_HOST}:{port}/health", timeout=0.5) as response:
+                if response.status == 200:
+                    return
+        except (OSError, URLError) as exc:
+            last_error = exc
+        time.sleep(0.1)
+    raise AssertionError(f"server did not become healthy: {last_error}")
+
+
+def _stop_process_cleanly(process: subprocess.Popen[str], stop_signal: signal.Signals) -> str:
+    process.send_signal(stop_signal)
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        output = _read_process_output(process.stdout)
+        raise AssertionError(f"server did not exit after {stop_signal.name}: {output}") from None
+    output = _read_process_output(process.stdout)
+    assert process.returncode == 0, output
+    return output
+
+
+def _assert_port_reusable(port: int) -> None:
+    with socket.socket() as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((LOCAL_HOST, port))
+
+
+def _assert_database_writable(db_path: Path) -> None:
+    connection = connect(db_path)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        connection.rollback()
+    finally:
+        connection.close()
 
 
 def test_cli_can_start_production_server_on_railway_host_and_port(monkeypatch) -> None:
@@ -262,6 +340,90 @@ def test_create_app_closes_internally_created_services_on_shutdown(monkeypatch) 
 
     assert calls["seed_demo"] is False
     assert calls["services_closed"] is True
+
+
+@pytest.mark.parametrize("stop_signal", [signal.SIGTERM, signal.SIGINT])
+def test_cli_serve_exits_cleanly_on_stop_signal(tmp_path, stop_signal: signal.Signals) -> None:
+    port = _unused_port()
+    db_path = tmp_path / "serve.sqlite3"
+    process = _start_cli_subprocess(
+        [
+            "serve",
+            "--host",
+            LOCAL_HOST,
+            "--port",
+            str(port),
+            "--db-path",
+            str(db_path),
+            "--no-debug",
+        ]
+    )
+    try:
+        _wait_for_health(port, process)
+        _stop_process_cleanly(process, stop_signal)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=10)
+
+    _assert_port_reusable(port)
+    _assert_database_writable(db_path)
+
+
+def test_dev_preview_exits_cleanly_on_sigterm(tmp_path) -> None:
+    port = _unused_port()
+    db_path = tmp_path / "preview.sqlite3"
+    process = _start_cli_subprocess(
+        [
+            "dev",
+            "preview",
+            "--host",
+            LOCAL_HOST,
+            "--port",
+            str(port),
+            "--db-path",
+            str(db_path),
+        ]
+    )
+    try:
+        _wait_for_health(port, process)
+        output = _stop_process_cleanly(process, signal.SIGTERM)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=10)
+
+    assert "preview database ready" in output
+    _assert_port_reusable(port)
+    _assert_database_writable(db_path)
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGHUP"), reason="SIGHUP is POSIX-only")
+def test_dev_preview_debug_exits_cleanly_on_sighup(tmp_path) -> None:
+    port = _unused_port()
+    db_path = tmp_path / "preview.sqlite3"
+    process = _start_cli_subprocess(
+        [
+            "dev",
+            "preview",
+            "--host",
+            LOCAL_HOST,
+            "--port",
+            str(port),
+            "--db-path",
+            str(db_path),
+        ]
+    )
+    try:
+        _wait_for_health(port, process)
+        _stop_process_cleanly(process, signal.SIGHUP)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=10)
+
+    _assert_port_reusable(port)
+    _assert_database_writable(db_path)
 
 
 def test_cli_init_db_creates_schema_without_demo_seed_by_default(monkeypatch, tmp_path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -601,6 +601,50 @@ def test_initialize_database_leaves_demo_seed_explicit(tmp_path) -> None:
     assert seeded_community_count > 0
 
 
+def test_initialize_database_repairs_partial_demo_seed(tmp_path) -> None:
+    db_path = tmp_path / "forum.sqlite3"
+    connection = connect(db_path)
+    try:
+        create_schema(connection)
+        repo = ForumRepository(connection)
+        repo.seed_default_community("Interrupted Seed")
+    finally:
+        connection.close()
+
+    initialize_database(db_path, seed_demo=True)
+    seeded = connect(db_path)
+    try:
+        counts = {
+            "communities": seeded.execute("SELECT COUNT(*) FROM communities").fetchone()[0],
+            "boards": seeded.execute("SELECT COUNT(*) FROM boards").fetchone()[0],
+            "threads": seeded.execute("SELECT COUNT(*) FROM threads").fetchone()[0],
+            "posts": seeded.execute("SELECT COUNT(*) FROM posts").fetchone()[0],
+            "characters": seeded.execute("SELECT COUNT(*) FROM characters").fetchone()[0],
+        }
+    finally:
+        seeded.close()
+
+    initialize_database(db_path, seed_demo=True)
+    rerun = connect(db_path)
+    try:
+        rerun_counts = {
+            "communities": rerun.execute("SELECT COUNT(*) FROM communities").fetchone()[0],
+            "boards": rerun.execute("SELECT COUNT(*) FROM boards").fetchone()[0],
+            "threads": rerun.execute("SELECT COUNT(*) FROM threads").fetchone()[0],
+            "posts": rerun.execute("SELECT COUNT(*) FROM posts").fetchone()[0],
+            "characters": rerun.execute("SELECT COUNT(*) FROM characters").fetchone()[0],
+        }
+    finally:
+        rerun.close()
+
+    assert counts["communities"] > 1
+    assert counts["boards"] > 0
+    assert counts["threads"] > 0
+    assert counts["posts"] > 0
+    assert counts["characters"] > 0
+    assert rerun_counts == counts
+
+
 def test_cli_bootstrap_first_realm_creates_empty_configured_realm(tmp_path, capsys) -> None:
     db_path = tmp_path / "forum.sqlite3"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,6 +294,80 @@ def test_dev_cli_exposes_preview_to_milo_discovery() -> None:
     assert result.exit_code == 0
     assert "preview" in result.output
     assert "local preview" in result.output
+    assert "checkpoint" in result.output
+    assert "backup" in result.output
+
+
+def test_dev_db_checkpoint_requires_existing_filesystem_database(tmp_path, capsys) -> None:
+    db_path = tmp_path / "forum.sqlite3"
+    initialize_database(db_path)
+
+    cli.main(["dev", "db", "checkpoint", "--db-path", str(db_path)])
+
+    output = capsys.readouterr().out
+    assert f"checkpointed {db_path}" in output
+    assert "busy=0" in output
+
+
+def test_dev_db_backup_creates_integrity_checked_copy(tmp_path, capsys) -> None:
+    db_path = tmp_path / "forum.sqlite3"
+    backup_path = tmp_path / "backups" / "forum-backup.sqlite3"
+    initialize_database(db_path)
+    connection = connect(db_path)
+    try:
+        connection.execute(
+            "INSERT INTO users (email, password_hash, created_at) VALUES (?, ?, ?)",
+            ("backup@example.com", "hash", "2026-05-13T00:00:00Z"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    cli.main(
+        [
+            "dev",
+            "db",
+            "backup",
+            "--db-path",
+            str(db_path),
+            "--output",
+            str(backup_path),
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert f"backed up {db_path} to {backup_path}" in output
+    copied = connect(backup_path)
+    try:
+        integrity = copied.execute("PRAGMA integrity_check").fetchone()[0]
+        email = copied.execute("SELECT email FROM users").fetchone()[0]
+    finally:
+        copied.close()
+    assert integrity == "ok"
+    assert email == "backup@example.com"
+
+
+def test_dev_db_backup_refuses_to_overwrite_without_flag(tmp_path) -> None:
+    db_path = tmp_path / "forum.sqlite3"
+    backup_path = tmp_path / "forum-backup.sqlite3"
+    initialize_database(db_path)
+    backup_path.write_text("already here")
+
+    with pytest.raises(FileExistsError):
+        cli.backup_database(db_path, backup_path)
+
+    cli.main(
+        [
+            "dev",
+            "db",
+            "backup",
+            "--db-path",
+            str(db_path),
+            "--output",
+            str(backup_path),
+            "--overwrite",
+        ]
+    )
 
 
 def test_app_services_close_releases_filesystem_database(tmp_path) -> None:

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -346,6 +346,23 @@ def test_rendered_route_query_budgets_are_tracked() -> None:
     asyncio.run(run())
 
 
+def test_board_thread_batch_render_preserves_scene_cards() -> None:
+    async def run() -> None:
+        app = _app()
+
+        async with TestClient(app) as client:
+            response = await client.get("/c/x-men-apocalypse/boards/danger-room")
+
+        assert response.status == 200
+        assert "X-Men Apocalypse" in response.text
+        assert "Danger Room" in response.text
+        assert "Cast" in response.text
+        assert "writer" in response.text
+        assert "town-hall" not in response.text
+
+    asyncio.run(run())
+
+
 def test_request_identity_resolves_membership_inside_selected_community() -> None:
     services = create_services(path=":memory:")
     community, user_id, membership_id, character_id = _add_hosted_membership(

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -22,6 +22,7 @@ from elbysodic.services.access import TENANT_SLUG_CACHE_KEY
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import scope_response_urls
+from tests._sql_probe import trace_sql
 
 _FORM = {"Content-Type": "application/x-www-form-urlencoded"}
 
@@ -294,6 +295,27 @@ def test_concurrent_rendered_get_navigation_stays_stable(tmp_path: Path) -> None
         for path, status, expected_text in responses:
             assert status == 200, path
             assert expected_text, path
+
+    asyncio.run(run())
+
+
+def test_rendered_get_navigation_does_not_write_to_database() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        app = create_app(debug=False, services=services)
+        routes = (
+            "/network",
+            "/c/rl-nyc/my/threads",
+            "/c/rl-small-town/boards/town-hall?filter=mine",
+            "/c/x-men-apocalypse/boards/danger-room",
+        )
+
+        async with TestClient(app) as client:
+            for path in routes:
+                with trace_sql(services.repo.connection) as trace:
+                    response = await client.get(path)
+                assert response.status == 200, path
+                assert trace.writes == [], path
 
     asyncio.run(run())
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -325,11 +325,11 @@ def test_rendered_route_query_budgets_are_tracked() -> None:
         services = create_services(path=":memory:")
         app = create_app(debug=False, services=services)
         budgets = {
-            "/network": 220,
-            "/c/rl-nyc/my/threads": 90,
-            "/c/rl-small-town/boards/town-hall?filter=mine": 130,
-            "/c/x-men-apocalypse/boards/danger-room": 270,
-            "/c/rl-nyc/claims": 90,
+            "/network": 180,
+            "/c/rl-nyc/my/threads": 80,
+            "/c/rl-small-town/boards/town-hall?filter=mine": 120,
+            "/c/x-men-apocalypse/boards/danger-room": 225,
+            "/c/rl-nyc/claims": 80,
         }
 
         async with TestClient(app) as client:

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -265,6 +265,39 @@ def test_health_check_does_not_require_registered_community_host() -> None:
     asyncio.run(run())
 
 
+def test_concurrent_rendered_get_navigation_stays_stable(tmp_path: Path) -> None:
+    async def run() -> None:
+        services = create_services(path=tmp_path / "rapid-navigation.sqlite3")
+        app = create_app(debug=False, services=services)
+        routes = [
+            ("/network", "Studio Network"),
+            ("/c/rl-nyc/my/threads", "RL NYC"),
+            ("/c/rl-small-town/boards/town-hall?filter=mine", "RL Small Town"),
+            ("/c/jurassic-park-universe/world", "Jurassic Park Universe"),
+            ("/c/x-men-apocalypse/boards/danger-room", "X-Men Apocalypse"),
+            ("/c/rl-nyc/claims", "RL NYC"),
+        ]
+
+        async with TestClient(app) as client:
+            for path, _expected in routes:
+                warm = await client.get(path)
+                assert warm.status == 200
+
+            async def fetch(path: str, expected: str) -> tuple[str, int, str]:
+                response = await client.get(path)
+                return path, response.status, response.text if expected in response.text else ""
+
+            responses = await asyncio.gather(
+                *(fetch(path, expected) for path, expected in routes * 2)
+            )
+
+        for path, status, expected_text in responses:
+            assert status == 200, path
+            assert expected_text, path
+
+    asyncio.run(run())
+
+
 def test_request_identity_resolves_membership_inside_selected_community() -> None:
     services = create_services(path=":memory:")
     community, user_id, membership_id, character_id = _add_hosted_membership(

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -468,6 +468,26 @@ def test_writer_queue_batch_render_preserves_lenses() -> None:
     asyncio.run(run())
 
 
+def test_scaled_my_threads_stays_within_batched_query_budget() -> None:
+    async def run() -> None:
+        services = _scale_board_services(thread_count=30)
+        app = create_app(debug=False, services=services)
+
+        async with TestClient(app) as client:
+            warm = await client.get("/c/x-men-apocalypse/my/threads")
+            assert warm.status == 200
+
+            with trace_sql(services.repo.connection) as trace:
+                response = await client.get("/c/x-men-apocalypse/my/threads")
+
+        assert response.status == 200
+        assert "Scale Realm" in response.text
+        assert "Scale Thread 0" in response.text
+        assert trace.count <= 370
+
+    asyncio.run(run())
+
+
 def test_public_network_catalog_hides_member_state(monkeypatch: pytest.MonkeyPatch) -> None:
     async def run() -> None:
         monkeypatch.setenv("ELBYSODIC_ENV", "production")

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -320,6 +320,32 @@ def test_rendered_get_navigation_does_not_write_to_database() -> None:
     asyncio.run(run())
 
 
+def test_rendered_route_query_budgets_are_tracked() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        app = create_app(debug=False, services=services)
+        budgets = {
+            "/network": 220,
+            "/c/rl-nyc/my/threads": 90,
+            "/c/rl-small-town/boards/town-hall?filter=mine": 130,
+            "/c/x-men-apocalypse/boards/danger-room": 270,
+            "/c/rl-nyc/claims": 90,
+        }
+
+        async with TestClient(app) as client:
+            for path, budget in budgets.items():
+                warm = await client.get(path)
+                assert warm.status == 200, path
+
+                with trace_sql(services.repo.connection) as trace:
+                    response = await client.get(path)
+
+                assert response.status == 200, path
+                assert trace.count <= budget, path
+
+    asyncio.run(run())
+
+
 def test_request_identity_resolves_membership_inside_selected_community() -> None:
     services = create_services(path=":memory:")
     community, user_id, membership_id, character_id = _add_hosted_membership(

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -382,6 +382,26 @@ def test_writer_queue_batch_render_preserves_lenses() -> None:
     asyncio.run(run())
 
 
+def test_public_network_catalog_hides_member_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run() -> None:
+        monkeypatch.setenv("ELBYSODIC_ENV", "production")
+        monkeypatch.setenv("ELBYSODIC_SECRET_KEY", "x" * 32)
+        monkeypatch.setenv("ELBYSODIC_ALLOWED_HOSTS", "*")
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+
+        async with TestClient(app) as client:
+            response = await client.get("/network")
+
+        assert response.status == 200
+        assert "Explore" in response.text
+        assert "playing as" not in response.text
+        assert "Dev personas" not in response.text
+        assert "Log out" not in response.text
+        assert "unread" not in response.text
+
+    asyncio.run(run())
+
+
 def test_request_identity_resolves_membership_inside_selected_community() -> None:
     services = create_services(path=":memory:")
     community, user_id, membership_id, character_id = _add_hosted_membership(

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -328,7 +328,7 @@ def test_rendered_route_query_budgets_are_tracked() -> None:
             "/network": 180,
             "/c/rl-nyc/my/threads": 80,
             "/c/rl-small-town/boards/town-hall?filter=mine": 120,
-            "/c/x-men-apocalypse/boards/danger-room": 225,
+            "/c/x-men-apocalypse/boards/danger-room": 215,
             "/c/rl-nyc/claims": 80,
         }
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -363,6 +363,25 @@ def test_board_thread_batch_render_preserves_scene_cards() -> None:
     asyncio.run(run())
 
 
+def test_writer_queue_batch_render_preserves_lenses() -> None:
+    async def run() -> None:
+        app = _app()
+
+        async with TestClient(app) as client:
+            active_face = await client.get("/c/rl-nyc/my/threads")
+            whole_roster = await client.get("/c/rl-nyc/my/threads?character=all")
+
+        assert active_face.status == 200
+        assert whole_roster.status == 200
+        assert "My threads" in active_face.text
+        assert "Queue lens: active face" in active_face.text
+        assert "Needs reply" in active_face.text or "Queue clear" in active_face.text
+        assert "Queue lens: whole roster" in whole_roster.text
+        assert "Waiting" in whole_roster.text or "Queue clear" in whole_roster.text
+
+    asyncio.run(run())
+
+
 def test_request_identity_resolves_membership_inside_selected_community() -> None:
     services = create_services(path=":memory:")
     community, user_id, membership_id, character_id = _add_hosted_membership(

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -325,7 +325,7 @@ def test_rendered_route_query_budgets_are_tracked() -> None:
         services = create_services(path=":memory:")
         app = create_app(debug=False, services=services)
         budgets = {
-            "/network": 180,
+            "/network": 165,
             "/c/rl-nyc/my/threads": 80,
             "/c/rl-small-town/boards/town-hall?filter=mine": 120,
             "/c/x-men-apocalypse/boards/danger-room": 215,

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -231,6 +231,18 @@ def _scale_board_services(*, thread_count: int = 30) -> AppServices:
     return AppServices(repo, DemoSeed(community, user, membership, viewer_character))
 
 
+def _scale_network_services(*, community_count: int = 12) -> AppServices:
+    services = create_services(path=":memory:")
+    for index in range(community_count):
+        _add_hosted_membership(
+            services,
+            slug=f"network-scale-{index}",
+            user_id=services.seed.user.id,
+            username=f"network-scale-{index}",
+        )
+    return services
+
+
 def _add_hosted_membership(
     services: AppServices,
     *,
@@ -507,6 +519,26 @@ def test_public_network_catalog_hides_member_state(monkeypatch: pytest.MonkeyPat
         assert "Dev personas" not in response.text
         assert "Log out" not in response.text
         assert "unread" not in response.text
+
+    asyncio.run(run())
+
+
+def test_scaled_signed_in_network_stays_within_batched_query_budget() -> None:
+    async def run() -> None:
+        services = _scale_network_services(community_count=12)
+        app = create_app(debug=False, services=services)
+
+        async with TestClient(app) as client:
+            warm = await client.get("/network")
+            assert warm.status == 200
+
+            with trace_sql(services.repo.connection) as trace:
+                response = await client.get("/network")
+
+        assert response.status == 200
+        assert "Studio Network" in response.text
+        assert "Hosted Program" in response.text
+        assert trace.count <= 370
 
     asyncio.run(run())
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -392,6 +392,9 @@ def test_rendered_route_query_budgets_are_tracked() -> None:
         app = create_app(debug=False, services=services)
         budgets = {
             "/network": 165,
+            "/c/x-men-apocalypse": 390,
+            "/c/x-men-apocalypse/locations": 200,
+            "/c/x-men-apocalypse/community": 350,
             "/c/rl-nyc/my/threads": 80,
             "/c/rl-small-town/boards/town-hall?filter=mine": 120,
             "/c/x-men-apocalypse/boards/danger-room": 215,

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -1119,6 +1119,32 @@ def test_dev_personas_are_gated_by_development_tools() -> None:
     asyncio.run(run())
 
 
+def test_htmx_timing_harness_is_gated_by_development_tools() -> None:
+    async def run() -> None:
+        disabled_app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=False,
+        )
+        async with TestClient(disabled_app) as client:
+            disabled = await client.get("/")
+
+        enabled_app = create_app(
+            debug=False,
+            services=create_services(path=":memory:"),
+            dev_tools=True,
+        )
+        async with TestClient(enabled_app) as client:
+            enabled = await client.get("/")
+
+        assert disabled.status == 200
+        assert enabled.status == 200
+        assert "elbysodic-htmx-timing.js" not in disabled.text
+        assert "elbysodic-htmx-timing.js" in enabled.text
+
+    asyncio.run(run())
+
+
 def test_seed_persona_matrix_names_multi_community_role_differences() -> None:
     services = create_services(path=":memory:")
     xmen_writer = resolve_seed_persona(services.repo, "xmen_writer")

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -165,6 +165,72 @@ def _faceless_services(services: AppServices, *, prefix: str = "faceless") -> Ap
     return AppServices(repo, DemoSeed(community, user, membership, None))
 
 
+def _scale_board_services(*, thread_count: int = 30) -> AppServices:
+    connection = connect(check_same_thread=False)
+    create_schema(connection)
+    repo = ForumRepository(connection)
+    community = repo.seed_default_community("Scale Realm")
+    role = repo.create_role(community.id, "member", "Member")
+    user = repo.create_user("scale-writer@example.com", "hash")
+    membership = repo.create_membership(community.id, user.id, role.id, "scale", "Scale")
+    viewer_character = repo.create_character(
+        community.id,
+        membership.id,
+        "scale-face",
+        "Scale Face",
+        make_default=True,
+    )
+    authors = [viewer_character]
+    for index in range(5):
+        author_user = repo.create_user(f"scale-author-{index}@example.com", "hash")
+        author_membership = repo.create_membership(
+            community.id,
+            author_user.id,
+            role.id,
+            f"scale-author-{index}",
+            f"Scale Author {index}",
+        )
+        authors.append(
+            repo.create_character(
+                community.id,
+                author_membership.id,
+                f"scale-author-{index}",
+                f"Scale Author {index}",
+            )
+        )
+    facet_group = repo.create_facet_group(community.id, "scale-lens", "Scale Lens")
+    facets = [
+        repo.create_facet(community.id, facet_group.id, f"scale-{index}", f"Scale {index}")
+        for index in range(3)
+    ]
+    board = repo.create_board(community.id, "scale-yard", "Scale Yard")
+    repo.assign_board_facet(community.id, board.id, facets[0].id)
+    for index in range(thread_count):
+        author = authors[index % len(authors)]
+        thread = repo.create_thread(
+            community.id,
+            board.id,
+            author.id,
+            f"scale-thread-{index}",
+            f"Scale Thread {index}",
+        )
+        repo.assign_thread_facet(community.id, thread.id, facets[index % len(facets)].id)
+        repo.create_post(
+            community.id,
+            thread.id,
+            author.id,
+            f"Opening post for scale thread {index}.",
+        )
+        repo.create_post(
+            community.id,
+            thread.id,
+            authors[(index + 1) % len(authors)].id,
+            f"Reply for scale thread {index} mentioning @Scale.",
+        )
+    membership = repo.get_membership(community.id, membership.id)
+    return AppServices(repo, DemoSeed(community, user, membership, viewer_character))
+
+
 def _add_hosted_membership(
     services: AppServices,
     *,
@@ -359,6 +425,26 @@ def test_board_thread_batch_render_preserves_scene_cards() -> None:
         assert "Cast" in response.text
         assert "writer" in response.text
         assert "town-hall" not in response.text
+
+    asyncio.run(run())
+
+
+def test_scaled_board_page_stays_within_batched_query_budget() -> None:
+    async def run() -> None:
+        services = _scale_board_services(thread_count=30)
+        app = create_app(debug=False, services=services)
+
+        async with TestClient(app) as client:
+            warm = await client.get("/c/x-men-apocalypse/boards/scale-yard")
+            assert warm.status == 200
+
+            with trace_sql(services.repo.connection) as trace:
+                response = await client.get("/c/x-men-apocalypse/boards/scale-yard")
+
+        assert response.status == 200
+        assert "Scale Yard" in response.text
+        assert "Scale Thread 29" in response.text
+        assert trace.count <= 350
 
     asyncio.run(run())
 

--- a/tests/test_posts_service.py
+++ b/tests/test_posts_service.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from elbysodic.domain.models import Character, Community, CommunityMembership, Facet, Post
+from elbysodic.services.posts import PostViewContextBuilder
+
+NOW = "2026-01-01T00:00:00+00:00"
+
+
+@dataclass(slots=True)
+class CountingPostRepo:
+    community: Community
+    characters: dict[int, Character]
+    memberships: dict[int, CommunityMembership]
+    list_community_characters_calls: int = 0
+    list_memberships_calls: int = 0
+    get_community_calls: int = 0
+    list_character_facets_calls: list[int] = field(default_factory=list)
+
+    def get_community(self, community_id: int) -> Community:
+        assert community_id == self.community.id
+        self.get_community_calls += 1
+        return self.community
+
+    def get_character(self, community_id: int, character_id: int) -> Character:
+        assert community_id == self.community.id
+        return self.characters[character_id]
+
+    def get_membership(self, community_id: int, membership_id: int) -> CommunityMembership:
+        assert community_id == self.community.id
+        return self.memberships[membership_id]
+
+    def list_character_facets(self, community_id: int, character_id: int) -> list[Facet]:
+        assert community_id == self.community.id
+        self.list_character_facets_calls.append(character_id)
+        return []
+
+    def list_community_characters(self, community_id: int) -> list[Character]:
+        assert community_id == self.community.id
+        self.list_community_characters_calls += 1
+        return list(self.characters.values())
+
+    def list_memberships(self, community_id: int) -> list[CommunityMembership]:
+        assert community_id == self.community.id
+        self.list_memberships_calls += 1
+        return list(self.memberships.values())
+
+
+def test_post_view_context_builder_caches_request_mention_links() -> None:
+    repo = CountingPostRepo(
+        community=_community(),
+        characters={
+            10: _character(10, membership_id=100, slug="alice-face", name="Alice"),
+            11: _character(11, membership_id=101, slug="bob-face", name="Bob"),
+        },
+        memberships={
+            100: _membership(100, username="alice"),
+            101: _membership(101, username="bob"),
+        },
+    )
+    builder = PostViewContextBuilder(repo, 1)
+
+    first = builder.context(
+        [
+            _post(1, author_character_id=10, author_membership_id=100),
+            _post(2, author_character_id=11, author_membership_id=101),
+        ]
+    )
+    second = builder.context([_post(3, author_character_id=10, author_membership_id=100)])
+
+    assert first.mention_links is second.mention_links
+    assert repo.list_community_characters_calls == 1
+    assert repo.list_memberships_calls == 1
+    assert repo.get_community_calls == 1
+
+
+def _community() -> Community:
+    return Community(
+        id=1,
+        name="Test Realm",
+        slug="test-realm",
+        host=None,
+        launch_status="open",
+        default_theme_id=None,
+        identity_accent_facet_group_id=None,
+        community_mark_url=None,
+        community_mark_alt="",
+        world_hero_image_url=None,
+        world_hero_image_alt="",
+        world_hero_treatment="natural",
+        world_hero_focal_point="center",
+        world_hero_overlay="none",
+        world_hero_height="standard",
+        enabled_post_profile_variants="default",
+        enabled_post_accent_styles="default",
+        enabled_post_border_styles="default",
+        enabled_post_title_styles="default",
+        enabled_post_densities="default",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _character(character_id: int, *, membership_id: int, slug: str, name: str) -> Character:
+    return Character(
+        id=character_id,
+        community_id=1,
+        membership_id=membership_id,
+        name=name,
+        slug=slug,
+        avatar_url=None,
+        poster_url=None,
+        poster_alt="",
+        tagline="",
+        accent_color="",
+        summary="",
+        post_profile_variant="default",
+        post_accent_style="default",
+        post_border_style="default",
+        post_title_style="default",
+        post_density="default",
+        application_status="accepted",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _membership(membership_id: int, *, username: str) -> CommunityMembership:
+    return CommunityMembership(
+        id=membership_id,
+        community_id=1,
+        user_id=membership_id,
+        username=username,
+        display_name=username.title(),
+        avatar_url=None,
+        role_id=1,
+        default_character_id=None,
+        post_count=0,
+        is_active=True,
+        joined_at=NOW,
+    )
+
+
+def _post(post_id: int, *, author_character_id: int, author_membership_id: int) -> Post:
+    return Post(
+        id=post_id,
+        community_id=1,
+        thread_id=1,
+        post_number=post_id,
+        author_membership_id=author_membership_id,
+        author_character_id=author_character_id,
+        body="Hello @Alice",
+        created_at=NOW,
+        updated_at=NOW,
+    )

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -1733,6 +1733,50 @@ def test_board_rollup_batch_reads_are_tenant_scoped(repo: ForumRepository) -> No
     ) == {thread.id: thread.updated_at}
 
 
+def test_network_membership_counts_batch_application_state(repo: ForumRepository) -> None:
+    community = repo.get_community(1)
+    role = repo.create_role(community.id, "network-member", "Network Member")
+    user = repo.create_user("network@example.com", "hash")
+    membership = repo.create_membership(community.id, user.id, role.id, "network", "Network")
+    other_user = repo.create_user("network-other@example.com", "hash")
+    other_membership = repo.create_membership(
+        community.id,
+        other_user.id,
+        role.id,
+        "network-other",
+        "Network Other",
+    )
+    repo.create_character(
+        community.id,
+        membership.id,
+        "network-draft",
+        "Network Draft",
+        application_status="draft",
+    )
+    repo.create_character(
+        community.id,
+        other_membership.id,
+        "network-submitted",
+        "Network Submitted",
+        application_status="submitted",
+    )
+    repo.create_character(
+        community.id,
+        other_membership.id,
+        "network-accepted",
+        "Network Accepted",
+        application_status="accepted",
+    )
+
+    assert repo.network_membership_counts([membership.id]) == {
+        membership.id: {
+            "reviewable_application_count": 2,
+            "own_application_count": 1,
+            "plotting_room_count": 0,
+        },
+    }
+
+
 def test_world_materials_are_tenant_scoped_and_facet_tagged(repo: ForumRepository) -> None:
     default = repo.get_community(1)
     hosted = repo.create_community("hosted", "Hosted Test")

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -1661,6 +1661,10 @@ def test_world_facets_scope_characters_boards_and_threads(repo: ForumRepository)
     ]
     assert [facet.slug for facet in repo.list_board_facets(community.id, board.id)] == ["x-men"]
     assert [facet.slug for facet in repo.list_thread_facets(community.id, thread.id)] == ["x-men"]
+    assert repo.list_characters_by_ids(community.id, [rogue.id]) == {rogue.id: rogue}
+    assert repo.list_memberships_by_ids(community.id, [membership.id]) == {
+        membership.id: membership,
+    }
     assert {
         thread_id: [facet.slug for facet in facets]
         for thread_id, facets in repo.list_thread_facets_for_threads(

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -1682,6 +1682,57 @@ def test_world_facets_scope_characters_boards_and_threads(repo: ForumRepository)
     }
 
 
+def test_board_rollup_batch_reads_are_tenant_scoped(repo: ForumRepository) -> None:
+    community = repo.get_community(1)
+    role = repo.create_role(community.id, "rollup-member", "Rollup Member")
+    user = repo.create_user("rollup@example.com", "hash")
+    membership = repo.create_membership(community.id, user.id, role.id, "rollup", "Rollup")
+    character = repo.create_character(community.id, membership.id, "rollup-face", "Rollup Face")
+    parent = repo.create_board(community.id, "rollup-parent", "Rollup Parent")
+    child = repo.create_board(
+        community.id,
+        "rollup-child",
+        "Rollup Child",
+        parent_board_id=parent.id,
+    )
+    other_parent = repo.create_board(community.id, "rollup-other", "Rollup Other")
+    thread = repo.create_thread(community.id, parent.id, character.id, "rollup-scene", "Scene")
+    child_thread = repo.create_thread(
+        community.id,
+        child.id,
+        character.id,
+        "rollup-child-scene",
+        "Child Scene",
+    )
+    repo.create_post(community.id, thread.id, character.id, "First post.")
+    repo.create_post(community.id, thread.id, character.id, "Second post.")
+    repo.create_post(community.id, child_thread.id, character.id, "Child post.")
+    repo.mark_thread_read(community.id, thread.id, membership.id, read_at=thread.updated_at)
+
+    assert repo.list_child_boards_for_boards(community.id, [parent.id, other_parent.id]) == {
+        parent.id: [child],
+    }
+    assert {
+        board_id: [item.id for item in threads]
+        for board_id, threads in repo.list_threads_for_boards(
+            community.id,
+            [parent.id, child.id],
+        ).items()
+    } == {
+        parent.id: [thread.id],
+        child.id: [child_thread.id],
+    }
+    assert repo.post_counts_by_thread(community.id, [thread.id, child_thread.id]) == {
+        thread.id: 2,
+        child_thread.id: 1,
+    }
+    assert repo.thread_read_at_for_threads(
+        community.id,
+        [thread.id, child_thread.id],
+        membership.id,
+    ) == {thread.id: thread.updated_at}
+
+
 def test_world_materials_are_tenant_scoped_and_facet_tagged(repo: ForumRepository) -> None:
     default = repo.get_community(1)
     hosted = repo.create_community("hosted", "Hosted Test")

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -1630,6 +1630,13 @@ def test_world_facets_scope_characters_boards_and_threads(repo: ForumRepository)
     thread = repo.create_thread(
         community.id, board.id, rogue.id, "sentinel-drill", "Sentinel Drill"
     )
+    second_thread = repo.create_thread(
+        community.id,
+        board.id,
+        rogue.id,
+        "blackbird-briefing",
+        "Blackbird Briefing",
+    )
 
     species = repo.create_facet_group(community.id, "species", "Species", sort_order=10)
     affiliation = repo.create_facet_group(
@@ -1645,6 +1652,8 @@ def test_world_facets_scope_characters_boards_and_threads(repo: ForumRepository)
     repo.assign_character_facet(community.id, rogue.id, x_men.id)
     repo.assign_board_facet(community.id, board.id, x_men.id)
     repo.assign_thread_facet(community.id, thread.id, x_men.id)
+    repo.assign_thread_facet(community.id, second_thread.id, mutant.id)
+    repo.assign_thread_facet(community.id, second_thread.id, x_men.id)
 
     assert [facet.slug for facet in repo.list_character_facets(community.id, rogue.id)] == [
         "mutant",
@@ -1652,8 +1661,21 @@ def test_world_facets_scope_characters_boards_and_threads(repo: ForumRepository)
     ]
     assert [facet.slug for facet in repo.list_board_facets(community.id, board.id)] == ["x-men"]
     assert [facet.slug for facet in repo.list_thread_facets(community.id, thread.id)] == ["x-men"]
+    assert {
+        thread_id: [facet.slug for facet in facets]
+        for thread_id, facets in repo.list_thread_facets_for_threads(
+            community.id,
+            [thread.id, second_thread.id],
+        ).items()
+    } == {
+        thread.id: ["x-men"],
+        second_thread.id: ["mutant", "x-men"],
+    }
     assert repo.list_character_ids_for_facets(community.id, [mutant.id, x_men.id]) == {rogue.id}
-    assert repo.list_thread_ids_for_facets(community.id, [x_men.id]) == {thread.id}
+    assert repo.list_thread_ids_for_facets(community.id, [x_men.id]) == {
+        thread.id,
+        second_thread.id,
+    }
 
 
 def test_world_materials_are_tenant_scoped_and_facet_tagged(repo: ForumRepository) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -211,6 +211,7 @@ source = { editable = "." }
 dependencies = [
     { name = "bengal-chirp", extra = ["config", "forms", "sessions", "ui"] },
     { name = "chirp-ui" },
+    { name = "milo-cli" },
     { name = "pyyaml" },
 ]
 
@@ -237,6 +238,7 @@ docs = [
 requires-dist = [
     { name = "bengal-chirp", extras = ["config", "forms", "sessions", "ui"], specifier = ">=0.6.0" },
     { name = "chirp-ui", specifier = ">=0.8.0" },
+    { name = "milo-cli", specifier = ">=0.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
## Summary
- add Milo dev preview, developer check, and SQLite checkpoint/backup helpers
- harden CLI server shutdown around app service and SQLite lifecycle
- add request-scoped DB/session and query-budget stability work for rendered routes
- batch hot rendered read paths: post views, mention links, thread facets, thread-card authors, board rollups, and signed-in network counts
- add scale fixtures for board pages, writer queues, and `/network`, plus board-index route budgets
- add dev-only htmx timing instrumentation, production-like local preview docs, and latest-click-wins browser QA harness
- document shutdown, backup, seed recovery, request lifecycle, preview, and query-budget contracts

## Steward Notes
- Consulted package/tooling, web/rendering, storage, service, and test stewards for the shutdown, SQLite lifecycle, and rendered read-model performance slices.
- Accepted P1s: shared server lifecycle, explicit app service close, SIGINT/SIGTERM/SIGHUP proof for local paths, SQLite reopen/write proof, request-scoped repository use for file-backed web requests, query-budget proof, and scale fixtures for batched surfaces.
- Accepted performance findings: repeated post enrichment, mention-link lookup, thread facet decoration, board rollup scans, and signed-in network aggregate counts were moved behind batch/read-model APIs.
- Deferred: deeper unread/read-state batching, thread navigation jump-target batching, board facet batching, public/network material aggregation, and running latest-click-wins browser QA against a live preview.
- Public preview correction: authenticated branches use request-scoped services, while signed-out public preview fallbacks keep the root public facade so production public routes preserve their 200/404 behavior.

## Proof
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/ scripts/latest_click_wins_qa.py`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`

## Follow-Up Epic
- Batch unread/read-state lookups across board cards, thread cards, navigation jumps, and writer queues.
- Batch thread navigation jump targets for first unread, previous/next unread, and latest-post links.
- Add `list_board_facets_for_boards()` and reuse facet groups once on board index surfaces.
- Add catalog-specific aggregate/read APIs for public/network premise, current event, and theme preview data.
- Ratchet scaled route budgets down after each batch lands.
- Run `uv run poe preview-prod-devtools`, then `uv run poe latest-click-wins-qa` and `uv run poe browser-qa-deep`.
- Add short route timing docs for `window.__elbysodicHtmxTimings`, `Server-Timing`, and query-budget tests.
