### PR TITLE
[codex] Upgrade Chirp to 0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ ty:
 	uv run ty check src/elbysodic/ tests/
 
 app-check:
-	uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
+	uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check(warnings_as_errors=True)"
 
 check: lint format-check ty app-check
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ uv run ruff check .
 uv run ruff format . --check
 uv run pytest -q --tb=short
 uv run ty check src/elbysodic/ tests/
-uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
+uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check(warnings_as_errors=True)"
 ```
 
 ## Running Locally
@@ -298,8 +298,8 @@ registry so Railway can build the app. Local-only uv config belongs in ignored
 `uv.toml`, and committed lockfile updates should be regenerated without local
 editable path sources.
 
-The checked-in lockfile tracks the current stack intake: Chirp 0.6, Chirp-UI
-0.8, Kida 0.9, and Pounce 0.7. When moving templates inside a folder, prefer
+The checked-in lockfile tracks the current stack intake: Chirp 0.7, Chirp-UI
+0.9, Kida 0.9, and Pounce 0.7. When moving templates inside a folder, prefer
 Kida's `./` relative imports for sibling `_components` references so local
 component groups stay refactor-safe.
 

--- a/changelog.d/+chirp-0.7.changed.md
+++ b/changelog.d/+chirp-0.7.changed.md
@@ -1,0 +1,1 @@
+Raised the minimum Chirp framework dependency to 0.7.0 so Elbysodic runs with the current route, template, security, and production diagnostics.

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -68,6 +68,12 @@ attributes, SSE fragments, and JSON payloads that carry local `href` values.
 Query strings and hidden `next`, `redirect`, or `return_to` paths must remain
 intact after scoping.
 
+Tenant-prefixed requests attach Chirp's request URL scope before page handlers
+run. New generated route values should use request-aware URL helpers so local
+paths are born inside `/c/{community_slug}`. The response rewriter remains as a
+compatibility net for existing templates and redirects until all tenant-scoped
+surfaces generate scoped URLs directly.
+
 Malformed tenant-local paths such as `/c/{community_slug}//login` fail closed
 instead of wrapping platform/global routes inside a community prefix.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ format-check = { cmd = "ruff format . --check", help = "Check formatting" }
 
 hooks = { cmd = "prek run --all-files", help = "Run all pre-commit hooks" }
 hooks-install = { cmd = "prek install", help = "Install pre-commit hooks" }
-app-check = { cmd = "python -c \"from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()\"", help = "Run Chirp route/template check" }
+app-check = { cmd = "python -c \"from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check(warnings_as_errors=True)\"", help = "Run Chirp route/template check" }
 
 ci = { sequence = ["lint", "format-check", "ty", "app-check", "test"], help = "Full CI check" }
 check = { sequence = ["lint", "format-check", "ty", "app-check"], help = "Quick check without tests" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "bengal-chirp[config,forms,sessions,ui]>=0.6.0",
+    "bengal-chirp[config,forms,sessions,ui]>=0.7.0",
     "chirp-ui>=0.9.0",
     "milo-cli>=0.2.2",
     "pyyaml>=6.0",

--- a/src/elbysodic/web/commands.py
+++ b/src/elbysodic/web/commands.py
@@ -5,5 +5,5 @@ from __future__ import annotations
 import secrets
 
 
-def command_token() -> str:
+def idempotency_key() -> str:
     return secrets.token_urlsafe(24)

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.html
@@ -39,7 +39,7 @@
         x-data="elbysodicComposer('{{ composer_config_id }}')"
         @submit="submitDraft()">
         {{ csrf_field() }}
-    <input type="hidden" name="command_token" value="{{ command_token }}">
+    <input type="hidden" name="idempotency_key" value="{{ idempotency_key }}">
     <div class="elbysodic-composer-heading">
       <div>
         <p class="elbysodic-kicker">Scene draft</p>

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py
@@ -10,7 +10,7 @@ from elbysodic.domain import Character
 from elbysodic.services import Mentionable
 from elbysodic.services.forum import POSTING_MODES, THREAD_STATUSES
 from elbysodic.services.threads import taggable_characters
-from elbysodic.web.commands import command_token
+from elbysodic.web.commands import idempotency_key
 from elbysodic.web.composer import composer_config, mention_picker_config
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_scoped_path
@@ -31,13 +31,13 @@ async def post(request: Request, board_slug: str) -> Page | Redirect:
     summary = str(form.get("summary") or "")
     posting_mode = str(form.get("posting_mode") or "freeform")
     body = str(form.get("body") or "")
-    token = str(form.get("command_token") or "")
+    key = str(form.get("idempotency_key") or "")
     services = get_services(request)
     command_key = f"start-thread:{board_slug}"
-    existing_result = services.command_result(command_key, token)
+    existing_result = services.command_result(command_key, key)
     if existing_result is not None:
         return Redirect(existing_result)
-    if not services.reserve_command(command_key, token):
+    if not services.reserve_command(command_key, key):
         return Redirect(f"/boards/{board_slug}/threads/new")
 
     try:
@@ -72,7 +72,7 @@ async def post(request: Request, board_slug: str) -> Page | Redirect:
     result_path = (
         f"/boards/{board_slug}/threads/{created.thread.slug}#post-{created.post.post_number}"
     )
-    services.complete_command(command_key, token, result_path)
+    services.complete_command(command_key, key, result_path)
     return Redirect(result_path)
 
 
@@ -124,7 +124,7 @@ def _render_form(
             body=body,
             composer_config={},
             composer_config_id="thread-composer-config",
-            command_token=command_token(),
+            idempotency_key=idempotency_key(),
         )
     selected_character = _select_character(
         viewer.roster,
@@ -177,7 +177,7 @@ def _render_form(
             mention_endpoint=mention_endpoint,
         ),
         composer_config_id=config_id,
-        command_token=command_token(),
+        idempotency_key=idempotency_key(),
     )
 
 

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
@@ -470,7 +470,7 @@
           @submit="submitDraft()">
         {{ csrf_field() }}
       <input type="hidden" name="intent" value="reply">
-      <input type="hidden" name="command_token" value="{{ command_token }}">
+      <input type="hidden" name="idempotency_key" value="{{ idempotency_key }}">
       <div class="elbysodic-composer-heading">
         <div>
           <p class="elbysodic-kicker">Next beat</p>

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py
@@ -10,7 +10,7 @@ from chirp.templating.returns import Page
 from elbysodic.domain import Character
 from elbysodic.services import Mentionable
 from elbysodic.services.forum import POSTING_MODES, THREAD_STATUSES
-from elbysodic.web.commands import command_token
+from elbysodic.web.commands import idempotency_key
 from elbysodic.web.composer import composer_config, mention_picker_config
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_scoped_path
@@ -98,12 +98,12 @@ async def post(request: Request, board_slug: str, thread_slug: str) -> Page | Re
 
     character_id = _parse_character_id(form.get("character_id"))
     body = str(form.get("body") or "")
-    token = str(form.get("command_token") or "")
+    key = str(form.get("idempotency_key") or "")
     command_key = f"reply:{board_slug}:{thread_slug}"
-    existing_result = services.command_result(command_key, token)
+    existing_result = services.command_result(command_key, key)
     if existing_result is not None:
         return Redirect(existing_result)
-    if not services.reserve_command(command_key, token):
+    if not services.reserve_command(command_key, key):
         return Redirect(request.path)
 
     try:
@@ -119,7 +119,7 @@ async def post(request: Request, board_slug: str, thread_slug: str) -> Page | Re
         )
 
     result_path = f"{request.path}#post-{post.post_number}"
-    services.complete_command(command_key, token, result_path)
+    services.complete_command(command_key, key, result_path)
     return Redirect(result_path)
 
 
@@ -165,7 +165,7 @@ def _render_thread(
             body=body,
             composer_config={},
             composer_config_id="reply-composer-config",
-            command_token=command_token(),
+            idempotency_key=idempotency_key(),
             thread_statuses=THREAD_STATUSES,
             posting_modes=POSTING_MODES,
             cast_picker_config_id="scene-cast-picker-config",
@@ -198,7 +198,7 @@ def _render_thread(
             mention_endpoint=mention_endpoint,
         ),
         composer_config_id=config_id,
-        command_token=command_token(),
+        idempotency_key=idempotency_key(),
         thread_statuses=THREAD_STATUSES,
         posting_modes=POSTING_MODES,
         cast_picker_config_id="scene-cast-picker-config",

--- a/src/elbysodic/web/pages/invite/{invite_token}/page.html
+++ b/src/elbysodic/web/pages/invite/{invite_token}/page.html
@@ -20,7 +20,7 @@
   {% end %}
 
   {% call surface(variant="elevated") %}
-  <form class="elbysodic-access-panel" method="post" action="/invite/{{ invite_token }}" hx-boost="false">
+  <form class="elbysodic-access-panel" method="post" hx-boost="false">
     {{ csrf_field() }}
     <p class="elbysodic-section-kicker">Invite-only access</p>
     <h1>{{ community.name }}</h1>

--- a/src/elbysodic/web/pages/invite/{invite_token}/page.py
+++ b/src/elbysodic/web/pages/invite/{invite_token}/page.py
@@ -85,7 +85,6 @@ def _render_invite(
         viewer=None,
         invitation=invitation,
         community=community,
-        invite_token=invite_token,
         form=form or InviteAcceptanceForm(),
         error=error,
         show_community_shell=False,

--- a/src/elbysodic/web/pages/login/page.html
+++ b/src/elbysodic/web/pages/login/page.html
@@ -36,7 +36,7 @@
     </label>
     <div class="chirpui-cluster chirpui-cluster--between">
       <p class="elbysodic-copy-helper">
-        {% if seed_passwords_enabled %}
+        {% if show_demo_login_hint %}
         Invite/demo accounts use password: <code>password</code>.
         {% else %}
         Access is invite-only for this launch; public registration is not open.

--- a/src/elbysodic/web/pages/login/page.py
+++ b/src/elbysodic/web/pages/login/page.py
@@ -75,7 +75,7 @@ def _render_login(
         email=email,
         next_url=next_url or _safe_next(str(getattr(request, "query", {}).get("next", "/"))),
         error=error,
-        seed_passwords_enabled=seed_passwords_enabled(),
+        show_demo_login_hint=seed_passwords_enabled(),
         show_community_shell=False,
     )
 

--- a/src/elbysodic/web/pages/studio/boards/{board_slug}/page.html
+++ b/src/elbysodic/web/pages/studio/boards/{board_slug}/page.html
@@ -215,7 +215,7 @@
         <label class="elbysodic-checkbox">
           <input type="checkbox"
                  name="is_private"
-                 {{ "checked" if values.is_private else "" }}>
+                 {{ "checked" if values.access_restricted else "" }}>
           <span>Staff/private board</span>
         </label>
       </div>
@@ -266,7 +266,7 @@
           </div>
           <div>
             <dt>Access</dt>
-            <dd>{{ "Private/staff" if editor.board.is_private else "Public" }}</dd>
+            <dd>{{ access_label }}</dd>
           </div>
           {% if editor.parent %}
           <div>

--- a/src/elbysodic/web/pages/studio/boards/{board_slug}/page.py
+++ b/src/elbysodic/web/pages/studio/boards/{board_slug}/page.py
@@ -95,7 +95,7 @@ async def post(request: Request, board_slug: str) -> Page | Redirect:
                 "navigation_order": str(form.get("navigation_order") or ""),
                 "show_in_navigation": form.get("show_in_navigation") == "on",
                 "sidebar_section": str(form.get("sidebar_section") or ""),
-                "is_private": form.get("is_private") == "on",
+                "access_restricted": form.get("is_private") == "on",
             },
         )
     return Redirect(f"/studio/boards/{board.slug}")
@@ -114,6 +114,7 @@ def _render_board_editor(
     except LookupError as exc:
         raise HTTPError(status=404, detail=str(exc)) from exc
     values = form_values or _values_from_board(editor.board)
+    access_label = "Private/staff" if editor.board.is_private else "Public"
     return Page.mounted(
         "studio/boards/{board_slug}/page.html",
         current_path=request.url,
@@ -128,6 +129,7 @@ def _render_board_editor(
         sidebar_section_labels=BOARD_SIDEBAR_SECTION_LABELS,
         error=error,
         values=values,
+        access_label=access_label,
     )
 
 
@@ -147,7 +149,7 @@ def _values_from_board(board: Board) -> dict[str, object]:
         "navigation_order": str(board.navigation_order),
         "show_in_navigation": board.show_in_navigation,
         "sidebar_section": board.sidebar_section,
-        "is_private": board.is_private,
+        "access_restricted": board.is_private,
     }
 
 

--- a/src/elbysodic/web/tenant.py
+++ b/src/elbysodic/web/tenant.py
@@ -87,7 +87,10 @@ class TenantPrefixMiddleware:
                 detail=f"Community not found: {community_slug}",
             )
 
-        scoped_request = replace(request, path=local_path)
+        scoped_request = replace(
+            request.with_url_scope(f"{TENANT_PREFIX}/{community_slug}"),
+            path=local_path,
+        )
         scoped_request._cache[TENANT_SLUG_CACHE_KEY] = community_slug
         scoped_request._cache[ORIGINAL_PATH_CACHE_KEY] = request.path
         response = await call_next(scoped_request)
@@ -118,6 +121,9 @@ def request_tenant_slug(request: object | None) -> str | None:
 def request_scoped_path(request: object | None, path: str) -> str:
     """Scope a local community endpoint when the current request is prefixed."""
 
+    scoped_url = getattr(request, "scoped_url", None)
+    if callable(scoped_url):
+        return scoped_url(path)
     tenant_slug = request_tenant_slug(request)
     return scoped_path(tenant_slug, path) if tenant_slug is not None else path
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode, urljoin
 
 import pytest
 from chirp.app import App
+from chirp.http.request import RequestUrlScope
 from chirp.http.response import Response
 from chirp.testing import TestClient
 from chirp_ui.alpine import check_alpine_runtime
@@ -21,7 +22,7 @@ from elbysodic.services import AppServices, create_services, default_database_pa
 from elbysodic.services.access import TENANT_SLUG_CACHE_KEY
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
-from elbysodic.web.tenant import scope_response_urls
+from elbysodic.web.tenant import request_scoped_path, scope_response_urls
 from tests._sql_probe import trace_sql
 
 _FORM = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -773,6 +774,22 @@ def test_tenant_scoping_preserves_authored_form_values() -> None:
     assert (
         'name="return_to" value="/c/x-men-apocalypse/claims?status=claimed&amp;q=magneto"'
         in scoped.body
+    )
+
+
+def test_request_scoped_path_uses_chirp_url_scope() -> None:
+    request = SimpleNamespace(url_scope=RequestUrlScope("/c/x-men-apocalypse"))
+
+    def scoped_url(path: str) -> str:
+        return request.url_scope.apply(path)
+
+    request.scoped_url = scoped_url
+
+    assert request_scoped_path(request, "/mentionables/search") == (
+        "/c/x-men-apocalypse/mentionables/search"
+    )
+    assert request_scoped_path(request, "/c/x-men-apocalypse/world") == (
+        "/c/x-men-apocalypse/world"
     )
 
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -6057,6 +6057,60 @@ def test_tenant_prefixed_plotting_room_scopes_live_and_plan_routes() -> None:
     asyncio.run(run())
 
 
+def test_plotting_room_sse_ready_event_uses_safe_channel() -> None:
+    async def run() -> None:
+        app = _app()
+        async with TestClient(app) as client:
+            response = await client.post(
+                "/wanted/human-un-liaison-for-b24",
+                body=b"intent=express_interest",
+                headers=_FORM,
+            )
+            assert response.status == 302
+
+        services = get_services()
+        repo = services.repo
+        community = services.seed.community
+        wanted_ad = repo.get_wanted_ad_by_slug(community.id, "human-un-liaison-for-b24")
+        rogue = repo.get_character_by_slug(community.id, "rogue")
+        interest = repo.get_wanted_ad_interest_for_character(community.id, wanted_ad.id, rogue.id)
+        charlie_membership = repo.get_membership_by_username(community.id, "charlie")
+        charlie_user = repo.get_user(charlie_membership.user_id)
+        xavier = repo.get_character_by_slug(community.id, "charles-xavier")
+        charlie_app = create_app(
+            debug=False,
+            services=AppServices(
+                repo,
+                DemoSeed(community, charlie_user, charlie_membership, xavier),
+            ),
+        )
+        async with TestClient(charlie_app) as charlie_client:
+            room_response = await charlie_client.post(
+                "/wanted/human-un-liaison-for-b24",
+                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                headers=_FORM,
+            )
+            assert room_response.status == 302
+
+            room = repo.get_plotting_room_for_wanted_interest(community.id, interest.id)
+            stream = await charlie_client.sse(
+                f"/plotting/{room.id}/stream",
+                max_events=1,
+                timeout=1.0,
+            )
+
+        assert stream.status == 200
+        assert len(stream.events) == 1
+        event = stream.events[0]
+        assert event.event == "plotting-room-ready"
+        assert event.data == "connected"
+        assert "\r" not in event.event
+        assert "\n" not in event.event
+        assert "\x00" not in event.event
+
+    asyncio.run(run())
+
+
 def test_tenant_prefixed_plotting_room_id_does_not_leak_cross_realm_room() -> None:
     async def run() -> None:
         app = _app()

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -8279,7 +8279,7 @@ def test_start_thread_creates_opening_post_as_selected_character() -> None:
             assert 'aria-label="Quote"' in form.text
             assert 'aria-label="Link"' in form.text
             assert "Power-stealing brawler with a careful heart." in form.text
-            token = _input_value(form.text, "command_token")
+            key = _input_value(form.text, "idempotency_key")
 
             response = await client.post(
                 "/boards/danger-room/threads/new",
@@ -8294,7 +8294,7 @@ def test_start_thread_creates_opening_post_as_selected_character() -> None:
                         "summary": "Magneto tags Xavier into an unreasonable simulation.",
                         "posting_mode": "posting_order",
                         "body": "Magneto sets the simulation to unfair.",
-                        "command_token": token,
+                        "idempotency_key": key,
                     },
                     doseq=True,
                 ).encode(),
@@ -8307,7 +8307,7 @@ def test_start_thread_creates_opening_post_as_selected_character() -> None:
                         "character_id": magneto.id,
                         "title": "Metal and Memory Duplicate",
                         "body": "This duplicate should not be posted.",
-                        "command_token": token,
+                        "idempotency_key": key,
                     },
                     doseq=True,
                 ).encode(),
@@ -8344,7 +8344,7 @@ def test_start_thread_creates_opening_post_as_selected_character() -> None:
     asyncio.run(run())
 
 
-def test_reply_command_token_prevents_duplicate_posts() -> None:
+def test_reply_idempotency_key_prevents_duplicate_posts() -> None:
     async def run() -> None:
         app = _app()
         services = get_services()
@@ -8362,14 +8362,14 @@ def test_reply_command_token_prevents_duplicate_posts() -> None:
             assert 'data-elbysodic-command-kind="reply"' in page.text
             assert 'data-elbysodic-actor-shape="explicit-character"' in page.text
             assert 'data-elbysodic-idempotency="command-token"' in page.text
-            token = _input_value(page.text, "command_token")
+            key = _input_value(page.text, "idempotency_key")
             first = await client.post(
                 "/boards/danger-room/threads/sentinel-drill",
                 body=urlencode(
                     {
                         "character_id": str(character.id),
                         "body": "Rogue checks the duplicate-submit guard.",
-                        "command_token": token,
+                        "idempotency_key": key,
                     }
                 ).encode(),
                 headers=_FORM,
@@ -8380,7 +8380,7 @@ def test_reply_command_token_prevents_duplicate_posts() -> None:
                     {
                         "character_id": str(character.id),
                         "body": "This duplicate should not create another post.",
-                        "command_token": token,
+                        "idempotency_key": key,
                     }
                 ).encode(),
                 headers=_FORM,

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -27,6 +27,14 @@ def test_post_markup_escapes_raw_html() -> None:
     assert "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;" in rendered
 
 
+def test_post_markup_escapes_event_handler_html() -> None:
+    rendered = str(render_post_body('<img src="x" onerror="alert(1)">'))
+
+    assert "<img" not in rendered
+    assert 'onerror="alert(1)"' not in rendered
+    assert "&lt;img src=&quot;x&quot; onerror=&quot;alert(1)&quot;&gt;" in rendered
+
+
 def test_post_markup_renders_known_mentions_as_links() -> None:
     rendered = str(
         render_post_body(

--- a/tests/test_route_smoke.py
+++ b/tests/test_route_smoke.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+
+from chirp.testing import RouteSmokeCase, TestClient, assert_route_smoke
+
+from elbysodic.db.seed import DemoSeed, resolve_seed_persona
+from elbysodic.services import AppServices, create_services
+from elbysodic.web import create_app
+
+
+def test_member_route_smoke_covers_full_pages_and_fragments() -> None:
+    async def run() -> None:
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+
+        async with TestClient(app) as client:
+            await assert_route_smoke(
+                client,
+                [
+                    "/",
+                    "/network",
+                    "/characters/rogue",
+                    RouteSmokeCase("/boards/danger-room", mode="both"),
+                    RouteSmokeCase("/boards/danger-room/threads/sentinel-drill", mode="both"),
+                ],
+            )
+
+    asyncio.run(run())
+
+
+def test_staff_route_smoke_covers_director_surfaces() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        staff = resolve_seed_persona(services.repo, "xmen_staff")
+        app = create_app(
+            debug=False,
+            services=AppServices(
+                services.repo,
+                DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+            ),
+        )
+
+        async with TestClient(app) as client:
+            await assert_route_smoke(client, ["/studio", "/studio/launch", "/applications"])
+
+    asyncio.run(run())

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -120,6 +120,18 @@ def test_production_config_parses_allowed_hosts_and_hsts(monkeypatch) -> None:
     assert app.config.strict_transport_security == "max-age=31536000"
 
 
+def test_production_default_allowed_hosts_pass_chirp_check(monkeypatch) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "production")
+    monkeypatch.setenv("ELBYSODIC_SECRET_KEY", "x" * 32)
+    monkeypatch.delenv("ELBYSODIC_ALLOWED_HOSTS", raising=False)
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+
+    app = create_app(debug=False, services=create_services(path=":memory:"))
+
+    assert app.config.allowed_hosts == (".up.railway.app", ".railway.app")
+    app.check(warnings_as_errors=True)
+
+
 def test_session_cookies_are_secure_in_production(monkeypatch) -> None:
     async def run() -> None:
         _set_production_env(monkeypatch)
@@ -534,6 +546,27 @@ def test_production_login_rate_limit_blocks_repeated_posts(monkeypatch) -> None:
         assert [response.status for response in responses[:10]] == [403] * 10
         assert responses[10].status == 429
         assert dict(responses[10].headers)["retry-after"] == "300"
+
+    asyncio.run(run())
+
+
+def test_production_login_rate_limit_ignores_spoofed_forwarded_for(monkeypatch) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+
+        async with TestClient(app) as client:
+            responses = [
+                await client.post(
+                    "/login",
+                    body=b"",
+                    headers={**_FORM, "X-Forwarded-For": f"198.51.100.{attempt}"},
+                )
+                for attempt in range(11)
+            ]
+
+        assert [response.status for response in responses[:10]] == [403] * 10
+        assert responses[10].status == 429
 
     asyncio.run(run())
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,16 +43,16 @@ wheels = [
 
 [[package]]
 name = "bengal-chirp"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "bengal-pounce" },
     { name = "kida-templates" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/c3/49b033f67c735fb4385d67e070c907e7db4d46e3b68ef15dc6db08e72a85/bengal_chirp-0.6.0.tar.gz", hash = "sha256:500d929c4d788edf99f311c0a0ee1fad6a1a52b6b57f39cef8a9af0cd0ccffb4", size = 559314, upload-time = "2026-05-02T18:12:59.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/29/bb07857a9247cd76c4e3c16ae31534a2164ef0c5beab3323503b33f11b6b/bengal_chirp-0.7.0.tar.gz", hash = "sha256:cee0f842625c414323a95ab54ab84b7a70fcabc1fee30f247a878984b187df80", size = 590007, upload-time = "2026-05-14T16:55:28.16Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/ae/8c6daf5e969c9ff36d7d4218a98e44fca56dd60b9c7e171de2e80dfebe67/bengal_chirp-0.6.0-py3-none-any.whl", hash = "sha256:3088c651d9e59ceb505e73b05b22bf8ca1b404d76dd7701cd08cb806aed7091b", size = 480323, upload-time = "2026-05-02T18:12:58.178Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d3/af30eca2364762d39d90254d9df4d7b05315d348b9ae8274a0fc8d3a0a6e/bengal_chirp-0.7.0-py3-none-any.whl", hash = "sha256:adc66aee61d8054eaa076ccecff075a1f8bb0bc364b8d14b4a04f349f9a9727f", size = 501407, upload-time = "2026-05-14T16:55:26.369Z" },
 ]
 
 [package.optional-dependencies]
@@ -236,7 +236,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bengal-chirp", extras = ["config", "forms", "sessions", "ui"], specifier = ">=0.6.0" },
+    { name = "bengal-chirp", extras = ["config", "forms", "sessions", "ui"], specifier = ">=0.7.0" },
     { name = "chirp-ui", specifier = ">=0.9.0" },
     { name = "milo-cli", specifier = ">=0.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary

- Raise the minimum `bengal-chirp[config,forms,sessions,ui]` dependency to `>=0.7.0` and refresh `uv.lock` to `bengal-chirp` 0.7.0.
- Clear Chirp 0.7/Kida privacy diagnostics by removing sensitive-looking rendered context names for idempotency, invites, login demo state, and Studio board access labels.
- Treat Chirp app-check warnings as errors in project gates and update README stack/check guidance.
- Add Chirp route smoke coverage for representative member, fragment, and director surfaces.
- Adopt Chirp request URL scope for tenant-prefixed generated paths while keeping the response rewriter as a compatibility net.
- Add production, markup, and plotting SSE hardening coverage.

## Notes

Chirp 0.7.0 adds stricter `app.check()` diagnostics, production trust-boundary defaults, SSE and markdown hardening, request URL scope helpers, and the `chirp-ui>=0.9.0` floor. Elbysodic already had the current Chirp-UI floor. This PR now uses the new diagnostics as a stricter local gate and starts migrating tenant-aware generated URLs toward Chirp's request-scope primitive.

The tenant response rewriter intentionally remains in place. Current templates still contain hardcoded local links and forms, so the URL scope work is a forward-compatible step rather than a full removal.

## Validation

- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `make app-check`
- `uv run pytest -q --tb=short`