### PR TITLE
[codex] Polish network discovery and scoped search

### DIFF
--- a/docs/product/navigation-menus.md
+++ b/docs/product/navigation-menus.md
@@ -99,7 +99,8 @@ Topbar owns:
 - The community brand/title as the community home affordance.
 - Mobile navigation trigger for `World Home`, `Locations`, `Wanted`, `Desk`,
   and `Studio`.
-- Future global/community search entry.
+- Global/community search entry using the scope contract in
+  `docs/product/scoped-search.md`.
 - Future explore/browse communities entry from the LBSodic home.
 - Notifications indicator.
 - Writer account, membership, and active-face identity menu.

--- a/docs/product/scoped-search.md
+++ b/docs/product/scoped-search.md
@@ -1,0 +1,63 @@
+# Scoped Search
+
+Search is a top-chrome utility, not a page-bottom fallback panel. It should let
+people move from their current context without making every page repeat a
+search box, shortcut wall, or filter matrix.
+
+## Jobs
+
+Search has two primary scopes:
+
+| Scope | Where It Appears | Job |
+| --- | --- | --- |
+| All realms | Product home, Network, signed-out product routes | Find public realms by premise, pace, hooks, roster shape, current chapter, and browsing posture. |
+| Current realm | Community routes | Find public-safe material inside the current realm: guidebook entries, places, scenes, wanted hooks, cast, claims, and current premise context. |
+
+The topbar owns the entry point because search is cross-cutting. Page content
+can show search results, local filters, and advanced browse controls, but the
+page should not add another generic search launcher unless search is the
+surface's primary job.
+
+## Interaction Contract
+
+- Product routes default to `All realms`.
+- Community routes default to the current realm.
+- A scoped result page can offer a secondary path to broaden from current realm
+  to all realms.
+- Empty searches do not render a wall of every possible facet. Show the search
+  control and a small set of useful browse paths instead.
+- Result cards inherit their section context. Avoid repeating labels like
+  `Realm`, `Scene`, `Wanted`, or `Guidebook` inside every child when the result
+  group already says what is being shown.
+- Topbar search must stay compact enough to coexist with identity, community
+  brand, notifications, and mobile navigation.
+
+## Visual Contract
+
+- Use one visible scope chip or label at the start of the control.
+- Use a placeholder for examples, not instructions.
+- Keep the submit affordance compact; icon-only is acceptable once an
+  accessible name is present.
+- Do not place search under long shelves or return-path panels on the Network
+  home. That position reads like leftover boilerplate and hides the utility
+  when people need it.
+- Results should prioritize readable titles, concise story-facing summaries,
+  and direct movement. Counts belong at the card or section edge only when they
+  change the user's decision.
+
+## Privacy Contract
+
+Current-realm search is rendered from public-safe read models for signed-out
+visitors. Signed-in members may see member-safe results only when the service
+contract explicitly includes membership, role, and active-face boundaries.
+
+Search must not leak:
+
+- private boards, scenes, or materials
+- staff-only workflow state
+- draft wanted hooks or unreviewed continuity
+- private membership, application, queue, or notification state
+- character or face data outside the current community
+
+When in doubt, ship the public-safe result first and add member/deck lanes only
+after the service contract and tests prove the boundary.

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -10,6 +10,7 @@ from contextlib import AbstractContextManager, suppress
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from urllib.parse import urlencode
 
 from elbysodic.blueprints import ProgramBlueprintPreview
 from elbysodic.db import Database, ForumRepository, connect, create_schema
@@ -294,6 +295,9 @@ from elbysodic.services.read_models import (
     RealmLaunchChecklistItem,
     RealmLaunchReadiness,
     SceneContextView,
+    ScopedSearchResult,
+    ScopedSearchSection,
+    ScopedSearchView,
     StudioBoardEditor,
     StudioIdentityOption,
     StudioNetworkDirectory,
@@ -1186,6 +1190,13 @@ class AppServices:
     def network_explore(self, query: str = "") -> NetworkExploreView:
         cards = self._public_catalog_cards()
         return _network_explore(cards, query)
+
+    def global_search(self, query: str = "") -> ScopedSearchView:
+        return _global_search(self._public_catalog_cards(), query)
+
+    def community_search(self, community_slug: str, query: str = "") -> ScopedSearchView:
+        community = self._public_preview_community(community_slug)
+        return _community_search(self.repo, community, query)
 
     def _public_catalog_cards(self) -> list[PublicCatalogCard]:
         return _public_catalog_cards(self.repo)
@@ -3512,6 +3523,236 @@ def _gateway_curation_guidebook_materials(
     )
 
 
+def _global_search(cards: list[PublicCatalogCard], query: str) -> ScopedSearchView:
+    normalized_query = query.strip()
+    results = _network_explore(cards, normalized_query).results if normalized_query else []
+    return ScopedSearchView(
+        query=normalized_query,
+        scope_label="All realms",
+        scope_kind="global",
+        action_href="/search",
+        broaden_href=None,
+        sections=[
+            ScopedSearchSection(
+                title="Realms",
+                results=[
+                    ScopedSearchResult(
+                        title=card.community.name,
+                        summary=_catalog_card_summary(card),
+                        href=card.entry_href,
+                        meta=f"{card.open_wanted_count} wanted · {card.roster_count} faces",
+                    )
+                    for card in results
+                ],
+            )
+        ]
+        if normalized_query
+        else [],
+    )
+
+
+def _community_search(
+    repo: ForumRepository,
+    community: Community,
+    query: str,
+) -> ScopedSearchView:
+    normalized_query = query.strip()
+    gateway = _public_realm_gateway(repo, community)
+    sections: list[ScopedSearchSection] = []
+    if normalized_query:
+        sections = [
+            section
+            for section in (
+                _community_guidebook_search_section(gateway, normalized_query),
+                _community_places_search_section(gateway, normalized_query),
+                _community_scenes_search_section(gateway, normalized_query),
+                _community_wanted_search_section(gateway, normalized_query),
+                _community_cast_search_section(gateway, normalized_query),
+                _community_social_search_section(gateway, normalized_query),
+            )
+            if section.results
+        ]
+    return ScopedSearchView(
+        query=normalized_query,
+        scope_label=community.name,
+        scope_kind="community",
+        action_href="/search",
+        broaden_href=_query_href("/search", normalized_query),
+        sections=sections,
+    )
+
+
+def _community_guidebook_search_section(
+    gateway: RealmGatewayView,
+    query: str,
+) -> ScopedSearchSection:
+    materials = _unique_material_summaries(
+        [
+            *gateway.guidebook.featured,
+            *gateway.guidebook.events,
+            *gateway.guidebook.guides,
+            *gateway.guidebook.application_materials,
+        ]
+    )
+    return ScopedSearchSection(
+        title="Guidebook",
+        results=[
+            ScopedSearchResult(
+                title=summary.display_title,
+                summary=summary.rendered_summary,
+                href=f"/world/{summary.material.slug}",
+                meta=summary.type_label,
+            )
+            for summary in materials
+            if _search_matches(
+                query,
+                summary.display_title,
+                summary.rendered_summary,
+                summary.type_label,
+            )
+        ],
+    )
+
+
+def _community_places_search_section(
+    gateway: RealmGatewayView,
+    query: str,
+) -> ScopedSearchSection:
+    return ScopedSearchSection(
+        title="Places",
+        results=[
+            ScopedSearchResult(
+                title=hub.board.name,
+                summary=hub.display_summary,
+                href=hub.href,
+                meta=f"{hub.public_thread_count} threads" if hub.public_thread_count else "",
+            )
+            for hub in gateway.scene_hubs
+            if _search_matches(query, hub.board.name, hub.display_summary)
+        ],
+    )
+
+
+def _community_scenes_search_section(
+    gateway: RealmGatewayView,
+    query: str,
+) -> ScopedSearchSection:
+    return ScopedSearchSection(
+        title="Scenes",
+        results=[
+            ScopedSearchResult(
+                title=scene.title,
+                summary=scene.summary,
+                href=scene.href,
+                meta=scene.board_label,
+            )
+            for scene in gateway.scene_previews
+            if _search_matches(
+                query,
+                scene.title,
+                scene.summary,
+                scene.board_label,
+                scene.cast_label,
+            )
+        ],
+    )
+
+
+def _community_wanted_search_section(
+    gateway: RealmGatewayView,
+    query: str,
+) -> ScopedSearchSection:
+    return ScopedSearchSection(
+        title="Wanted hooks",
+        results=[
+            ScopedSearchResult(
+                title=wanted.title,
+                summary=wanted.summary,
+                href=wanted.href,
+                meta=wanted.related_label or wanted.type_label,
+            )
+            for wanted in gateway.wanted_previews
+            if _search_matches(
+                query,
+                wanted.title,
+                wanted.summary,
+                wanted.type_label,
+                wanted.related_label,
+            )
+        ],
+    )
+
+
+def _community_cast_search_section(
+    gateway: RealmGatewayView,
+    query: str,
+) -> ScopedSearchSection:
+    return ScopedSearchSection(
+        title="Cast",
+        results=[
+            ScopedSearchResult(
+                title=member.character.name,
+                summary=member.summary,
+                href=member.href,
+            )
+            for member in gateway.cast_members
+            if _search_matches(query, member.character.name, member.summary)
+        ],
+    )
+
+
+def _community_social_search_section(
+    gateway: RealmGatewayView,
+    query: str,
+) -> ScopedSearchSection:
+    return ScopedSearchSection(
+        title="Ways to belong",
+        results=[
+            ScopedSearchResult(
+                title=lane.title,
+                summary=lane.summary,
+                href="/",
+                meta=lane.tone,
+            )
+            for lane in gateway.social_lanes
+            if _search_matches(query, lane.title, lane.summary, lane.tone)
+        ],
+    )
+
+
+def _catalog_card_summary(card: PublicCatalogCard) -> str:
+    if card.current_event is not None:
+        return card.current_event.rendered_summary
+    if card.premise is not None:
+        return card.premise.rendered_summary
+    if card.discovery_profile is not None and card.discovery_profile.catalog_pitch:
+        return card.discovery_profile.catalog_pitch
+    return card.application_posture_label
+
+
+def _unique_material_summaries(materials: list[MaterialSummary]) -> list[MaterialSummary]:
+    seen: set[int] = set()
+    unique: list[MaterialSummary] = []
+    for summary in materials:
+        if summary.material.id in seen:
+            continue
+        seen.add(summary.material.id)
+        unique.append(summary)
+    return unique
+
+
+def _search_matches(query: str, *values: object) -> bool:
+    terms = [term for term in query.casefold().split() if term]
+    if not terms:
+        return False
+    haystack = " ".join(str(value or "") for value in values).casefold()
+    return all(term in haystack for term in terms)
+
+
+def _query_href(path: str, query: str) -> str:
+    return f"{path}?{urlencode({'q': query})}" if query else path
+
+
 def _public_realm_gateway(repo: ForumRepository, community: Community) -> RealmGatewayView:
     program = _public_studio_program(repo, community.slug)
     guidebook = _public_world_hub(repo, community.id)
@@ -3750,9 +3991,7 @@ def _realm_gateway_premise_evolution(
     current_pressure_title = atmosphere.title
     current_pressure_summary = atmosphere.copy
     inciting_incident = (
-        current_pressure_summary
-        if atmosphere.source_type == "event"
-        else premise_summary
+        current_pressure_summary if atmosphere.source_type == "event" else premise_summary
     )
     consequences = _realm_gateway_consequence_summary(
         current_pressure_title,

--- a/src/elbysodic/services/network.py
+++ b/src/elbysodic/services/network.py
@@ -372,22 +372,56 @@ def network_home(cards: list[PublicCatalogCard], viewer: ForumView | None) -> Ne
     return NetworkHomeView(
         featured=cards[0] if cards else None,
         slices=[
-            NetworkSlice("Premise engines", "/network", cards),
-            NetworkSlice(
-                "Small-town social webs",
-                "/network?q=small-town-social-web",
-                _cards_matching_discovery(cards, "small-town-social-web"),
-            ),
-            NetworkSlice(
-                "Mystery and current chapters",
-                "/network?q=current-chapter",
-                _cards_matching_discovery(cards, "current-chapter"),
-            ),
+            NetworkSlice("Top 10 realms", "/network", cards[:10]),
+            *_network_home_premise_slices(cards),
         ],
         browse_facets=network_browse_facets(cards),
         filter_groups=network_filter_groups(cards),
         return_path=return_path,
     )
+
+
+def _network_home_premise_slices(cards: list[PublicCatalogCard]) -> list[NetworkSlice]:
+    slices = []
+    for premise in DISCOVERY_PROFILE_CHOICE_VALUES["premise_archetype"]:
+        matching_cards = _cards_matching_profile(cards, "premise_archetype", premise)
+        if matching_cards:
+            slices.append(
+                NetworkSlice(
+                    _premise_slice_title(premise),
+                    f"/network?q={quote_plus(premise)}",
+                    matching_cards,
+                )
+            )
+    return slices
+
+
+def _cards_matching_profile(
+    cards: list[PublicCatalogCard],
+    field_name: str,
+    value: str,
+) -> list[PublicCatalogCard]:
+    return [
+        card
+        for card in cards
+        if card.discovery_profile is not None
+        and str(getattr(card.discovery_profile, field_name, "") or "").lower() == value
+    ]
+
+
+def _premise_slice_title(value: str) -> str:
+    titles = {
+        "small-town-social-web": "Small-town social webs",
+        "weird-town-mystery": "Weird-town mysteries",
+        "urban-supernatural-pressure-cooker": "Urban supernatural pressure cookers",
+        "court-and-faction-fantasy": "Court and faction fantasy",
+        "original-canon-adjacent-au": "Original canon-adjacent AUs",
+        "fame-and-industry-drama": "Fame and industry dramas",
+        "survival-trials": "Survival trials",
+        "occult-historical-pressure": "Occult historical pressure",
+        "strange-frontier": "Strange frontiers",
+    }
+    return titles.get(value, _discovery_filter_label(value))
 
 
 def network_explore(cards: list[PublicCatalogCard], query: str = "") -> NetworkExploreView:

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -2193,6 +2193,34 @@ class NetworkExploreView:
 
 
 @dataclass(frozen=True, slots=True)
+class ScopedSearchResult:
+    title: str
+    summary: str
+    href: str
+    meta: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ScopedSearchSection:
+    title: str
+    results: list[ScopedSearchResult]
+
+
+@dataclass(frozen=True, slots=True)
+class ScopedSearchView:
+    query: str
+    scope_label: str
+    scope_kind: str
+    action_href: str
+    broaden_href: str | None
+    sections: list[ScopedSearchSection]
+
+    @property
+    def result_count(self) -> int:
+        return sum(len(section.results) for section in self.sections)
+
+
+@dataclass(frozen=True, slots=True)
 class DiscoveryProfileChoice:
     value: str
     label: str

--- a/src/elbysodic/web/pages/_components/realm_gateway.html
+++ b/src/elbysodic/web/pages/_components/realm_gateway.html
@@ -237,7 +237,7 @@
 
 {% def gateway_cast(gateway) %}
 {% if gateway.cast_members %}
-{% call gateway_section("Cast", "Already in the room", heading_id="realm-cast-title") %}
+{% call gateway_section("Cast", "Featured faces", heading_id="realm-cast-title") %}
   <div class="elbysodic-realm-cast-grid">
     {% for member in gateway.cast_members %}
     <a class="elbysodic-realm-cast-card" href="{{ member.href }}">
@@ -261,7 +261,7 @@
 
 {% def gateway_social_lanes(gateway) %}
 {% if gateway.social_lanes %}
-{% call gateway_section("Claims", "Ways to belong", heading_id="realm-social-title", modifier="elbysodic-realm-gateway-section--social-map") %}
+{% call gateway_section("Claims", "Social map", heading_id="realm-social-title", modifier="elbysodic-realm-gateway-section--social-map") %}
   <div class="elbysodic-realm-lane-grid">
     {% for lane in gateway.social_lanes %}
     {{ gateway_social_lane_card(lane) }}

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -184,7 +184,7 @@
          type="search"
          value="{{ query }}"
          placeholder="Search">
-  <button type="submit">Search</button>
+  <button type="submit" aria-label="Search {{ scope_label }}">Go</button>
 </form>
 {% end %}
 

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -242,29 +242,18 @@
            @keydown.escape.window="open = false">
     <summary class="elbysodic-identity-menu__summary"
              aria-label="Identity menu: {{ viewer.membership.username }}{% if viewer.current_character %} playing as {{ viewer.current_character.name }}{% end %}">
-      <span class="elbysodic-identity-menu__avatar-stack" aria-hidden="true">
-        <span class="elbysodic-identity-menu__writer-avatar">{{ (viewer.membership.display_name or viewer.membership.username)[:1] }}</span>
-        {% if viewer.current_character %}
-        <span class="elbysodic-identity-menu__face-avatar">
-          {% if viewer.current_character.avatar_url %}
-          <img src="{{ viewer.current_character.avatar_url }}" alt="">
-          {% else %}
-          {{ viewer.current_character.name[:1] }}
-          {% end %}
-        </span>
+      <span class="elbysodic-identity-menu__summary-avatar" aria-hidden="true">
+        {% if viewer.current_character and viewer.current_character.avatar_url %}
+        <img src="{{ viewer.current_character.avatar_url }}" alt="">
+        {% elif viewer.current_character %}
+        {{ viewer.current_character.name[:1] }}
+        {% else %}
+        {{ (viewer.membership.display_name or viewer.membership.username)[:1] }}
         {% end %}
       </span>
       {% if viewer.unread_notification_count %}
       <span class="elbysodic-identity-menu__summary-badge">{{ viewer.unread_notification_count }}</span>
       {% end %}
-      <span class="elbysodic-identity-menu__copy">
-        {% if viewer.current_character %}
-        <span class="elbysodic-identity-menu__face">{{ viewer.current_character.name }}</span>
-        {% else %}
-        <span class="elbysodic-identity-menu__face">No face</span>
-        {% end %}
-        <span class="elbysodic-identity-menu__label">@{{ viewer.membership.username }}</span>
-      </span>
     </summary>
     <div class="elbysodic-identity-menu__panel">
       <header class="elbysodic-identity-menu__hero">

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -175,6 +175,19 @@
 </a>
 {% end %}
 
+{% def topbar_search(scope_label, query="") %}
+<form class="elbysodic-topbar-search" action="/search" method="get" role="search" hx-boost="false">
+  <label class="chirpui-visually-hidden" for="elbysodic-topbar-search-input">Search {{ scope_label }}</label>
+  <span class="elbysodic-topbar-search__scope">{{ scope_label }}</span>
+  <input id="elbysodic-topbar-search-input"
+         name="q"
+         type="search"
+         value="{{ query }}"
+         placeholder="Search">
+  <button type="submit">Search</button>
+</form>
+{% end %}
+
 {% block topbar_center %}
 {% set topbar_board_section = board_section_for_path(viewer, current_path or "/") if viewer else "" %}
 {% if board is defined %}
@@ -193,6 +206,10 @@
 <nav class="elbysodic-topnav elbysodic-topnav--global" aria-label="Global">
   {{ topnav_link("/network", "Explore", topbar_route.network_active) }}
 </nav>
+{% set topbar_search_viewer = viewer | default(none) %}
+{% set topbar_search_community = (topbar_search_viewer.community if shell_has_community and topbar_search_viewer else (community | default(none))) %}
+{% set topbar_search_query = search_query | default(network_search_query | default("")) %}
+{{ topbar_search(topbar_search_community.name if topbar_search_community else "All realms", topbar_search_query) }}
 {% if shell_has_community %}
 {% call drawer("elbysodic-mobile-shell", title=mobile_nav_label, side="left", cls="elbysodic-mobile-shell-drawer") %}
   {% set drawer_board_section = topbar_board_section %}

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -257,12 +257,6 @@
     </form>
   </section>
 
-  <section class="elbysodic-network-explore-map" aria-label="Explore by tag relationship">
-    {% for facet in browse_facets %}
-    {{ explore_tag(facet.label, facet.href, facet.tone, facet.result_count) }}
-    {% end %}
-  </section>
-
   <section class="elbysodic-network-rail" aria-labelledby="explore-results-heading">
     <div class="elbysodic-network-rail__header">
       <div>
@@ -305,9 +299,14 @@
   <details class="elbysodic-network-filter-drawer">
     <summary>
       <span>Browse by fit</span>
-      <em>{{ filter_groups | length }} groups</em>
+      <em>{{ browse_facets | length + filter_groups | length }} ways</em>
     </summary>
     <section class="elbysodic-network-filter-panel" aria-label="Explore by discovery profile">
+      <div class="elbysodic-network-filter-drawer__chips" aria-label="Popular fits">
+        {% for facet in browse_facets %}
+        {{ explore_tag(facet.label, facet.href, facet.tone, facet.result_count) }}
+        {% end %}
+      </div>
       {% for group in filter_groups %}
       {{ explore_filter_group(group) }}
       {% end %}
@@ -318,40 +317,6 @@
   <section class="elbysodic-network-explore-lanes" aria-label="Relationship browse lanes">
     {% for lane in relationship_lanes %}
     {{ explore_lane(lane.title, lane.summary, lane.href, lane.result_count ~ " " ~ lane.metric_label) }}
-    {% end %}
-  </section>
-
-  <section class="elbysodic-network-two-up" aria-label="Explore support lanes">
-    {% call surface(variant="elevated") %}
-    <div class="elbysodic-network-editorial-panel">
-      <p class="elbysodic-section-kicker">Wanted</p>
-      <h2>Open roles and ties across the network.</h2>
-      <div class="elbysodic-network-casting-list">
-        {% for program in explore_programs %}
-        {% if program.open_wanted_count %}
-        <a href="{{ program.entry_href }}/wanted">
-          <strong>{{ program.community.name }}</strong>
-          <span>{{ program.open_wanted_count }} wanted hooks</span>
-        </a>
-        {% end %}
-        {% end %}
-      </div>
-    </div>
-    {% end %}
-
-    {% call surface(variant="elevated") %}
-    <div class="elbysodic-network-editorial-panel">
-      <p class="elbysodic-section-kicker">Start here</p>
-      <h2>Realms you can read before you apply.</h2>
-      <div class="elbysodic-network-casting-list">
-        {% for program in explore_programs %}
-        <a href="{{ program.entry_href }}">
-          <strong>{{ program.community.name }}</strong>
-          <span>{{ program.application_posture_label }} · {{ program.invite_posture_label }}</span>
-        </a>
-        {% end %}
-      </div>
-    </div>
     {% end %}
   </section>
   {% else %}

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -148,7 +148,7 @@
 </section>
 {% end %}
 
-{% def home_realm_tile(program, variant="landscape") %}
+{% def home_realm_tile(program, variant="landscape", rank=none) %}
 <article class="elbysodic-network-home-tile elbysodic-network-home-tile--{{ variant }}"
          style="--elbysodic-network-accent: {{ program.theme_preview.accent }};">
   <a href="{{ program.entry_href }}" aria-label="Preview {{ program.community.name }}">
@@ -156,6 +156,9 @@
     <img src="{{ program.community.world_hero_image_url }}" alt="{{ program.community.world_hero_image_alt }}">
     {% else %}
     <span class="elbysodic-network-home-tile__fallback" aria-hidden="true">{{ program.monogram }}</span>
+    {% end %}
+    {% if rank %}
+    <span class="elbysodic-network-home-tile__rank" aria-label="Rank {{ rank }}">{{ "%02d" % rank }}</span>
     {% end %}
     <span class="elbysodic-network-home-tile__shade" aria-hidden="true"></span>
     <span class="elbysodic-network-home-tile__copy">
@@ -188,7 +191,7 @@
   </div>
   <div class="elbysodic-network-home-rail elbysodic-network-home-rail--portrait">
     {% for program in programs %}
-    {{ home_realm_tile(program, "portrait") }}
+    {{ home_realm_tile(program, "portrait", loop.index) }}
     {% end %}
   </div>
 </section>

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -367,20 +367,6 @@
   {{ home_slice(slice.title, slice.href, slice.programs) }}
   {% end %}
 
-  <section class="elbysodic-network-home-genres" aria-label="Genre slices">
-    {% for facet in browse_facets %}
-    <a href="{{ facet.href }}">{{ facet.label }}{% if facet.result_count %} · {{ facet.result_count }}{% end %}</a>
-    {% end %}
-  </section>
-
-  {% if filter_groups %}
-  <section class="elbysodic-network-filter-panel" aria-label="Explore by discovery profile">
-    {% for group in filter_groups %}
-    {{ explore_filter_group(group) }}
-    {% end %}
-  </section>
-  {% end %}
-
   {% if return_path %}
   <section class="elbysodic-network-home-return" aria-label="Signed-in return">
     <div>
@@ -418,6 +404,11 @@
         <button class="elbysodic-network-search__submit" type="submit">Search</button>
       </div>
     </form>
+    <div class="elbysodic-network-home-genres" aria-label="Genre slices">
+      {% for facet in browse_facets %}
+      <a href="{{ facet.href }}">{{ facet.label }}{% if facet.result_count %}<span>{{ facet.result_count }}</span>{% end %}</a>
+      {% end %}
+    </div>
   </section>
   {% end %}
   {% else %}

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -322,20 +322,12 @@
   {% else %}
   {{ home_showcase(featured) }}
 
-  <section class="elbysodic-network-strip" aria-label="Studio network totals">
-    <div>
-      <p class="elbysodic-section-kicker">Elbysodic</p>
-      <h2>Play-by-post realms with faces, scenes, wanted hooks, and continuity.</h2>
-    </div>
-    <div class="elbysodic-network-strip__metrics">
-      {{ metric_item(home_slices[0].programs | length, "realms") }}
-    </div>
-  </section>
-
-  {{ home_portrait_slice(home_slices[0].title, home_slices[0].href, home_slices[0].programs) }}
-  {% for slice in home_slices[1:] %}
-  {{ home_slice(slice.title, slice.href, slice.programs) }}
-  {% end %}
+  <div class="elbysodic-network-home-stack">
+    {{ home_portrait_slice(home_slices[0].title, home_slices[0].href, home_slices[0].programs) }}
+    {% for slice in home_slices[1:] %}
+    {{ home_slice(slice.title, slice.href, slice.programs) }}
+    {% end %}
+  </div>
 
   {% end %}
   {% else %}

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -163,7 +163,9 @@
     <span class="elbysodic-network-home-tile__shade" aria-hidden="true"></span>
     <span class="elbysodic-network-home-tile__copy">
       <strong>{{ program.community.name }}</strong>
+      {% if variant == "portrait" %}
       <span>{{ program.open_wanted_count }} wanted · {{ program.roster_count }} faces</span>
+      {% endif %}
     </span>
   </a>
 </article>

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -194,9 +194,12 @@
 </section>
 {% end %}
 
-{% def explore_tag(label, href, tone="neutral") %}
+{% def explore_tag(label, href, tone="neutral", count=none) %}
 <a class="elbysodic-network-explore-tag elbysodic-network-explore-tag--{{ tone }}" href="{{ href }}">
   <span>{{ label }}</span>
+  {% if count %}
+  <em>{{ count }}</em>
+  {% end %}
 </a>
 {% end %}
 
@@ -205,12 +208,7 @@
   <h2>{{ group.title }}</h2>
   <div class="elbysodic-network-filter-group__options">
     {% for option in group.options %}
-    <a class="elbysodic-network-explore-tag elbysodic-network-explore-tag--{{ option.tone }}" href="{{ option.href }}">
-      <span>{{ option.label }}</span>
-      {% if option.result_count %}
-      <em>{{ option.result_count }}</em>
-      {% end %}
-    </a>
+    {{ explore_tag(option.label, option.href, option.tone, option.result_count) }}
     {% end %}
   </div>
 </section>
@@ -256,21 +254,7 @@
 
   <section class="elbysodic-network-explore-map" aria-label="Explore by tag relationship">
     {% for facet in browse_facets %}
-    {{ explore_tag(facet.label ~ (" (" ~ facet.result_count ~ ")" if facet.result_count else ""), facet.href, facet.tone) }}
-    {% end %}
-  </section>
-
-  {% if filter_groups %}
-  <section class="elbysodic-network-filter-panel" aria-label="Explore by discovery profile">
-    {% for group in filter_groups %}
-    {{ explore_filter_group(group) }}
-    {% end %}
-  </section>
-  {% end %}
-
-  <section class="elbysodic-network-explore-lanes" aria-label="Relationship browse lanes">
-    {% for lane in relationship_lanes %}
-    {{ explore_lane(lane.title, lane.summary, lane.href, lane.result_count ~ " " ~ lane.metric_label) }}
+    {{ explore_tag(facet.label, facet.href, facet.tone, facet.result_count) }}
     {% end %}
   </section>
 
@@ -309,6 +293,26 @@
     {% call surface(variant="elevated") %}
     <p class="elbysodic-empty-state">No reachable realms match that search yet.</p>
     {% end %}
+    {% end %}
+  </section>
+
+  {% if filter_groups %}
+  <details class="elbysodic-network-filter-drawer">
+    <summary>
+      <span>Browse by fit</span>
+      <em>{{ filter_groups | length }} groups</em>
+    </summary>
+    <section class="elbysodic-network-filter-panel" aria-label="Explore by discovery profile">
+      {% for group in filter_groups %}
+      {{ explore_filter_group(group) }}
+      {% end %}
+    </section>
+  </details>
+  {% end %}
+
+  <section class="elbysodic-network-explore-lanes" aria-label="Relationship browse lanes">
+    {% for lane in relationship_lanes %}
+    {{ explore_lane(lane.title, lane.summary, lane.href, lane.result_count ~ " " ~ lane.metric_label) }}
     {% end %}
   </section>
 

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -370,31 +370,6 @@
   {{ home_slice(slice.title, slice.href, slice.programs) }}
   {% end %}
 
-  <section class="elbysodic-network-explore-panel" aria-labelledby="home-explore-heading">
-    <div class="elbysodic-network-rail__header">
-      <div>
-        <p class="elbysodic-section-kicker">Explore</p>
-        <h2 id="home-explore-heading">Search by premise, pace, hooks, and chapters in motion.</h2>
-      </div>
-      <a class="chirpui-btn chirpui-btn--secondary" href="/network">Open Network</a>
-    </div>
-    <form class="elbysodic-network-search" action="/network" method="get" role="search">
-      <label for="network-home-search">Search story fit</label>
-      <div class="elbysodic-network-search__control">
-        <span class="elbysodic-network-search__scope">Realms</span>
-        <input id="network-home-search"
-               name="q"
-               type="search"
-               placeholder="weird-town mystery, relaxed, forum-first, wanted">
-        <button class="elbysodic-network-search__submit" type="submit">Search</button>
-      </div>
-    </form>
-    <div class="elbysodic-network-home-genres" aria-label="Genre slices">
-      {% for facet in browse_facets %}
-      <a href="{{ facet.href }}">{{ facet.label }}{% if facet.result_count %}<span>{{ facet.result_count }}</span>{% end %}</a>
-      {% end %}
-    </div>
-  </section>
   {% end %}
   {% else %}
   {% call section_header("Studio Network") %}

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -370,24 +370,6 @@
   {{ home_slice(slice.title, slice.href, slice.programs) }}
   {% end %}
 
-  {% if return_path %}
-  <section class="elbysodic-network-home-return" aria-label="Signed-in return">
-    <div>
-      <p class="elbysodic-section-kicker">Return path</p>
-      <h2>Your desk is one click away.</h2>
-    </div>
-    <div class="elbysodic-network-home-return__actions">
-      <a class="chirpui-btn chirpui-btn--secondary" href="{{ return_path.desk_href }}">Open Writer Desk</a>
-      <a class="chirpui-btn chirpui-btn--secondary" href="{{ return_path.notification_href }}">
-        Notifications
-        {% if return_path.unread_notification_count %}
-        · {{ return_path.unread_notification_count }}
-        {% end %}
-      </a>
-    </div>
-  </section>
-  {% end %}
-
   <section class="elbysodic-network-explore-panel" aria-labelledby="home-explore-heading">
     <div class="elbysodic-network-rail__header">
       <div>

--- a/src/elbysodic/web/pages/search/_meta.py
+++ b/src/elbysodic/web/pages/search/_meta.py
@@ -1,0 +1,3 @@
+from chirp.pages.types import RouteMeta
+
+META = RouteMeta(title="Search", breadcrumb_label="Search")

--- a/src/elbysodic/web/pages/search/page.html
+++ b/src/elbysodic/web/pages/search/page.html
@@ -1,0 +1,81 @@
+{% imports %}
+  {% from "chirpui/layout.html" import container, stack %}
+  {% from "chirpui/surface.html" import surface %}
+{% end %}
+
+{% def scoped_search_form(search) %}
+<form class="elbysodic-scoped-search" action="{{ search.action_href }}" method="get" role="search">
+  <label for="scoped-search-input">Search {{ search.scope_label }}</label>
+  <div class="elbysodic-scoped-search__control">
+    <span>{{ search.scope_label }}</span>
+    <input id="scoped-search-input"
+           name="q"
+           type="search"
+           value="{{ search.query }}"
+           placeholder="{{ "premise, pace, hooks" if search.scope_kind == "global" else "places, scenes, faces, hooks" }}">
+    <button type="submit">Search</button>
+  </div>
+</form>
+{% end %}
+
+{% block page_root %}
+<div id="page-root">
+{% block page_root_inner %}
+{% block page_content %}
+{% call container(max_width="72rem") %}
+{% call stack(gap="lg") %}
+<section class="elbysodic-search-hero" aria-labelledby="search-heading">
+  <div>
+    <p class="elbysodic-section-kicker">{{ "All realms" if scoped_search.scope_kind == "global" else "Current realm" }}</p>
+    <h1 id="search-heading">Search {{ scoped_search.scope_label }}</h1>
+  </div>
+  {{ scoped_search_form(scoped_search) }}
+  {% if scoped_search.broaden_href %}
+  <a class="elbysodic-search-hero__broaden"
+     href="{{ scoped_search.broaden_href }}"
+     data-elbysodic-global-link>Search all realms</a>
+  {% end %}
+</section>
+
+{% if scoped_search.query %}
+  {% if scoped_search.sections %}
+  <section class="elbysodic-search-results" aria-label="Search results">
+    <div class="elbysodic-search-results__summary">
+      <strong>{{ scoped_search.result_count }}</strong>
+      <span>{{ "result" if scoped_search.result_count == 1 else "results" }} for "{{ scoped_search.query }}"</span>
+    </div>
+    {% for section in scoped_search.sections %}
+    <section class="elbysodic-search-section" aria-labelledby="search-section-{{ loop.index }}">
+      <h2 id="search-section-{{ loop.index }}">{{ section.title }}</h2>
+      <div class="elbysodic-search-list">
+        {% for result in section.results %}
+        <a class="elbysodic-search-result" href="{{ result.href }}">
+          <span>
+            <strong>{{ result.title }}</strong>
+            <small>{{ result.summary }}</small>
+          </span>
+          {% if result.meta %}
+          <em>{{ result.meta }}</em>
+          {% end %}
+        </a>
+        {% end %}
+      </div>
+    </section>
+    {% end %}
+  </section>
+  {% else %}
+  {% call surface(variant="elevated") %}
+  <p class="elbysodic-empty-state">No public results match "{{ scoped_search.query }}" here yet.</p>
+  {% end %}
+  {% end %}
+{% else %}
+{% call surface(variant="elevated") %}
+<p class="elbysodic-empty-state">Search from the current scope, or broaden to the network when you need a new realm.</p>
+{% end %}
+{% end %}
+{% end %}
+{% end %}
+{% endblock %}
+</div>
+{% endblock %}
+{% endblock %}

--- a/src/elbysodic/web/pages/search/page.html
+++ b/src/elbysodic/web/pages/search/page.html
@@ -1,6 +1,5 @@
 {% imports %}
   {% from "chirpui/layout.html" import container, stack %}
-  {% from "chirpui/surface.html" import surface %}
 {% end %}
 
 {% def scoped_search_form(search) %}
@@ -27,7 +26,7 @@
 <section class="elbysodic-search-hero" aria-labelledby="search-heading">
   <div>
     <p class="elbysodic-section-kicker">{{ "All realms" if scoped_search.scope_kind == "global" else "Current realm" }}</p>
-    <h1 id="search-heading">Search {{ scoped_search.scope_label }}</h1>
+    <h1 id="search-heading">Search</h1>
   </div>
   {{ scoped_search_form(scoped_search) }}
   {% if scoped_search.broaden_href %}
@@ -46,7 +45,10 @@
     </div>
     {% for section in scoped_search.sections %}
     <section class="elbysodic-search-section" aria-labelledby="search-section-{{ loop.index }}">
-      <h2 id="search-section-{{ loop.index }}">{{ section.title }}</h2>
+      <div class="elbysodic-search-section__header">
+        <h2 id="search-section-{{ loop.index }}">{{ section.title }}</h2>
+        <span>{{ section.results | length }}</span>
+      </div>
       <div class="elbysodic-search-list">
         {% for result in section.results %}
         <a class="elbysodic-search-result" href="{{ result.href }}">
@@ -64,14 +66,26 @@
     {% end %}
   </section>
   {% else %}
-  {% call surface(variant="elevated") %}
-  <p class="elbysodic-empty-state">No public results match "{{ scoped_search.query }}" here yet.</p>
-  {% end %}
+  <section class="elbysodic-search-empty" aria-label="No search results">
+    <h2>No matches yet</h2>
+    <p>Try fewer words, a place name, a face, or a premise phrase.</p>
+    {% if scoped_search.broaden_href %}
+    <a href="{{ scoped_search.broaden_href }}" data-elbysodic-global-link>Search all realms</a>
+    {% else %}
+    <a href="/network">Browse realms</a>
+    {% end %}
+  </section>
   {% end %}
 {% else %}
-{% call surface(variant="elevated") %}
-<p class="elbysodic-empty-state">Search from the current scope, or broaden to the network when you need a new realm.</p>
-{% end %}
+<section class="elbysodic-search-empty" aria-label="Search prompt">
+  <h2>Start with a few words</h2>
+  <p>{{ "Try a premise, pace, hook, or roster shape." if scoped_search.scope_kind == "global" else "Try a place, scene, face, hook, or guidebook title." }}</p>
+  {% if scoped_search.broaden_href %}
+  <a href="{{ scoped_search.broaden_href }}" data-elbysodic-global-link>Search all realms</a>
+  {% else %}
+  <a href="/network">Browse realms</a>
+  {% end %}
+</section>
 {% end %}
 {% end %}
 {% end %}

--- a/src/elbysodic/web/pages/search/page.py
+++ b/src/elbysodic/web/pages/search/page.py
@@ -1,0 +1,49 @@
+"""Scoped public search surface."""
+
+from __future__ import annotations
+
+from chirp.errors import HTTPError
+from chirp.http.request import Request
+from chirp.templating.returns import Page
+
+from elbysodic.services.forum import AppServices
+from elbysodic.services.read_models import ForumView
+from elbysodic.web.state import get_services
+from elbysodic.web.tenant import request_tenant_slug
+
+
+def get(request: Request) -> Page:
+    query = str(request.query.get("q") or "").strip()
+    tenant_slug = request_tenant_slug(request)
+    services, viewer = _search_services(request)
+    try:
+        search = (
+            services.community_search(tenant_slug, query)
+            if tenant_slug is not None
+            else services.global_search(query)
+        )
+        community = (
+            services.public_studio_program(tenant_slug).community
+            if tenant_slug is not None
+            else None
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    return Page.mounted(
+        "search/page.html",
+        current_path=request.url,
+        page_title=f"Search · {search.scope_label}",
+        viewer=viewer,
+        community=community,
+        scoped_search=search,
+        search_query=query,
+        show_community_shell=viewer is not None and tenant_slug is not None,
+    )
+
+
+def _search_services(request: Request) -> tuple[AppServices, ForumView | None]:
+    try:
+        services = get_services(request)
+        return services, services.viewer()
+    except LookupError, PermissionError:
+        return get_services(), None

--- a/src/elbysodic/web/static/elbysodic-theme/20-shell.css
+++ b/src/elbysodic/web/static/elbysodic-theme/20-shell.css
@@ -696,10 +696,10 @@
     border-radius: 999px;
     cursor: pointer;
     display: flex;
-    gap: 0.4rem;
+    gap: 0.18rem;
     list-style: none;
-    min-block-size: 2.05rem;
-    padding: 0.18rem 0.48rem 0.18rem 0.28rem;
+    min-block-size: 2.18rem;
+    padding: 0.16rem 0.4rem 0.16rem 0.16rem;
 }
 
 .elbysodic-identity-menu__summary::-webkit-details-marker {
@@ -711,24 +711,17 @@
 }
 
 .elbysodic-identity-menu__summary::after {
-    border-left: 0.27rem solid transparent;
-    border-right: 0.27rem solid transparent;
-    border-top: 0.3rem solid var(--chirpui-text-muted);
+    border-left: 0.22rem solid transparent;
+    border-right: 0.22rem solid transparent;
+    border-top: 0.25rem solid var(--chirpui-text-muted);
     content: "";
-    margin-inline-start: 0.05rem;
+    margin-inline-start: 0.02rem;
 }
 
 .elbysodic-identity-menu[open] .elbysodic-identity-menu__summary,
 .elbysodic-identity-menu__summary:hover {
     background: color-mix(in srgb, var(--chirpui-accent) 10%, var(--chirpui-surface));
     border-color: var(--chirpui-border-strong);
-}
-
-.elbysodic-identity-menu__avatar-stack {
-    align-items: end;
-    display: inline-grid;
-    grid-template-columns: 1.34rem 0.5rem;
-    grid-template-rows: 1.34rem 0.5rem;
 }
 
 .elbysodic-identity-menu__summary-badge {
@@ -741,15 +734,15 @@
     font-size: var(--chirpui-font-xs);
     font-weight: 900;
     justify-content: center;
-    margin-inline-start: -0.45rem;
-    min-width: 1.18rem;
-    padding: 0.01rem 0.24rem;
+    margin-inline-start: -0.62rem;
+    margin-block-start: -0.85rem;
+    min-width: 1.12rem;
+    padding: 0 0.22rem;
     position: relative;
-    z-index: 1;
+    z-index: 2;
 }
 
-.elbysodic-identity-menu__writer-avatar,
-.elbysodic-identity-menu__face-avatar {
+.elbysodic-identity-menu__summary-avatar {
     align-items: center;
     aspect-ratio: 1;
     background:
@@ -763,61 +756,22 @@
     justify-content: center;
     overflow: hidden;
     text-decoration: none;
-}
-
-.elbysodic-identity-menu__writer-avatar {
     font-size: var(--chirpui-font-sm);
-    grid-column: 1 / 3;
-    grid-row: 1 / 3;
-    width: 1.64rem;
+    inline-size: 1.8rem;
 }
 
-.elbysodic-identity-menu__face-avatar {
-    background: color-mix(in srgb, var(--chirpui-accent) 24%, var(--chirpui-surface));
-    border-color: var(--chirpui-bg-subtle);
-    box-shadow: 0 0 0 1px var(--chirpui-border);
-    font-size: 0.6rem;
-    grid-column: 2 / 4;
-    grid-row: 2 / 4;
-    width: 0.88rem;
-}
-
-.elbysodic-identity-menu__face-avatar img {
+.elbysodic-identity-menu__summary-avatar img {
     height: 100%;
     object-fit: cover;
     width: 100%;
 }
 
-.elbysodic-identity-menu__copy {
-    display: grid;
-    gap: 0;
-    min-width: 0;
-}
-
-.elbysodic-identity-menu__label,
 .elbysodic-identity-menu__kicker {
     color: var(--chirpui-text-muted);
     font-size: var(--chirpui-font-xs);
     font-weight: 900;
     line-height: 1;
     text-transform: uppercase;
-}
-
-.elbysodic-identity-menu__face {
-    color: var(--chirpui-text);
-    font-size: var(--chirpui-font-xs);
-    font-weight: 800;
-    line-height: 1.1;
-    max-inline-size: 6.8rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.elbysodic-identity-menu__role {
-    color: var(--chirpui-text-muted);
-    font-size: var(--chirpui-font-xs);
-    font-weight: 800;
 }
 
 .elbysodic-identity-menu__panel {
@@ -1208,13 +1162,8 @@
         max-width: min(14rem, 58vw);
     }
 
-    .elbysodic-identity-menu__copy {
-        display: none;
-        min-width: 0;
-    }
-
     .elbysodic-identity-menu__summary {
-        gap: 0.35rem;
+        gap: 0.18rem;
         padding-inline-end: 0.45rem;
     }
 

--- a/src/elbysodic/web/static/elbysodic-theme/20-shell.css
+++ b/src/elbysodic/web/static/elbysodic-theme/20-shell.css
@@ -615,6 +615,64 @@
     padding: 0.02rem 0.35rem;
 }
 
+.elbysodic-topbar-search {
+    align-items: center;
+    background: color-mix(in srgb, var(--chirpui-bg-subtle) 86%, transparent);
+    border: 1px solid color-mix(in srgb, var(--chirpui-border) 78%, transparent);
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    flex: 1 1 22rem;
+    grid-template-columns: auto minmax(8rem, 1fr) auto;
+    max-inline-size: 34rem;
+    min-inline-size: 16rem;
+    overflow: hidden;
+}
+
+.elbysodic-topbar-search__scope {
+    align-items: center;
+    border-inline-end: 1px solid color-mix(in srgb, var(--chirpui-border) 78%, transparent);
+    color: var(--chirpui-text-muted);
+    display: inline-flex;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+    max-inline-size: 8.5rem;
+    min-block-size: 2.15rem;
+    overflow: hidden;
+    padding-inline: 0.65rem;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.elbysodic-topbar-search input {
+    background: transparent;
+    border: 0;
+    color: var(--chirpui-text);
+    font: inherit;
+    font-size: var(--chirpui-font-sm);
+    min-block-size: 2.15rem;
+    min-width: 0;
+    padding: 0.35rem 0.65rem;
+}
+
+.elbysodic-topbar-search button {
+    background: color-mix(in srgb, var(--chirpui-accent) 88%, var(--chirpui-text));
+    border: 0;
+    border-inline-start: 1px solid color-mix(in srgb, var(--chirpui-border) 72%, transparent);
+    color: var(--chirpui-on-accent);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--chirpui-font-sm);
+    font-weight: 900;
+    min-block-size: 2.15rem;
+    padding-inline: 0.75rem;
+}
+
+.elbysodic-topbar-search button:hover,
+.elbysodic-topbar-search button:focus-visible {
+    background: color-mix(in srgb, var(--chirpui-accent) 78%, var(--chirpui-text));
+}
+
 .elbysodic-shell-identity {
     align-items: center;
     display: flex;
@@ -1121,6 +1179,17 @@
         overflow-y: hidden;
         padding-bottom: 0.1rem;
         scrollbar-width: thin;
+    }
+
+    .elbysodic-topbar-search {
+        flex: 1 1 auto;
+        grid-template-columns: minmax(0, 1fr) auto;
+        max-inline-size: none;
+        min-inline-size: 0;
+    }
+
+    .elbysodic-topbar-search__scope {
+        display: none;
     }
 
     .elbysodic-shell-identity {

--- a/src/elbysodic/web/static/elbysodic-theme/20-shell.css
+++ b/src/elbysodic/web/static/elbysodic-theme/20-shell.css
@@ -621,10 +621,10 @@
     border: 1px solid color-mix(in srgb, var(--chirpui-border) 78%, transparent);
     border-radius: var(--chirpui-radius-sm);
     display: grid;
-    flex: 1 1 22rem;
+    flex: 0 1 28rem;
     grid-template-columns: auto minmax(8rem, 1fr) auto;
-    max-inline-size: 34rem;
-    min-inline-size: 16rem;
+    max-inline-size: 30rem;
+    min-inline-size: 14rem;
     overflow: hidden;
 }
 
@@ -636,7 +636,7 @@
     font-size: var(--chirpui-font-xs);
     font-weight: 900;
     max-inline-size: 8.5rem;
-    min-block-size: 2.15rem;
+    min-block-size: 2rem;
     overflow: hidden;
     padding-inline: 0.65rem;
     text-overflow: ellipsis;
@@ -650,7 +650,7 @@
     color: var(--chirpui-text);
     font: inherit;
     font-size: var(--chirpui-font-sm);
-    min-block-size: 2.15rem;
+    min-block-size: 2rem;
     min-width: 0;
     padding: 0.35rem 0.65rem;
 }
@@ -664,8 +664,8 @@
     font: inherit;
     font-size: var(--chirpui-font-sm);
     font-weight: 900;
-    min-block-size: 2.15rem;
-    padding-inline: 0.75rem;
+    min-block-size: 2rem;
+    padding-inline: 0.65rem;
 }
 
 .elbysodic-topbar-search button:hover,
@@ -1074,6 +1074,18 @@
     border-radius: var(--chirpui-radius-full);
     height: 0.45rem;
     width: 0.45rem;
+}
+
+@media (max-width: 68rem) {
+    .elbysodic-topbar-search {
+        flex-basis: 18rem;
+        grid-template-columns: minmax(0, 1fr) auto;
+        min-inline-size: 10rem;
+    }
+
+    .elbysodic-topbar-search__scope {
+        display: none;
+    }
 }
 
 @media (max-width: 48rem) {

--- a/src/elbysodic/web/static/elbysodic-theme/47-network-catalog.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network-catalog.css
@@ -126,6 +126,161 @@
     background: color-mix(in srgb, var(--elbysodic-atmosphere-dye) 82%, var(--chirpui-text));
 }
 
+.elbysodic-search-hero {
+    align-items: end;
+    border-bottom: 1px solid var(--chirpui-border);
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.7fr) auto;
+    padding-block: 1rem 1.4rem;
+}
+
+.elbysodic-search-hero h1 {
+    font-size: clamp(2.2rem, 5vw, 4rem);
+    line-height: 0.98;
+    margin: 0;
+}
+
+.elbysodic-search-hero__broaden {
+    align-self: end;
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-sm);
+    font-weight: 800;
+    text-decoration: none;
+}
+
+.elbysodic-search-hero__broaden:hover,
+.elbysodic-search-hero__broaden:focus-visible {
+    color: var(--chirpui-text);
+}
+
+.elbysodic-scoped-search {
+    display: grid;
+    gap: 0.45rem;
+    min-width: 0;
+}
+
+.elbysodic-scoped-search label {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-sm);
+    font-weight: 800;
+}
+
+.elbysodic-scoped-search__control {
+    align-items: stretch;
+    background: var(--chirpui-surface);
+    border: 1px solid var(--chirpui-border);
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    overflow: hidden;
+}
+
+.elbysodic-scoped-search__control span {
+    align-items: center;
+    border-inline-end: 1px solid var(--chirpui-border);
+    color: var(--chirpui-text-muted);
+    display: inline-flex;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+    max-inline-size: 11rem;
+    overflow: hidden;
+    padding-inline: 0.7rem;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.elbysodic-scoped-search__control input {
+    background: transparent;
+    border: 0;
+    color: var(--chirpui-text);
+    font: inherit;
+    min-block-size: 2.7rem;
+    min-width: 0;
+    padding: 0.65rem 0.8rem;
+}
+
+.elbysodic-scoped-search__control button {
+    background: color-mix(in srgb, var(--chirpui-accent) 86%, var(--chirpui-text));
+    border: 0;
+    border-inline-start: 1px solid var(--chirpui-border);
+    color: var(--chirpui-on-accent);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 900;
+    padding-inline: 1rem;
+}
+
+.elbysodic-search-results {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.elbysodic-search-results__summary {
+    align-items: baseline;
+    color: var(--chirpui-text-muted);
+    display: flex;
+    gap: 0.45rem;
+}
+
+.elbysodic-search-results__summary strong {
+    color: var(--chirpui-text);
+    font-size: var(--chirpui-font-xl);
+}
+
+.elbysodic-search-section {
+    display: grid;
+    gap: 0.7rem;
+}
+
+.elbysodic-search-section h2 {
+    font-size: var(--chirpui-font-xl);
+    margin: 0;
+}
+
+.elbysodic-search-list {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.elbysodic-search-result {
+    align-items: center;
+    background: var(--chirpui-surface);
+    border: 1px solid var(--chirpui-border);
+    border-radius: var(--chirpui-radius-sm);
+    color: var(--chirpui-text);
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 0.85rem 1rem;
+    text-decoration: none;
+}
+
+.elbysodic-search-result:hover,
+.elbysodic-search-result:focus-visible {
+    border-color: var(--chirpui-accent);
+}
+
+.elbysodic-search-result span {
+    display: grid;
+    gap: 0.18rem;
+    min-width: 0;
+}
+
+.elbysodic-search-result small,
+.elbysodic-search-result em {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-sm);
+    line-height: 1.4;
+}
+
+.elbysodic-search-result em {
+    font-style: normal;
+    font-weight: 800;
+    white-space: nowrap;
+}
+
 .elbysodic-network-discovery-band {
     display: flex;
     flex-wrap: wrap;

--- a/src/elbysodic/web/static/elbysodic-theme/47-network-catalog.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network-catalog.css
@@ -355,10 +355,11 @@
     color: var(--chirpui-accent);
 }
 
-.elbysodic-network-explore-map {
+.elbysodic-network-filter-drawer__chips {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    grid-column: 1 / -1;
 }
 
 .elbysodic-network-explore-tag {
@@ -706,42 +707,6 @@
     background: color-mix(in srgb, var(--elbysodic-network-accent) 14%, var(--chirpui-surface));
     border-color: color-mix(in srgb, var(--elbysodic-network-accent) 56%, var(--chirpui-border));
     color: var(--chirpui-text);
-}
-
-.elbysodic-network-editorial-panel {
-    display: grid;
-    gap: 1rem;
-    padding: 1rem;
-}
-
-.elbysodic-network-editorial-panel h2 {
-    color: var(--chirpui-text);
-    font-family: var(--elbysodic-display-font-family);
-    font-size: 1.8rem;
-    letter-spacing: 0;
-    line-height: 1;
-    margin: 0;
-}
-
-.elbysodic-network-casting-list {
-    display: grid;
-    gap: 0.55rem;
-}
-
-.elbysodic-network-casting-list a {
-    align-items: center;
-    border-block-start: 1px solid var(--chirpui-border);
-    color: var(--chirpui-text);
-    display: flex;
-    gap: 0.75rem;
-    justify-content: space-between;
-    padding-block-start: 0.55rem;
-    text-decoration: none;
-}
-
-.elbysodic-network-casting-list span {
-    color: var(--chirpui-text-muted);
-    font-size: var(--chirpui-font-sm);
 }
 
 .elbysodic-network-mood-grid {

--- a/src/elbysodic/web/static/elbysodic-theme/47-network-catalog.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network-catalog.css
@@ -131,12 +131,13 @@
     border-bottom: 1px solid var(--chirpui-border);
     display: grid;
     gap: 1rem;
-    grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.7fr) auto;
+    grid-template-columns: minmax(0, 0.56fr) minmax(20rem, 0.92fr) auto;
     padding-block: 1rem 1.4rem;
 }
 
 .elbysodic-search-hero h1 {
-    font-size: clamp(2.2rem, 5vw, 4rem);
+    color: var(--chirpui-text);
+    font-size: clamp(2.4rem, 7vw, 5.4rem);
     line-height: 0.98;
     margin: 0;
 }
@@ -214,7 +215,7 @@
 
 .elbysodic-search-results {
     display: grid;
-    gap: 1.5rem;
+    gap: 1.4rem;
 }
 
 .elbysodic-search-results__summary {
@@ -234,26 +235,42 @@
     gap: 0.7rem;
 }
 
+.elbysodic-search-section__header {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+}
+
 .elbysodic-search-section h2 {
     font-size: var(--chirpui-font-xl);
     margin: 0;
 }
 
+.elbysodic-search-section__header span {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-sm);
+    font-weight: 900;
+}
+
 .elbysodic-search-list {
     display: grid;
-    gap: 0.45rem;
+    gap: 0.65rem;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
 }
 
 .elbysodic-search-result {
-    align-items: center;
-    background: var(--chirpui-surface);
-    border: 1px solid var(--chirpui-border);
+    align-content: space-between;
+    background:
+        linear-gradient(135deg, color-mix(in srgb, var(--chirpui-accent) 8%, transparent), transparent 62%),
+        var(--chirpui-surface);
+    border: 1px solid color-mix(in srgb, var(--chirpui-border) 88%, transparent);
     border-radius: var(--chirpui-radius-sm);
     color: var(--chirpui-text);
     display: grid;
-    gap: 0.75rem;
-    grid-template-columns: minmax(0, 1fr) auto;
-    padding: 0.85rem 1rem;
+    gap: 1rem;
+    min-block-size: 8rem;
+    padding: 1rem;
     text-decoration: none;
 }
 
@@ -264,8 +281,13 @@
 
 .elbysodic-search-result span {
     display: grid;
-    gap: 0.18rem;
+    gap: 0.32rem;
     min-width: 0;
+}
+
+.elbysodic-search-result strong {
+    font-size: var(--chirpui-font-lg);
+    line-height: 1.1;
 }
 
 .elbysodic-search-result small,
@@ -276,9 +298,38 @@
 }
 
 .elbysodic-search-result em {
+    justify-self: start;
     font-style: normal;
     font-weight: 800;
     white-space: nowrap;
+}
+
+.elbysodic-search-empty {
+    background:
+        linear-gradient(135deg, color-mix(in srgb, var(--chirpui-accent) 8%, transparent), transparent 64%),
+        var(--chirpui-surface);
+    border: 1px solid var(--chirpui-border);
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    gap: 0.6rem;
+    padding: clamp(1rem, 3vw, 1.5rem);
+}
+
+.elbysodic-search-empty h2 {
+    font-size: var(--chirpui-font-xl);
+    margin: 0;
+}
+
+.elbysodic-search-empty p {
+    color: var(--chirpui-text-muted);
+    line-height: 1.5;
+    margin: 0;
+}
+
+.elbysodic-search-empty a {
+    color: var(--chirpui-text);
+    font-weight: 900;
+    text-decoration: none;
 }
 
 .elbysodic-network-discovery-band {

--- a/src/elbysodic/web/static/elbysodic-theme/47-network-catalog.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network-catalog.css
@@ -150,35 +150,34 @@
 }
 
 .elbysodic-network-explore-map {
-    display: grid;
-    gap: 0.55rem;
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 10rem), 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
 .elbysodic-network-explore-tag {
-    align-items: end;
+    align-items: center;
     background:
         linear-gradient(135deg, color-mix(in srgb, var(--chirpui-accent) 10%, transparent), transparent 58%),
         var(--chirpui-surface);
     border: 1px solid var(--chirpui-border);
-    border-radius: var(--chirpui-radius-sm);
+    border-radius: 999px;
     color: var(--chirpui-text);
-    display: grid;
-    font-family: var(--elbysodic-display-font-family);
-    font-size: 1.1rem;
-    line-height: 1;
-    min-block-size: 6rem;
-    padding: 0.8rem;
+    display: inline-flex;
+    font-size: var(--chirpui-font-sm);
+    font-weight: 750;
+    gap: 0.45rem;
+    line-height: 1.15;
+    min-block-size: 2.35rem;
+    padding: 0.5rem 0.7rem;
     text-decoration: none;
 }
 
 .elbysodic-network-explore-tag em {
     color: var(--chirpui-text-muted);
-    font-family: var(--chirpui-font-family);
     font-size: var(--chirpui-font-xs);
     font-style: normal;
     font-weight: 850;
-    justify-self: end;
 }
 
 .elbysodic-network-explore-tag--hot {
@@ -194,10 +193,39 @@
     color: var(--chirpui-accent);
 }
 
+.elbysodic-network-filter-drawer {
+    background: color-mix(in srgb, var(--chirpui-surface) 88%, transparent);
+    border: 1px solid color-mix(in srgb, var(--chirpui-border) 72%, transparent);
+    border-radius: var(--chirpui-radius-sm);
+}
+
+.elbysodic-network-filter-drawer summary {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: space-between;
+    padding: 0.85rem 1rem;
+}
+
+.elbysodic-network-filter-drawer summary span {
+    color: var(--chirpui-text);
+    font-weight: 800;
+}
+
+.elbysodic-network-filter-drawer summary em {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-xs);
+    font-style: normal;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
 .elbysodic-network-filter-panel {
     display: grid;
     gap: 1rem;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+    padding: 0 1rem 1rem;
 }
 
 .elbysodic-network-filter-group {
@@ -222,17 +250,7 @@
 }
 
 .elbysodic-network-filter-group__options .elbysodic-network-explore-tag {
-    align-items: center;
-    display: flex;
-    font-family: var(--chirpui-font-family);
-    font-size: var(--chirpui-font-sm);
-    font-weight: 750;
-    gap: 0.5rem;
     justify-content: space-between;
-    line-height: 1.2;
-    min-block-size: 2.6rem;
-    min-inline-size: 0;
-    padding: 0.55rem 0.7rem;
 }
 
 .elbysodic-network-explore-lanes {

--- a/src/elbysodic/web/static/elbysodic-theme/47-network.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network.css
@@ -354,22 +354,31 @@
 }
 
 .elbysodic-network-home-genres {
-    display: grid;
-    gap: 0.7rem;
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 11rem), 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
 }
 
 .elbysodic-network-home-genres a {
-    background: color-mix(in srgb, var(--chirpui-surface) 86%, var(--chirpui-bg));
-    border: 1px solid var(--chirpui-border);
-    border-radius: var(--chirpui-radius-sm);
+    align-items: center;
+    background: color-mix(in srgb, var(--chirpui-surface) 88%, transparent);
+    border: 1px solid color-mix(in srgb, var(--chirpui-border) 78%, transparent);
+    border-radius: 999px;
     color: var(--chirpui-text);
-    font-family: var(--elbysodic-display-font-family);
-    font-size: 1.1rem;
-    line-height: 1;
-    min-block-size: 5.5rem;
-    padding: 1rem;
+    display: inline-flex;
+    font-size: var(--chirpui-font-sm);
+    font-weight: 750;
+    gap: 0.35rem;
+    line-height: 1.1;
+    min-block-size: 2.25rem;
+    padding: 0.45rem 0.65rem;
     text-decoration: none;
+}
+
+.elbysodic-network-home-genres a span {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-xs);
+    font-weight: 850;
 }
 
 .elbysodic-network-home-genres a:hover,

--- a/src/elbysodic/web/static/elbysodic-theme/47-network.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network.css
@@ -221,11 +221,6 @@
     gap: 0.5rem;
 }
 
-.elbysodic-network-explore-panel {
-    display: grid;
-    gap: 0.9rem;
-}
-
 .elbysodic-network-home-slice {
     display: grid;
     gap: 0.8rem;
@@ -238,8 +233,7 @@
     justify-content: space-between;
 }
 
-.elbysodic-network-home-slice__header h2,
-.elbysodic-network-explore-panel h2 {
+.elbysodic-network-home-slice__header h2 {
     color: var(--chirpui-text);
     font-family: var(--elbysodic-display-font-family);
     font-size: 1.8rem;
@@ -370,40 +364,6 @@
     color: var(--elbysodic-on-media-muted);
     font-size: var(--chirpui-font-sm);
     font-weight: 750;
-}
-
-.elbysodic-network-home-genres {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.45rem;
-}
-
-.elbysodic-network-home-genres a {
-    align-items: center;
-    background: color-mix(in srgb, var(--chirpui-surface) 88%, transparent);
-    border: 1px solid color-mix(in srgb, var(--chirpui-border) 78%, transparent);
-    border-radius: 999px;
-    color: var(--chirpui-text);
-    display: inline-flex;
-    font-size: var(--chirpui-font-sm);
-    font-weight: 750;
-    gap: 0.35rem;
-    line-height: 1.1;
-    min-block-size: 2.25rem;
-    padding: 0.45rem 0.65rem;
-    text-decoration: none;
-}
-
-.elbysodic-network-home-genres a span {
-    color: var(--chirpui-text-muted);
-    font-size: var(--chirpui-font-xs);
-    font-weight: 850;
-}
-
-.elbysodic-network-home-genres a:hover,
-.elbysodic-network-home-genres a:focus-visible {
-    border-color: var(--chirpui-accent);
-    color: var(--chirpui-accent);
 }
 
 .elbysodic-network-strip {

--- a/src/elbysodic/web/static/elbysodic-theme/47-network.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network.css
@@ -126,7 +126,7 @@
     border: 1px solid var(--chirpui-border);
     border-radius: var(--chirpui-radius);
     display: grid;
-    min-block-size: clamp(28rem, 68vh, 42rem);
+    min-block-size: clamp(27rem, 62vh, 38rem);
     overflow: hidden;
     position: relative;
 }
@@ -150,8 +150,8 @@
 
 .elbysodic-network-home-showcase__shade {
     background:
-        linear-gradient(90deg, rgba(4, 6, 8, 0.9), rgba(4, 6, 8, 0.45) 52%, rgba(4, 6, 8, 0.08)),
-        linear-gradient(0deg, rgba(4, 6, 8, 0.6), rgba(4, 6, 8, 0.08) 58%);
+        linear-gradient(90deg, rgba(4, 6, 8, 0.92), rgba(4, 6, 8, 0.48) 52%, rgba(4, 6, 8, 0.1)),
+        linear-gradient(0deg, rgba(4, 6, 8, 0.58), rgba(4, 6, 8, 0.06) 58%);
     z-index: 1;
 }
 
@@ -173,7 +173,7 @@
 .elbysodic-network-home-showcase h1 {
     color: var(--elbysodic-on-media-text);
     font-family: var(--elbysodic-network-display-font);
-    font-size: clamp(3rem, 8vw, 6.5rem);
+    font-size: clamp(3rem, 7vw, 5.75rem);
     letter-spacing: 0;
     line-height: 0.9;
     margin: 0;
@@ -221,9 +221,14 @@
     gap: 0.5rem;
 }
 
+.elbysodic-network-home-stack {
+    display: grid;
+    gap: clamp(1.4rem, 3vw, 2.2rem);
+}
+
 .elbysodic-network-home-slice {
     display: grid;
-    gap: 0.9rem;
+    gap: 0.75rem;
 }
 
 .elbysodic-network-home-slice__header {
@@ -236,7 +241,7 @@
 .elbysodic-network-home-slice__header h2 {
     color: var(--chirpui-text);
     font-family: var(--elbysodic-display-font-family);
-    font-size: 1.65rem;
+    font-size: 1.45rem;
     letter-spacing: 0;
     line-height: 1;
     margin: 0;
@@ -251,11 +256,12 @@
 
 .elbysodic-network-home-rail {
     display: grid;
-    gap: 0.7rem;
-    grid-auto-columns: clamp(18rem, 26vw, 24rem);
+    gap: 0.8rem;
+    grid-auto-columns: clamp(16.5rem, 24vw, 22rem);
     grid-auto-flow: column;
     overflow-x: auto;
     padding-block-end: 0.35rem;
+    scroll-snap-type: inline proximity;
     scrollbar-width: none;
 }
 
@@ -264,8 +270,8 @@
 }
 
 .elbysodic-network-home-rail--portrait {
-    gap: 0.85rem;
-    grid-auto-columns: clamp(13rem, 18vw, 16.25rem);
+    gap: 0.8rem;
+    grid-auto-columns: clamp(12.25rem, 16vw, 14.75rem);
 }
 
 .elbysodic-network-home-tile {
@@ -274,6 +280,7 @@
     border: 1px solid color-mix(in srgb, var(--elbysodic-network-accent) 16%, var(--chirpui-border));
     border-radius: var(--chirpui-radius-sm);
     overflow: hidden;
+    scroll-snap-align: start;
 }
 
 .elbysodic-network-home-tile a {
@@ -285,7 +292,7 @@
 }
 
 .elbysodic-network-home-tile--portrait a {
-    aspect-ratio: 3 / 4.35;
+    aspect-ratio: 3 / 4.15;
 }
 
 .elbysodic-network-home-tile img,
@@ -327,17 +334,21 @@
 }
 
 .elbysodic-network-home-tile__rank {
+    align-items: center;
     align-self: start;
-    color: color-mix(in srgb, var(--elbysodic-network-accent) 72%, var(--elbysodic-on-media-text));
-    display: block;
-    font-family: var(--elbysodic-display-font-family);
-    font-size: clamp(2.5rem, 5vw, 4.8rem);
-    font-weight: 900;
+    background: rgba(5, 7, 10, 0.62);
+    border: 1px solid color-mix(in srgb, var(--elbysodic-network-accent) 42%, rgba(255, 255, 255, 0.26));
+    border-radius: 999px;
+    color: var(--elbysodic-on-media-text);
+    display: inline-grid;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 850;
+    inline-size: 2.25rem;
     justify-self: end;
-    line-height: 0.75;
-    margin: 0.75rem 0.75rem 0 0;
-    opacity: 0.88;
-    text-shadow: 0 0.35rem 1.6rem rgba(0, 0, 0, 0.42);
+    line-height: 1;
+    margin: 0.6rem 0.6rem 0 0;
+    min-block-size: 2.25rem;
+    place-items: center;
     z-index: 1;
 }
 
@@ -345,7 +356,7 @@
     align-self: end;
     display: grid;
     gap: 0.2rem;
-    padding: 0.9rem;
+    padding: 0.85rem;
     position: relative;
     z-index: 2;
 }
@@ -353,7 +364,7 @@
 .elbysodic-network-home-tile__copy strong {
     color: var(--elbysodic-on-media-text);
     font-family: var(--elbysodic-display-font-family);
-    font-size: 1.28rem;
+    font-size: 1.18rem;
     line-height: 1;
 }
 
@@ -363,16 +374,6 @@
     font-weight: 750;
 }
 
-.elbysodic-network-strip {
-    align-items: end;
-    border-block-end: 1px solid var(--chirpui-border);
-    display: grid;
-    gap: 1rem;
-    grid-template-columns: minmax(0, 1fr) auto;
-    padding: 0.35rem 0 1.25rem;
-}
-
-.elbysodic-network-strip h2,
 .elbysodic-network-rail__header h2 {
     color: var(--chirpui-text);
     font-family: var(--elbysodic-display-font-family);
@@ -380,10 +381,6 @@
     letter-spacing: 0;
     line-height: 1;
     margin: 0;
-}
-
-.elbysodic-network-strip p {
-    margin-block-end: 0;
 }
 
 .elbysodic-network-rail {
@@ -463,12 +460,8 @@
             linear-gradient(90deg, rgba(5, 7, 9, 0.7), rgba(5, 7, 9, 0.16));
     }
 
-    .elbysodic-network-strip {
-        grid-template-columns: 1fr;
-    }
-
     .elbysodic-network-home-showcase {
-        min-block-size: 32rem;
+        min-block-size: 30rem;
     }
 
     .elbysodic-network-home-showcase__copy {

--- a/src/elbysodic/web/static/elbysodic-theme/47-network.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network.css
@@ -223,7 +223,7 @@
 
 .elbysodic-network-home-slice {
     display: grid;
-    gap: 0.8rem;
+    gap: 0.9rem;
 }
 
 .elbysodic-network-home-slice__header {
@@ -236,7 +236,7 @@
 .elbysodic-network-home-slice__header h2 {
     color: var(--chirpui-text);
     font-family: var(--elbysodic-display-font-family);
-    font-size: 1.8rem;
+    font-size: 1.65rem;
     letter-spacing: 0;
     line-height: 1;
     margin: 0;
@@ -251,11 +251,11 @@
 
 .elbysodic-network-home-rail {
     display: grid;
-    gap: 0.8rem;
-    grid-auto-columns: clamp(18rem, 28vw, 26rem);
+    gap: 0.7rem;
+    grid-auto-columns: clamp(18rem, 26vw, 24rem);
     grid-auto-flow: column;
     overflow-x: auto;
-    padding-block-end: 0.25rem;
+    padding-block-end: 0.35rem;
     scrollbar-width: none;
 }
 
@@ -264,19 +264,20 @@
 }
 
 .elbysodic-network-home-rail--portrait {
-    grid-auto-columns: clamp(14rem, 20vw, 18rem);
+    gap: 0.85rem;
+    grid-auto-columns: clamp(13rem, 18vw, 16.25rem);
 }
 
 .elbysodic-network-home-tile {
     --elbysodic-network-accent: var(--elbysodic-atmosphere-dye);
     background: var(--chirpui-surface);
-    border: 1px solid color-mix(in srgb, var(--elbysodic-network-accent) 20%, var(--chirpui-border));
+    border: 1px solid color-mix(in srgb, var(--elbysodic-network-accent) 16%, var(--chirpui-border));
     border-radius: var(--chirpui-radius-sm);
     overflow: hidden;
 }
 
 .elbysodic-network-home-tile a {
-    aspect-ratio: 16 / 10;
+    aspect-ratio: 16 / 9;
     color: var(--elbysodic-on-media-text);
     display: grid;
     position: relative;
@@ -284,7 +285,7 @@
 }
 
 .elbysodic-network-home-tile--portrait a {
-    aspect-ratio: 3 / 4;
+    aspect-ratio: 3 / 4.35;
 }
 
 .elbysodic-network-home-tile img,
@@ -322,41 +323,37 @@
 }
 
 .elbysodic-network-home-tile__shade {
-    background: linear-gradient(0deg, rgba(4, 6, 8, 0.82), rgba(4, 6, 8, 0.06) 62%);
+    background: linear-gradient(0deg, rgba(4, 6, 8, 0.84), rgba(4, 6, 8, 0.04) 68%);
 }
 
 .elbysodic-network-home-tile__rank {
     align-self: start;
-    background: color-mix(in srgb, var(--chirpui-surface) 86%, transparent);
-    border: 1px solid color-mix(in srgb, var(--elbysodic-network-accent) 40%, var(--chirpui-border));
-    border-radius: 999px;
-    color: color-mix(in srgb, var(--elbysodic-network-accent) 68%, var(--chirpui-text));
-    display: grid;
+    color: color-mix(in srgb, var(--elbysodic-network-accent) 72%, var(--elbysodic-on-media-text));
+    display: block;
     font-family: var(--elbysodic-display-font-family);
-    font-size: 1.05rem;
+    font-size: clamp(2.5rem, 5vw, 4.8rem);
     font-weight: 900;
-    inline-size: 2.8rem;
     justify-self: end;
-    line-height: 1;
-    margin: 0.75rem;
-    min-block-size: 2.8rem;
-    place-items: center;
-    z-index: 2;
+    line-height: 0.75;
+    margin: 0.75rem 0.75rem 0 0;
+    opacity: 0.88;
+    text-shadow: 0 0.35rem 1.6rem rgba(0, 0, 0, 0.42);
+    z-index: 1;
 }
 
 .elbysodic-network-home-tile__copy {
     align-self: end;
     display: grid;
     gap: 0.2rem;
-    padding: 0.85rem;
+    padding: 0.9rem;
     position: relative;
-    z-index: 1;
+    z-index: 2;
 }
 
 .elbysodic-network-home-tile__copy strong {
     color: var(--elbysodic-on-media-text);
     font-family: var(--elbysodic-display-font-family);
-    font-size: 1.35rem;
+    font-size: 1.28rem;
     line-height: 1;
 }
 

--- a/src/elbysodic/web/static/elbysodic-theme/47-network.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network.css
@@ -398,8 +398,7 @@
     justify-content: space-between;
 }
 
-.elbysodic-network-continue-grid,
-.elbysodic-network-two-up {
+.elbysodic-network-continue-grid {
     display: grid;
     gap: 0.9rem;
 }
@@ -409,6 +408,8 @@
 }
 
 .elbysodic-network-two-up {
+    display: grid;
+    gap: 0.9rem;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
 }
 

--- a/src/elbysodic/web/static/elbysodic-theme/47-network.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network.css
@@ -296,6 +296,7 @@
 
 .elbysodic-network-home-tile img,
 .elbysodic-network-home-tile__fallback,
+.elbysodic-network-home-tile__rank,
 .elbysodic-network-home-tile__shade,
 .elbysodic-network-home-tile__copy {
     grid-area: 1 / 1;
@@ -329,6 +330,25 @@
 
 .elbysodic-network-home-tile__shade {
     background: linear-gradient(0deg, rgba(4, 6, 8, 0.82), rgba(4, 6, 8, 0.06) 62%);
+}
+
+.elbysodic-network-home-tile__rank {
+    align-self: start;
+    background: color-mix(in srgb, var(--chirpui-surface) 86%, transparent);
+    border: 1px solid color-mix(in srgb, var(--elbysodic-network-accent) 40%, var(--chirpui-border));
+    border-radius: 999px;
+    color: color-mix(in srgb, var(--elbysodic-network-accent) 68%, var(--chirpui-text));
+    display: grid;
+    font-family: var(--elbysodic-display-font-family);
+    font-size: 1.05rem;
+    font-weight: 900;
+    inline-size: 2.8rem;
+    justify-self: end;
+    line-height: 1;
+    margin: 0.75rem;
+    min-block-size: 2.8rem;
+    place-items: center;
+    z-index: 2;
 }
 
 .elbysodic-network-home-tile__copy {

--- a/src/elbysodic/web/static/elbysodic-theme/47-network.css
+++ b/src/elbysodic/web/static/elbysodic-theme/47-network.css
@@ -215,8 +215,7 @@
     font-weight: 900;
 }
 
-.elbysodic-network-home-showcase__actions,
-.elbysodic-network-home-return__actions {
+.elbysodic-network-home-showcase__actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
@@ -407,23 +406,6 @@
     color: var(--chirpui-accent);
 }
 
-.elbysodic-network-home-return {
-    align-items: center;
-    border-block-start: 1px solid var(--chirpui-border);
-    display: flex;
-    gap: 1rem;
-    justify-content: space-between;
-    padding-block-start: 1rem;
-}
-
-.elbysodic-network-home-return h2 {
-    color: var(--chirpui-text);
-    font-family: var(--elbysodic-display-font-family);
-    font-size: 1.4rem;
-    line-height: 1;
-    margin: 0;
-}
-
 .elbysodic-network-strip {
     align-items: end;
     border-block-end: 1px solid var(--chirpui-border);
@@ -523,8 +505,7 @@
             linear-gradient(90deg, rgba(5, 7, 9, 0.7), rgba(5, 7, 9, 0.16));
     }
 
-    .elbysodic-network-strip,
-    .elbysodic-network-home-return {
+    .elbysodic-network-strip {
         grid-template-columns: 1fr;
     }
 
@@ -538,11 +519,6 @@
 
     .elbysodic-network-home-showcase h1 {
         font-size: 3rem;
-    }
-
-    .elbysodic-network-home-return {
-        align-items: start;
-        display: grid;
     }
 
     .elbysodic-network-rail__header {

--- a/src/elbysodic/web/tenant.py
+++ b/src/elbysodic/web/tenant.py
@@ -35,6 +35,7 @@ _SCOPED_PATH_PREFIXES = (
     "/my",
     "/notifications",
     "/plotting",
+    "/search",
     "/studio",
     "/wanted",
     "/world",

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -1901,6 +1901,37 @@ def test_network_explore_search_filters_programs() -> None:
     asyncio.run(run())
 
 
+def test_global_search_renders_public_realm_results() -> None:
+    async def run() -> None:
+        app = _app()
+        async with TestClient(app) as client:
+            response = await client.get("/search?q=magic school")
+
+        assert response.status == 200
+        assert "Search All realms" in response.text
+        assert "HP Universe" in response.text
+        assert "2 wanted · 3 faces" in response.text
+        assert 'href="/c/hp-universe"' in response.text
+
+    asyncio.run(run())
+
+
+def test_community_search_scopes_to_public_realm_results() -> None:
+    async def run() -> None:
+        app = _app()
+        async with TestClient(app) as client:
+            response = await client.get("/c/harbor-society/search?q=ledger")
+
+        assert response.status == 200
+        assert "Search Harbor Society" in response.text
+        assert 'action="/c/harbor-society/search"' in response.text
+        assert 'href="/search?q=ledger"' in response.text
+        assert "The Ledger Page Under Table Six" in response.text
+        assert "Scenes" in response.text
+
+    asyncio.run(run())
+
+
 def test_original_premise_discovery_routes_support_persona_qa() -> None:
     async def run() -> None:
         services = create_services(path=":memory:")
@@ -2215,7 +2246,9 @@ def test_original_premise_gateways_surface_premise_entry_and_scene_hubs() -> Non
             f"/c/{community_slug}/request-access",
         }
         assert gateway.wanted_previews
-        assert all("wanted" not in preview.type_label.lower() for preview in gateway.wanted_previews)
+        assert all(
+            "wanted" not in preview.type_label.lower() for preview in gateway.wanted_previews
+        )
         assert all(
             preview.related_label is None
             or not preview.related_label.lower().startswith(("current chapter:", "premise:"))
@@ -2275,7 +2308,9 @@ def test_original_premise_gateways_surface_premise_entry_and_scene_hubs() -> Non
                     assert "Club Role" in content
                     assert "Influence Lane" in content
                     assert "Business" in content
-                    assert "Old names, newcomer ties, and marriages that still carry debt." in content
+                    assert (
+                        "Old names, newcomer ties, and marriages that still carry debt." in content
+                    )
                     assert (
                         "Members, guests, staff, donors, and applicants with something to prove."
                         in content

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2983,6 +2983,7 @@ def test_root_renders_elbysodic_network_home_not_default_community() -> None:
         assert "Mystery and current chapters" not in root.text
         assert 'class="elbysodic-network-home-tile__rank"' in root.text
         assert "Rank 1" in root.text
+        assert '<span>5 wanted · 8 faces</span>' in root.text
         assert "Search by premise, pace, hooks, and chapters in motion." not in root.text
         assert "Search story fit" not in root.text
         assert 'class="elbysodic-topbar-search" action="/search"' in root.text

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2376,6 +2376,8 @@ def test_original_premise_gateways_surface_premise_entry_and_scene_hubs() -> Non
                 assert "Open roles and ties" not in content
                 assert "Wanted hook" not in content
                 assert "Scene hub" not in content
+                assert "Already in the room" not in content
+                assert "Ways to belong" not in content
                 assert "Current Chapter:" not in content
                 assert "Premise:" not in content
                 assert not any(copy in content for copy in boilerplate_copy)
@@ -2986,6 +2988,13 @@ def test_root_renders_elbysodic_network_home_not_default_community() -> None:
         assert 'class="elbysodic-network-home-tile__rank"' in root.text
         assert "Rank 1" in root.text
         assert '<span>5 wanted · 8 faces</span>' in root.text
+        landscape_tiles = re.findall(
+            r'<article class="[^"]*elbysodic-network-home-tile--landscape[^"]*"[^>]*>.*?</article>',
+            root.text,
+            re.DOTALL,
+        )
+        assert landscape_tiles
+        assert not any("wanted ·" in tile or "faces</span>" in tile for tile in landscape_tiles)
         assert "Search by premise, pace, hooks, and chapters in motion." not in root.text
         assert "Search story fit" not in root.text
         assert 'class="elbysodic-topbar-search" action="/search"' in root.text

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2939,10 +2939,14 @@ def test_root_renders_elbysodic_network_home_not_default_community() -> None:
         assert '<span class="elbysodic-community-brand__name">Elbysodic</span>' in root.text
         assert "Studio Network" in root.text
         assert "Featured realm" in root.text
-        assert "Premise engines" in root.text
+        assert "Top 10 realms" in root.text
+        assert "Premise engines" not in root.text
         assert "Small-town social webs" in root.text
-        assert "Mystery and current chapters" in root.text
-        assert "Search realms by premise, pace, hooks, and current chapters." in root.text
+        assert "Weird-town mysteries" in root.text
+        assert "Mystery and current chapters" not in root.text
+        assert 'class="elbysodic-network-home-tile__rank"' in root.text
+        assert "Rank 1" in root.text
+        assert "Search by premise, pace, hooks, and chapters in motion." in root.text
         assert "Your desk is one click away." in root.text
         assert "What can move next." not in root.text
         assert "Memberships on this account." not in root.text
@@ -2950,7 +2954,7 @@ def test_root_renders_elbysodic_network_home_not_default_community() -> None:
         assert "Explore Elbysodic" not in root.text
         assert 'aria-label="Community"' not in root.text
         assert 'class="chirpui-sidebar elbysodic-sidebar"' not in root.text
-        assert 'href="/c/x-men-apocalypse"' in root.text
+        assert 'href="/c/afterlight-accord"' in root.text
         assert 'href="/c/x-men-apocalypse/desk"' in root.text
         assert "Afterlight Accord" in root.text
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2946,7 +2946,8 @@ def test_root_renders_elbysodic_network_home_not_default_community() -> None:
         assert "Mystery and current chapters" not in root.text
         assert 'class="elbysodic-network-home-tile__rank"' in root.text
         assert "Rank 1" in root.text
-        assert "Search by premise, pace, hooks, and chapters in motion." in root.text
+        assert "Search by premise, pace, hooks, and chapters in motion." not in root.text
+        assert "Search story fit" not in root.text
         assert "Your desk is one click away." not in root.text
         assert "Open Writer Desk" not in root.text
         assert "What can move next." not in root.text

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2947,7 +2947,8 @@ def test_root_renders_elbysodic_network_home_not_default_community() -> None:
         assert 'class="elbysodic-network-home-tile__rank"' in root.text
         assert "Rank 1" in root.text
         assert "Search by premise, pace, hooks, and chapters in motion." in root.text
-        assert "Your desk is one click away." in root.text
+        assert "Your desk is one click away." not in root.text
+        assert "Open Writer Desk" not in root.text
         assert "What can move next." not in root.text
         assert "Memberships on this account." not in root.text
         assert "Choose the realm you are writing in." not in root.text
@@ -2955,7 +2956,7 @@ def test_root_renders_elbysodic_network_home_not_default_community() -> None:
         assert 'aria-label="Community"' not in root.text
         assert 'class="chirpui-sidebar elbysodic-sidebar"' not in root.text
         assert 'href="/c/afterlight-accord"' in root.text
-        assert 'href="/c/x-men-apocalypse/desk"' in root.text
+        assert 'href="/c/x-men-apocalypse/desk"' not in root.text
         assert "Afterlight Accord" in root.text
 
     asyncio.run(run())

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2299,10 +2299,12 @@ def test_original_premise_gateways_surface_premise_entry_and_scene_hubs() -> Non
                 assert "Guidebook" in content
                 assert "Before you enter" in content
                 assert "Claims" in content
+                assert "Social map" in content
                 assert 'aria-labelledby="realm-social-title"' in response.text
                 assert 'id="realm-social-title"' in response.text
                 if community_slug == "harbor-society":
                     assert "Cast" in content
+                    assert "Featured faces" in content
                     assert "Maris Vale" in content
                     assert "August Reed" in content
                     assert "Town Power Map" in content

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2983,6 +2983,8 @@ def test_root_renders_elbysodic_network_home_not_default_community() -> None:
         assert "Rank 1" in root.text
         assert "Search by premise, pace, hooks, and chapters in motion." not in root.text
         assert "Search story fit" not in root.text
+        assert 'class="elbysodic-topbar-search" action="/search"' in root.text
+        assert "All realms" in root.text
         assert "Your desk is one click away." not in root.text
         assert "Open Writer Desk" not in root.text
         assert "What can move next." not in root.text
@@ -3023,6 +3025,10 @@ def test_shell_groups_community_modes_in_topbar_and_context_in_sidebar() -> None
             assert 'href="/c/x-men-apocalypse/desk"' in index.text
             assert 'aria-label="Primary community rooms"' in index.text
             assert 'aria-label="Global"' in index.text
+            assert (
+                'class="elbysodic-topbar-search" action="/c/x-men-apocalypse/search"' in index.text
+            )
+            assert "Search X-Men Apocalypse" in index.text
             assert 'class="elbysodic-primary-rail"' in index.text
             assert ">Home</a>" not in index.text
             assert re.search(

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -3029,6 +3029,14 @@ def test_shell_groups_community_modes_in_topbar_and_context_in_sidebar() -> None
                 'class="elbysodic-topbar-search" action="/c/x-men-apocalypse/search"' in index.text
             )
             assert "Search X-Men Apocalypse" in index.text
+            identity_summary = re.search(
+                r'<summary class="elbysodic-identity-menu__summary"[^>]*>(?P<body>.*?)</summary>',
+                index.text,
+                re.S,
+            )
+            assert identity_summary is not None
+            assert "elbysodic-identity-menu__summary-avatar" in identity_summary.group("body")
+            assert "elbysodic-identity-menu__copy" not in identity_summary.group("body")
             assert 'class="elbysodic-primary-rail"' in index.text
             assert ">Home</a>" not in index.text
             assert re.search(

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -1909,6 +1909,7 @@ def test_global_search_renders_public_realm_results() -> None:
 
         assert response.status == 200
         assert "Search All realms" in response.text
+        assert "elbysodic-search-section__header" in response.text
         assert "HP Universe" in response.text
         assert "2 wanted · 3 faces" in response.text
         assert 'href="/c/hp-universe"' in response.text
@@ -1928,6 +1929,7 @@ def test_community_search_scopes_to_public_realm_results() -> None:
         assert 'href="/search?q=ledger"' in response.text
         assert "The Ledger Page Under Table Six" in response.text
         assert "Scenes" in response.text
+        assert "Try a place, scene, face, hook, or guidebook title." not in response.text
 
     asyncio.run(run())
 

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -544,6 +544,7 @@ def test_network_home_does_not_render_full_filter_matrix() -> None:
         assert 'class="elbysodic-network-home-genres"' in response.text
         assert "Top 10 realms" in response.text
         assert "Premise engines" not in response.text
+        assert "Your desk is one click away." not in response.text
         assert 'class="elbysodic-network-filter-panel"' not in response.text
 
     asyncio.run(run())

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -527,6 +527,20 @@ def test_public_network_explore_keeps_filters_below_results() -> None:
     asyncio.run(run())
 
 
+def test_network_home_does_not_render_full_filter_matrix() -> None:
+    async def run() -> None:
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+        async with TestClient(app) as client:
+            response = await client.get("/")
+
+        assert response.status == 200
+        assert "Search by premise, pace, hooks, and chapters in motion." in response.text
+        assert 'class="elbysodic-network-home-genres"' in response.text
+        assert 'class="elbysodic-network-filter-panel"' not in response.text
+
+    asyncio.run(run())
+
+
 def test_public_network_search_uses_explicit_discovery_metadata() -> None:
     services = create_services(path=":memory:")
     community = services.repo.get_community_by_slug("rl-small-town")

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -216,7 +216,8 @@ def test_production_routes_require_session(monkeypatch) -> None:
 
         assert health.status == 200
         assert root.status == 200
-        assert "Play-by-post realms with faces, scenes, wanted hooks, and continuity." in root.text
+        assert "Top 10 realms" in root.text
+        assert "Play-by-post realms with faces, scenes, wanted hooks, and continuity." not in root.text
         assert "starlane" not in root.text
         assert "playing as Rogue" not in root.text
         assert "elbysodic-identity-menu" not in root.text
@@ -243,7 +244,8 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert dict(studio.headers)["location"] == "/login?next=/studio"
         assert tenant.status == 200
         assert "elbysodic-realm-gateway-hero" in tenant.text
-        assert "What it opens" in tenant.text
+        assert "Already moving" in tenant.text
+        assert "Ways in" in tenant.text
         assert "Current Event: B-24 Winter" in tenant.text
         assert "starlane" not in tenant.text
         assert "playing as Rogue" not in tenant.text

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -465,6 +465,12 @@ def test_network_read_models_split_public_cards_from_viewer_state() -> None:
     assert home.featured.community.slug == "afterlight-accord"
     assert home.return_path is not None
     assert home.return_path.desk_href.startswith("/c/")
+    assert home.slices[0].title == "Top 10 realms"
+    assert len(home.slices[0].programs) == 10
+    assert {home_slice.title for home_slice in home.slices[1:]} >= {
+        "Small-town social webs",
+        "Weird-town mysteries",
+    }
     assert explore.results
     assert {facet.label for facet in explore.browse_facets} >= {
         "open wanted hooks",
@@ -536,6 +542,8 @@ def test_network_home_does_not_render_full_filter_matrix() -> None:
         assert response.status == 200
         assert "Search by premise, pace, hooks, and chapters in motion." in response.text
         assert 'class="elbysodic-network-home-genres"' in response.text
+        assert "Top 10 realms" in response.text
+        assert "Premise engines" not in response.text
         assert 'class="elbysodic-network-filter-panel"' not in response.text
 
     asyncio.run(run())

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -540,8 +540,8 @@ def test_network_home_does_not_render_full_filter_matrix() -> None:
             response = await client.get("/")
 
         assert response.status == 200
-        assert "Search by premise, pace, hooks, and chapters in motion." in response.text
-        assert 'class="elbysodic-network-home-genres"' in response.text
+        assert "Search by premise, pace, hooks, and chapters in motion." not in response.text
+        assert 'class="elbysodic-network-home-genres"' not in response.text
         assert "Top 10 realms" in response.text
         assert "Premise engines" not in response.text
         assert "Your desk is one click away." not in response.text

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -525,6 +525,8 @@ def test_public_network_explore_keeps_filters_below_results() -> None:
 
         assert response.status == 200
         assert 'class="elbysodic-network-filter-drawer"' in response.text
+        assert "elbysodic-network-explore-map" not in response.text
+        assert "elbysodic-network-two-up" not in response.text
         assert "Browse by fit" in response.text
         assert response.text.index("explore-results-heading") < response.text.index(
             "elbysodic-network-filter-drawer"

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -511,6 +511,22 @@ def test_network_read_models_split_public_cards_from_viewer_state() -> None:
         assert card.invite_posture_label == "Public preview"
 
 
+def test_public_network_explore_keeps_filters_below_results() -> None:
+    async def run() -> None:
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+        async with TestClient(app) as client:
+            response = await client.get("/network")
+
+        assert response.status == 200
+        assert 'class="elbysodic-network-filter-drawer"' in response.text
+        assert "Browse by fit" in response.text
+        assert response.text.index("explore-results-heading") < response.text.index(
+            "elbysodic-network-filter-drawer"
+        )
+
+    asyncio.run(run())
+
+
 def test_public_network_search_uses_explicit_discovery_metadata() -> None:
     services = create_services(path=":memory:")
     community = services.repo.get_community_by_slug("rl-small-town")


### PR DESCRIPTION
## What changed

- Added the scoped search contract and implemented global/community search routes.
- Moved search into the topbar with global scope on network pages and community scope inside realms.
- Simplified the public network home into a featured realm, Top 10 rail, and quieter category shelves.
- Calmed the network browse page by moving filters below results and removing the visual filter wall.
- Tightened the active identity control to the active face/avatar only.
- Aligned public community gateway headings away from internal/planning language.
- Added render tests that guard against noisy labels, repeated metadata, and full filter clutter returning.

## Why

The public discovery surfaces were reading too much like an internal dashboard: repeated labels, utility panels, oversized taxonomy controls, and low-value explanatory text were competing with the story and discovery tasks. This pass makes discovery more editorial, scoped, and quieter while preserving PBP vocabulary.

## Validation

- `uv run pytest -q tests/test_forum_slice.py::test_root_renders_elbysodic_network_home_not_default_community tests/test_web_security.py::test_production_routes_require_session tests/test_web_security.py::test_network_home_does_not_render_full_filter_matrix -q`
- `uv run pytest -q tests/test_forum_slice.py::test_original_premise_gateways_surface_premise_entry_and_scene_hubs tests/test_forum_slice.py::test_root_renders_elbysodic_network_home_not_default_community tests/test_web_security.py::test_network_home_does_not_render_full_filter_matrix tests/test_web_security.py::test_public_network_explore_keeps_filters_below_results -q`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`

The Chirp check still reports the known `_layout.html` topbar search input warning against `IdentityForm`; no errors.
