### PR TITLE
Polish Studio shell and access flows

### DIFF
--- a/changelog.d/+account-linked-access-request-ui.changed.md
+++ b/changelog.d/+account-linked-access-request-ui.changed.md
@@ -1,0 +1,1 @@
+Signed-in access requests now use the writer's existing Elbysodic account instead of asking them to retype contact email.

--- a/changelog.d/+contextual-director-controls.changed.md
+++ b/changelog.d/+contextual-director-controls.changed.md
@@ -1,0 +1,1 @@
+Directors can now reach realm home and board/place management from the object they are viewing, while Studio Structure reads as an audit and bulk repair room.

--- a/changelog.d/+studio-discovery-live-preview.changed.md
+++ b/changelog.d/+studio-discovery-live-preview.changed.md
@@ -1,0 +1,1 @@
+Studio Discovery now updates the Network card preview while directors edit profile fields.

--- a/changelog.d/+studio-gateway-drag-order.changed.md
+++ b/changelog.d/+studio-gateway-drag-order.changed.md
@@ -1,0 +1,1 @@
+Studio Structure now lets directors reorder gateway curation rows with drag or Up/Down controls.

--- a/changelog.d/+studio-progressive-rooms.changed.md
+++ b/changelog.d/+studio-progressive-rooms.changed.md
@@ -1,0 +1,1 @@
+Split Director Studio into progressive rooms for structure, appearance, and content so the Studio home stays focused on active director attention and room handoffs.

--- a/changelog.d/+studio-sidebar-scope.changed.md
+++ b/changelog.d/+studio-sidebar-scope.changed.md
@@ -1,0 +1,1 @@
+Scoped the Studio inner rail to Studio-owned destinations so production, wanted, world, and desk routes no longer appear inside the Studio sidebar.

--- a/changelog.d/+studio-structure-clearer-rooms.changed.md
+++ b/changelog.d/+studio-structure-clearer-rooms.changed.md
@@ -1,0 +1,1 @@
+Studio Structure now uses a Public Home Spotlight composer with selected items, a candidate library, and a preview while separating board map, sidebar, sub-forum placement, and navigation preview goals.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -98,7 +98,10 @@ staff controls.
 Community access requests are interest records, not permission records.
 `CommunityAccessRequest` rows are scoped by `community_id` and may include the
 writer's email, display name, face concept, wanted-hook interest, and private
-notes for directors. Creating a request must not create a `User`,
+notes for directors. When the visitor is already signed in to Elbysodic, the
+request may link `account_user_id` and the rendered request flow should treat it
+as an account-linked entry request rather than asking the writer to retype or
+exchange contact email. Creating a request must not create a `User`,
 `CommunityMembership`, role, character, reserve, claim, invitation, session, or
 active-face state. Public realm previews may submit a request and show
 account-vs-anonymous posture, but only director-capable memberships in the same

--- a/docs/architecture/theme-css-architecture.md
+++ b/docs/architecture/theme-css-architecture.md
@@ -48,7 +48,7 @@ Use these layers when adding or moving CSS:
   pickers, scene setup fields, draft status, and post style previews. Rendered
   post shells and scene cast displays stay in `45-posts-scenes.css`.
 - **studio**: Director Studio, launch, operations, intake, appearance editor,
-  navigation composer, board taxonomy, and director workflow rooms.
+  navigation composer, board map, and director workflow rooms.
 - **legacy-ledger**: selectors that still need markup work, component
   extraction, or Chirp adoption. The ledger should shrink over time.
 
@@ -127,7 +127,7 @@ The deep browser pass should keep covering these CSS ownership slices:
 | `41-48` product families | board index/detail, thread list/detail, members/roster, claims, wanted, world, Network catalog |
 | `47-network-catalog.css` | `/network`, `/network?q=...`, realm entry actions, application starter |
 | `49-composer.css` | new thread, reply composer, post edit, scene setup/cast mention picker, post style preview |
-| `60-studio.css` | Studio overview, launch, operations, intake, appearance, board taxonomy |
+| `60-studio.css` | Studio overview, launch, operations, intake, appearance, board map |
 
 When a browser failure appears after CSS movement, first check whether the
 selector lives in the same layer as the markup flow above. Cross-layer selectors

--- a/docs/product/information-hierarchy.md
+++ b/docs/product/information-hierarchy.md
@@ -68,7 +68,7 @@ Use this contract before adding or expanding a hub:
   roster, applications, casting, discovery, or inbox as persistent shortcuts.
 - **Studio** answers: what needs a director now? It can surface launch
   blockers, review queues, production health, navigation warnings, and current
-  publishing work. It should not also be the full board taxonomy editor,
+  publishing work. It should not also be the full board map editor,
   navigation composer, appearance editor, casting desk, and continuity editor
   unless those are the current director job.
 - **Community home** answers: where am I in the world? It should orient around
@@ -89,9 +89,19 @@ Scoped pages own durable workflows:
 - `/plotting` owns planning rooms and interest handoffs.
 - `/studio/operations` owns daily director production work.
 - `/studio/launch` owns launch readiness and setup sequencing.
-- Future Studio routes should own appearance, navigation, board taxonomy,
-  materials, and casting/review work before those editors are removed from the
-  Studio home.
+- `/studio/discovery` owns the Writer Network listing and public fit signals.
+- `/studio/structure` owns the audit view for Public Home Spotlight, board
+  map, sidebar language, and navigation health. Object-local surfaces own the
+  first edit path: realm home controls manage the home spotlight, and board or
+  location pages expose permitted board/place controls. Studio Structure keeps
+  the selected sequence, candidate library, preview, and bulk repair tools for
+  directors who need to scan the whole realm at once.
+- `/studio/intake` owns application fields, claims, reserves, and Program
+  Blueprint preview.
+- `/studio/appearance` owns theme tokens, realm media, identity accents, and
+  post style vocabulary.
+- `/studio/content` owns guidebook drafts, current event pressure, wanted-hook
+  context, and location coverage.
 
 A hub section should pass at least one test:
 

--- a/docs/product/navigation-menus.md
+++ b/docs/product/navigation-menus.md
@@ -65,7 +65,7 @@ The accepted primary shell model is:
 | Locations | `locations` | Public-safe when locations are public | Location tree, active scenes here, related wants, current place context | Start scene here, local filters, watch/read, place management when authorized |
 | Wanted | `wanted` | Public/member-safe with capability-gated actions | Wanted board, Casting, Claims, Reserves, related wants, hook handoffs | Raise interest, reserve, watch, start plotting, ready for scene |
 | Desk | `desk` | Signed-in community members only | Queue, Inbox, Roster, Plotting, Applications, Discovery; applicant-state rows when relevant | Reply, mark caught up, watch, continue to next attention item |
-| Studio | `studio` | Staff/director only | Operations, Launch, Intake, Boards, Navigation, Appearance, Continuity, Materials | Save, publish, review, request revision, staff-only object actions |
+| Studio | `studio` | Staff/director only | Operations, Launch, Discovery profile, Structure, Intake, Appearance, Content | Save, publish, review, request revision, staff-only object actions |
 
 `Network` stays out of the default rail until cross-realm network behavior is a
 real workflow.
@@ -314,7 +314,7 @@ Use language and grouping instead:
 
 - Story-facing: `World Home`, `Locations`, `Guidebook`, `Wanted`.
 - Writer work: `Queue`, `Roster`, `Plotting`, `Applications`, `Discovery`.
-- Director work: `Studio`, `Navigation`, `Board taxonomy`, `Production`.
+- Director work: `Studio`, `Navigation`, `Board map`, `Production`.
 
 Active face is a lens and identity state, not a navigation mode. It may appear
 as a compact sidebar context module where relevant, but it must not hide or
@@ -439,21 +439,25 @@ Configurable:
   its short description, choose its relative order, and decide whether its
   divider label is visible. This is for community vocabulary, not for inventing
   new routing rules.
-- Studio's Board Taxonomy editor is the canonical place to review and adjust
-  this classification. Treat it as production direction: changing a board kind
-  changes the board's meaning; changing sidebar placement changes navigation
-  without pretending the board is a different kind of object.
-- Board Taxonomy rows should foreground the director decision first: board
+- Board and location pages are the primary place to adjust that board's
+  identity, parent/sub-forum relationship, sidebar placement, and navigation
+  order when the viewer has permission. Studio's Board Map view is the
+  canonical audit and bulk repair surface for scanning that classification
+  across the whole realm. Treat it as production direction: changing a board
+  kind changes the board's meaning; changing sidebar placement changes
+  navigation without pretending the board is a different kind of object.
+- Board Map rows should foreground the director decision first: board
   name, kind, sidebar placement, visibility, and parent/child relationship.
-  Form controls belong behind an `Edit placement` disclosure so the list stays
+  Bulk controls belong behind a repair disclosure so the list stays
   scannable, especially on mobile.
 - Studio's board editor is the deeper production room for each board: identity,
   parent, media, sort order, navigation order, visibility, and access belong
   there when a quick taxonomy row is not enough.
-- Studio's Navigation Composer preview is the canonical place to inspect the
-  result. It must distinguish configured sections, app-owned rows,
-  board-derived rows, material-derived rows, identity-derived rows, and
-  wanted-derived rows so directors understand what they are configuring.
+- Studio's Sidebar Audit preview is the canonical place to inspect the
+  result. It must explain each sidebar context's goal first, then distinguish
+  fixed routes, configured sections, board links, current events, active-face
+  routes, and wanted-hook routes without making implementation labels the main
+  read.
 - Optional named sidebar collections inside a realm.
 - Ordering and visibility of board-derived links within allowed sections.
 - Hidden boards may remain reachable by direct URL and visible in page content
@@ -689,10 +693,10 @@ These are the navigation pressure points to revisit as Elbysodic grows:
   Writer Desk because it is a cross-cutting attention surface, not a realm.
 - The Guidebook sidebar is acting as a table of contents plus object directory.
   Keep it only while the sections remain stable director-authored collections.
-- Studio's `Production` grouping currently jumps to writer-facing routes such
-  as `/applications`, `/wanted`, and `/casting`. This is acceptable as a
-  shortcut, but a future production workflow should get a real `/studio/...`
-  route instead of overloading those public surfaces.
+- Studio's inner rail stays inside Studio-owned routes. Writer-facing routes
+  such as `/applications`, `/wanted`, `/claims`, `/casting`, and `/world` can
+  appear as inspect links inside a Studio room, but they must not masquerade as
+  Studio subsections.
 - `/applications` is a current edge case: writers submit or track their own
   applications, while directors review production flow. Treat it as Writer Desk
   by default until a distinct Studio application-review route exists.

--- a/src/elbysodic/services/boards.py
+++ b/src/elbysodic/services/boards.py
@@ -146,6 +146,7 @@ def board_page(
         direct_thread_count=direct_thread_count,
         next_unread_thread=next_unread_thread(repo, viewer, board),
         can_start_thread=policies.can_start_thread(viewer.membership, board, viewer.role),
+        can_manage_board=policies.can_manage_navigation(viewer.membership, viewer.role),
     )
 
 

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -64,6 +64,7 @@ from elbysodic.domain.models import (
     Role,
     SidebarSectionConfig,
     Thread,
+    User,
     WantedAd,
     WantedAdInterest,
 )
@@ -424,6 +425,10 @@ class InvitationManagementItem:
 class AccessRequestManagementItem:
     request: CommunityAccessRequest
     status_label: str
+    display_label: str
+    contact_label: str
+    account_link_label: str
+    account_user: User | None = None
     invitation: InvitationManagementItem | None = None
     activity: tuple[AccessRequestActivityItem, ...] = ()
 
@@ -4884,15 +4889,28 @@ def _access_request_management_item(
         invitation_item = _invitation_management_item(
             repo.get_community_invitation(request.community_id, request.invitation_id)
         )
+    account_user = None
+    if request.account_user_id is not None:
+        with suppress(LookupError):
+            account_user = repo.get_user(request.account_user_id)
     activity: tuple[AccessRequestActivityItem, ...] = ()
     if include_activity:
         activity = tuple(
             _access_request_activity_item(event)
             for event in repo.list_community_access_request_events(request.community_id, request.id)
         )
+    display_label = request.display_name or (
+        "Linked account request" if account_user is not None else request.email
+    )
+    contact_label = "Elbysodic account on file" if account_user is not None else request.email
+    account_link_label = "Linked Elbysodic account" if account_user is not None else "Email request"
     return AccessRequestManagementItem(
         request=request,
         status_label=request.status.title(),
+        display_label=display_label,
+        contact_label=contact_label,
+        account_link_label=account_link_label,
+        account_user=account_user,
         invitation=invitation_item,
         activity=activity,
     )
@@ -5130,7 +5148,7 @@ def _navigation_preview_sections(
         NavigationPreviewItem(
             label=item.board.name,
             href=item.summary.href,
-            source_label="Board-derived",
+            source_label="Board",
             behavior_label=(
                 f"{item.child_count} sublocations" if item.child_count else "Major location"
             ),
@@ -5146,7 +5164,7 @@ def _navigation_preview_sections(
         NavigationPreviewItem(
             label=item.board.name,
             href=item.summary.href,
-            source_label="Board-derived",
+            source_label="Board",
             behavior_label=item.kind_label,
             count=item.summary.unread_thread_count or None,
         )
@@ -5157,7 +5175,7 @@ def _navigation_preview_sections(
         NavigationPreviewItem(
             label=item.board.name,
             href=item.summary.href,
-            source_label="Board-derived",
+            source_label="Board",
             behavior_label=item.kind_label,
             count=item.summary.unread_thread_count or None,
         )
@@ -5168,7 +5186,7 @@ def _navigation_preview_sections(
         NavigationPreviewItem(
             label=item.board.name,
             href=item.summary.href,
-            source_label="Board-derived",
+            source_label="Board",
             behavior_label=item.kind_label,
             count=item.summary.unread_thread_count or None,
         )
@@ -5176,31 +5194,31 @@ def _navigation_preview_sections(
         if item.board.show_in_navigation and item.board.sidebar_section == "studio"
     ]
     studio_items = [
-        NavigationPreviewItem("Overview", "/studio", "App-owned", "Realm home"),
+        NavigationPreviewItem("Overview", "/studio", "Fixed route", "Studio home"),
         NavigationPreviewItem(
-            "Board taxonomy",
-            "/studio#board-taxonomy",
-            "App-owned",
-            "Production control",
+            "Board map",
+            "/studio/structure#board-taxonomy",
+            "Fixed route",
+            "Board placement",
         ),
         NavigationPreviewItem(
             "Navigation composer",
-            "/studio#navigation-composer",
-            "App-owned",
-            "Production preview",
+            "/studio/structure#navigation-composer",
+            "Fixed route",
+            "Sidebar result",
         ),
-        NavigationPreviewItem("Guidebook", "/world", "App-owned", "Cross-realm shortcut"),
-        NavigationPreviewItem("World map", "/", "App-owned", "Cross-realm shortcut"),
-        NavigationPreviewItem("Applications", "/applications", "App-owned", "Production queue"),
-        NavigationPreviewItem("Wanted board", "/wanted", "App-owned", "Casting surface"),
-        NavigationPreviewItem("Casting desk", "/casting", "App-owned", "Casting queue"),
+        NavigationPreviewItem("Guidebook", "/world", "Fixed route", "World material"),
+        NavigationPreviewItem("World map", "/", "Fixed route", "Realm home"),
+        NavigationPreviewItem("Applications", "/applications", "Fixed route", "Intake"),
+        NavigationPreviewItem("Wanted board", "/wanted", "Fixed route", "Casting"),
+        NavigationPreviewItem("Casting desk", "/casting", "Fixed route", "Casting queue"),
     ]
     if current_event is not None:
         studio_items.append(
             NavigationPreviewItem(
                 current_event.material.title,
                 f"/world/{current_event.material.slug}",
-                "Material-derived",
+                "Current event",
                 "Current event",
             )
         )
@@ -5209,16 +5227,19 @@ def _navigation_preview_sections(
         NavigationPreviewSection(
             realm_label="World",
             title="World sidebar",
-            description="World lanes use director language while board placement stays constrained.",
+            description=(
+                "Help visitors move from the realm overview into locations, community "
+                "spaces, and the member directory."
+            ),
             label_visible=(
                 sidebar_sections["locations"].show_label or sidebar_sections["community"].show_label
             ),
             items=[
-                NavigationPreviewItem("Overview", "/", "App-owned", "Realm home"),
+                NavigationPreviewItem("Overview", "/", "Fixed route", "Realm home"),
                 NavigationPreviewItem(
                     sidebar_sections["locations"].label,
                     "/locations",
-                    "Configured section",
+                    "Section",
                     "Location index",
                     len(location_items),
                 ),
@@ -5226,40 +5247,45 @@ def _navigation_preview_sections(
                 NavigationPreviewItem(
                     sidebar_sections["community"].label,
                     "/community",
-                    "Configured section",
+                    "Section",
                     "Community index",
                     len(community_items),
                 ),
-                NavigationPreviewItem("Members", "/members", "App-owned", "Directory"),
+                NavigationPreviewItem("Members", "/members", "Fixed route", "Directory"),
                 *community_items,
             ],
         ),
         NavigationPreviewSection(
             realm_label="Writer Desk",
             title="Desk sidebar",
-            description=sidebar_sections["desk"].description,
+            description=(
+                "Keep writer obligations, inbox, roster, plotting, and applications close "
+                "to the active face workflow."
+            ),
             label_visible=sidebar_sections["desk"].show_label,
             items=[
-                NavigationPreviewItem("Overview", "/desk", "App-owned", "Realm home"),
-                NavigationPreviewItem("Queue", "/my/threads", "App-owned", "Writing lane"),
+                NavigationPreviewItem("Overview", "/desk", "Fixed route", "Desk home"),
+                NavigationPreviewItem("Queue", "/my/threads", "Fixed route", "Writing queue"),
                 NavigationPreviewItem(
                     "Inbox",
                     "/notifications",
-                    "App-owned",
-                    "Attention surface",
+                    "Fixed route",
+                    "Attention",
                     unread_notification_count or None,
                 ),
-                NavigationPreviewItem("Roster", "/characters", "App-owned", "Identity lane"),
-                NavigationPreviewItem("Plotting", "/plotting", "App-owned", "Collaboration"),
-                NavigationPreviewItem("Applications", "/applications", "App-owned", "Intake"),
-                NavigationPreviewItem("Discovery", "/discover", "App-owned", "Find play"),
+                NavigationPreviewItem("Roster", "/characters", "Fixed route", "Faces"),
+                NavigationPreviewItem("Plotting", "/plotting", "Fixed route", "Collaboration"),
+                NavigationPreviewItem("Applications", "/applications", "Fixed route", "Intake"),
+                NavigationPreviewItem("Discovery", "/discover", "Fixed route", "Find play"),
                 *desk_board_items,
             ],
         ),
         NavigationPreviewSection(
             realm_label="Studio",
             title="Studio sidebar",
-            description=sidebar_sections["studio"].description,
+            description=(
+                "Keep director production rooms and staff boards separate from writer navigation."
+            ),
             label_visible=sidebar_sections["studio"].show_label,
             items=studio_items,
         ),
@@ -5267,25 +5293,25 @@ def _navigation_preview_sections(
             realm_label="Wanted",
             title="Casting sidebar",
             description=(
-                "Casting navigation stays lean: app-owned surfaces first, then the active "
-                "face and context-specific wants."
+                "Keep wanted hooks, applications, casting work, and active-face context in "
+                "one lean path."
             ),
             label_visible=False,
             items=[
-                NavigationPreviewItem("Wanted board", "/wanted", "App-owned", "Realm home"),
-                NavigationPreviewItem("Casting desk", "/casting", "App-owned", "Pipeline"),
-                NavigationPreviewItem("Applications", "/applications", "App-owned", "Intake"),
+                NavigationPreviewItem("Wanted board", "/wanted", "Fixed route", "Wanted"),
+                NavigationPreviewItem("Casting desk", "/casting", "Fixed route", "Pipeline"),
+                NavigationPreviewItem("Applications", "/applications", "Fixed route", "Intake"),
                 NavigationPreviewItem(
                     active_face.name if active_face else "Active face",
                     f"/characters/{active_face.slug}" if active_face else "/characters",
-                    "Identity-derived",
-                    "Current lens" if active_face else "Choose a face",
+                    "Active face",
+                    "Current face" if active_face else "Choose a face",
                 ),
                 NavigationPreviewItem(
                     "Open wants",
                     "/wanted",
-                    "Wanted-derived",
-                    "Context list",
+                    "Wanted hooks",
+                    "Open hooks",
                     len(open_wanted_ads) or None,
                 ),
             ],
@@ -5417,7 +5443,7 @@ def _navigation_health_warnings(
                         "visible board-derived links currently live there."
                     ),
                     section=section,
-                    href="/studio#navigation-composer",
+                    href="/studio/structure#navigation-composer",
                 )
             )
 
@@ -5442,7 +5468,7 @@ def _navigation_health_warnings(
                         "route row. Hiding the label may make the sidebar cleaner."
                     ),
                     section=section,
-                    href="/studio#navigation-composer",
+                    href="/studio/structure#navigation-composer",
                 )
             )
 

--- a/src/elbysodic/services/operations.py
+++ b/src/elbysodic/services/operations.py
@@ -232,9 +232,9 @@ def director_operations(
             OperationsCard(
                 kicker="Navigation",
                 title="Production health",
-                summary="Sidebar, board taxonomy, and route-shape notes.",
+                summary="Sidebar, board map, and route-shape notes.",
                 count=len(studio.navigation_warnings),
-                href="/studio#navigation",
+                href="/studio/structure#navigation",
                 cta="Open navigation studio",
                 variant="warning",
                 items=tuple(warning.title for warning in studio.navigation_warnings[:4]),

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -246,6 +246,7 @@ class BoardPage:
     direct_thread_count: int
     next_unread_thread: ThreadNavigationItem | None
     can_start_thread: bool
+    can_manage_board: bool
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/elbysodic/web/navigation.py
+++ b/src/elbysodic/web/navigation.py
@@ -535,8 +535,23 @@ def _studio_sections(
                 key="launch",
                 label="Launch",
                 href="/studio/launch",
-                active=_path_in(state.path, "/studio/launch"),
+                active=_path_in(state.path, "/studio/launch")
+                or _path_in(state.path, "/studio/access-requests"),
                 icon_id="launch",
+            ),
+            ShellNavItem(
+                key="discovery",
+                label="Discovery profile",
+                href="/studio/discovery",
+                active=_path_in(state.path, "/studio/discovery"),
+                icon_id="discovery",
+            ),
+            ShellNavItem(
+                key="structure",
+                label="Structure",
+                href="/studio/structure",
+                active=_path_in(state.path, "/studio/structure"),
+                icon_id="boards",
             ),
             ShellNavItem(
                 key="intake",
@@ -546,74 +561,23 @@ def _studio_sections(
                 icon_id="intake",
             ),
             ShellNavItem(
-                key="board-taxonomy",
-                label="Board taxonomy",
-                href="/studio#board-taxonomy",
-                active=False,
-                icon_id="boards",
+                key="appearance",
+                label="Appearance",
+                href="/studio/appearance",
+                active=_path_in(state.path, "/studio/appearance"),
+                icon_id="appearance",
             ),
             ShellNavItem(
-                key="navigation-composer",
-                label="Navigation composer",
-                href="/studio#navigation-composer",
-                active=False,
-                icon_id="navigation",
-            ),
-            ShellNavItem(
-                key="guidebook",
-                label="Guidebook",
-                href="/world",
-                active=False,
-                icon_id="guidebook",
-            ),
-            ShellNavItem(
-                key="world-home",
-                label="World Home",
-                href="/",
-                active=False,
-                icon_id="home",
+                key="content",
+                label="Content",
+                href="/studio/content",
+                active=_path_in(state.path, "/studio/content"),
+                icon_id="materials",
             ),
         ]
     )
-    production_items: list[ShellNavItem] = [
-        ShellNavItem(
-            key="applications-production",
-            label="Production",
-            href="/applications",
-            active=state.applications_active,
-            icon_id="operations",
-        ),
-        ShellNavItem(
-            key="applications",
-            label="Applications",
-            href="/applications",
-            active=state.applications_active,
-            icon_id="applications",
-        ),
-        ShellNavItem(
-            key="wanted",
-            label="Wanted board",
-            href="/wanted",
-            active=state.wanted_active,
-            icon_id="wanted",
-        ),
-        ShellNavItem(
-            key="casting",
-            label="Casting desk",
-            href="/casting",
-            active=state.casting_active,
-            icon_id="casting",
-        ),
-        ShellNavItem(
-            key="claims",
-            label="Claims",
-            href="/claims",
-            active=state.claims_active,
-            icon_id="claims",
-        ),
-    ]
     if viewer:
-        production_items.extend(
+        studio_items.extend(
             _board_shell_item(item.board, item.unread_thread_count, current_board=board)
             for item in viewer.studio_navigation_boards
         )
@@ -624,23 +588,7 @@ def _studio_sections(
             source="studio",
             items=tuple(studio_items),
         ),
-        ShellNavSection(
-            key="production",
-            label="Production",
-            source="studio",
-            items=tuple(production_items),
-        ),
     ]
-    current_event = getattr(studio, "current_event", None)
-    if current_event is not None:
-        sections.append(
-            ShellNavSection(
-                key="current-event",
-                label="Current Event",
-                source="studio",
-                items=(_material_item(current_event),),
-            )
-        )
     return tuple(sections)
 
 

--- a/src/elbysodic/web/pages/_components/access.html
+++ b/src/elbysodic/web/pages/_components/access.html
@@ -1,0 +1,25 @@
+{% def product_identity() %}
+<div class="elbysodic-product-identity">
+  <img class="elbysodic-product-identity__mark"
+       src="/elbysodic-static/brand/elbysodic-mark.svg"
+       alt="">
+  <span class="elbysodic-product-identity__name">Elbysodic</span>
+</div>
+{% end %}
+
+{% def access_account_notice(account_visitor, community=none) %}
+{% if account_visitor %}
+<section class="elbysodic-access-account" aria-label="Signed-in account">
+  <span class="elbysodic-access-account__avatar" aria-hidden="true">{{ account_visitor.avatar_label }}</span>
+  <div>
+    <p class="elbysodic-section-kicker">Existing Elbysodic account</p>
+    <h2>Request access without a separate email handoff.</h2>
+    {% if community %}
+    <p>Your account can ask to join {{ community.name }} directly. Directors see the request, first-face context, and linked account state.</p>
+    {% else %}
+    <p>Your account is active. Open a realm preview to request entry into that roster.</p>
+    {% end %}
+  </div>
+</section>
+{% end %}
+{% end %}

--- a/src/elbysodic/web/pages/_components/director_controls.html
+++ b/src/elbysodic/web/pages/_components/director_controls.html
@@ -1,0 +1,26 @@
+{% def director_context_panel(kicker, title, summary="", cls="") %}
+<aside class="elbysodic-director-context{{ " " ~ cls if cls else "" }}" aria-label="{{ title }}">
+  <div class="elbysodic-director-context__copy">
+    <p class="elbysodic-kicker">{{ kicker }}</p>
+    <h2>{{ title }}</h2>
+    {% if summary %}
+    <p>{{ summary }}</p>
+    {% end %}
+  </div>
+  <div class="elbysodic-director-context__actions">
+    {% slot %}
+  </div>
+</aside>
+{% end %}
+
+{% def director_action_menu(label, summary="Director tools") %}
+<details class="elbysodic-director-menu">
+  <summary>
+    <span>{{ label }}</span>
+    <small>{{ summary }}</small>
+  </summary>
+  <div class="elbysodic-director-menu__panel">
+    {% slot %}
+  </div>
+</details>
+{% end %}

--- a/src/elbysodic/web/pages/_components/network_catalog.html
+++ b/src/elbysodic/web/pages/_components/network_catalog.html
@@ -5,7 +5,9 @@
 {% end %}
 
 {% def program_summary(program) %}
-{% if program.current_event %}
+{% if program.discovery_profile and program.discovery_profile.catalog_pitch %}
+{{ program.discovery_profile.catalog_pitch }}
+{% elif program.current_event %}
 {{ program.current_event.material.summary }}
 {% elif program.premise %}
 {{ program.premise.material.summary }}
@@ -31,9 +33,10 @@ A realm ready for scenes, casting, and writer movement.
 {{ metric_item(program.claim_type_count, "claims", href=program.entry_href ~ "/claims") }}
 {% end %}
 
-{% def program_card(program, viewer=none) %}
+{% def program_card(program, viewer=none, preview=false) %}
 <article class="elbysodic-network-card{{ " elbysodic-network-card--no-hero" if not program.community.world_hero_image_url else "" }}"
-         style="--elbysodic-network-accent: {{ program.theme_preview.accent }}; --elbysodic-network-surface: {{ program.theme_preview.surface }}; --elbysodic-network-text: {{ program.theme_preview.text }}; --elbysodic-network-display-font: {{ program.theme_preview.display_font }};">
+         style="--elbysodic-network-accent: {{ program.theme_preview.accent }}; --elbysodic-network-surface: {{ program.theme_preview.surface }}; --elbysodic-network-text: {{ program.theme_preview.text }}; --elbysodic-network-display-font: {{ program.theme_preview.display_font }};"
+         {% if preview %}data-elbysodic-discovery-preview-card{% end %}>
   <a class="elbysodic-network-card__realm-link" href="{{ program.entry_href }}" aria-label="Preview {{ program.community.name }}">
     <span class="chirpui-visually-hidden">Preview {{ program.community.name }}</span>
   </a>
@@ -63,18 +66,18 @@ A realm ready for scenes, casting, and writer movement.
         {% if viewer and viewer.community.id == program.community.id %}
         {{ badge("current membership", variant="success") }}
         {% end %}
-        {{ badge(program.invite_posture_label, variant="info") }}
+        <span {% if preview %}data-elbysodic-preview-access{% end %}>{{ badge(program.invite_posture_label, variant="info") }}</span>
         {% if program.discovery_profile and program.discovery_profile.activity_pace %}
-        {{ badge(program.discovery_profile.activity_pace, variant="info") }}
+        <span {% if preview %}data-elbysodic-preview-pace{% end %}>{{ badge(program.discovery_profile.activity_pace, variant="info") }}</span>
         {% end %}
       </div>
     </header>
-    <p class="elbysodic-copy-summary">{{ program_summary(program) }}</p>
+    <p class="elbysodic-copy-summary" {% if preview %}data-elbysodic-preview-summary{% end %}>{{ program_summary(program) }}</p>
     <p class="elbysodic-copy-meta">
       {{ program.application_posture_label }} · {{ program.claims_posture_label }}
     </p>
     {% if program.discovery_profile %}
-    <p class="elbysodic-copy-meta">
+    <p class="elbysodic-copy-meta" {% if preview %}data-elbysodic-preview-fit{% end %}>
       {{ program.discovery_profile.premise_archetype or "Premise-led realm" }}
       {% if program.discovery_profile.lore_aperture %}
       · {{ program.discovery_profile.lore_aperture }}
@@ -84,7 +87,7 @@ A realm ready for scenes, casting, and writer movement.
       {% end %}
     </p>
     {% else %}
-    <p class="elbysodic-copy-meta">Read the premise, roster, wanted, and first steps.</p>
+    <p class="elbysodic-copy-meta" {% if preview %}data-elbysodic-preview-fit{% end %}>Read the premise, roster, wanted, and first steps.</p>
     {% end %}
     <div class="elbysodic-network-card__metrics" aria-label="{{ program.community.name }} signals">
       {{ program_metric_links(program) }}

--- a/src/elbysodic/web/pages/_components/realm_gateway.html
+++ b/src/elbysodic/web/pages/_components/realm_gateway.html
@@ -1,5 +1,6 @@
 {% imports %}
   {% from "chirpui/badge.html" import badge %}
+  {% from "_components/director_controls.html" import director_context_panel %}
 {% end %}
 
 {% def gateway_action(action, variant="primary") %}
@@ -323,9 +324,16 @@
 {% end %}
 {% end %}
 
-{% def realm_gateway_home(gateway, viewer=None, account_visitor=None) %}
+{% def realm_gateway_home(gateway, viewer=None, account_visitor=None, can_manage_home=false) %}
 <div class="elbysodic-realm-gateway">
   {{ gateway_hero(gateway) }}
+  {% if can_manage_home %}
+  {% call director_context_panel("Director controls", "Realm home controls", "This surface owns the first visitor scan. Use Studio Structure when you need the cross-realm audit.") %}
+    <a class="chirpui-btn chirpui-btn--primary" href="/studio/structure#gateway-curation">Manage home spotlight</a>
+    <a class="chirpui-btn chirpui-btn--secondary" href="/studio/discovery">Edit discovery profile</a>
+    <a class="chirpui-btn chirpui-btn--secondary" href="/studio/appearance">Edit appearance</a>
+  {% end %}
+  {% end %}
   {{ gateway_account_status(gateway, account_visitor) }}
   {{ gateway_continuation(gateway) }}
   {{ gateway_premise_stage(gateway) }}

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -81,7 +81,7 @@
     })();
     </script>
     <link rel="icon" href="/elbysodic-static/brand/elbysodic-favicon.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="/elbysodic-static/elbysodic-theme.css?v=sidebar-reexpand-1">
+    <link rel="stylesheet" href="/elbysodic-static/elbysodic-theme.css?v=sticky-topbar-1">
     <style id="elbysodic-program-theme">
 {{ program_theme_css(shell_has_community, viewer) }}
     </style>
@@ -115,7 +115,7 @@
       }
     </style>
     {% end %}
-    <script defer src="/elbysodic-static/elbysodic-shell.js?v=sidebar-cookie-2"></script>
+    <script defer src="/elbysodic-static/elbysodic-shell.js?v=sidebar-rail-toggle-1"></script>
     <script defer src="/elbysodic-static/elbysodic-composer.js?v=scene-context-inspector-1"></script>
     {% if dev_tools_enabled() %}
     <script defer src="/elbysodic-static/elbysodic-htmx-timing.js?v=1"></script>
@@ -139,21 +139,93 @@
 {% block brand_link %}
 {% set brand_has_community_shell = show_community_shell | default(true) %}
 {% set brand_viewer = viewer | default(none) %}
+{% set brand_account = account_visitor | default(none) %}
 {% set brand_community = (brand_viewer.community if brand_has_community_shell and brand_viewer else (community | default(none))) %}
-<a href="/"
-   class="chirpui-app-shell__brand elbysodic-community-brand"
-   hx-boost="false">
-  {% if brand_community and brand_community.community_mark_url %}
-  <img class="elbysodic-community-brand__mark"
-       src="{{ brand_community.community_mark_url }}"
-       alt="{{ brand_community.community_mark_alt }}">
-  {% elif not brand_has_community_shell %}
-  <img class="elbysodic-community-brand__mark elbysodic-product-mark elbysodic-product-mark--brand"
-       src="/elbysodic-static/brand/elbysodic-mark-small.svg"
-       alt="">
-  {% end %}
-  <span class="elbysodic-community-brand__name">{{ brand_community.name if brand_community else "Elbysodic" }}</span>
-</a>
+{% set brand_identity_options = brand_viewer.identity_options if brand_viewer else (brand_account.identity_options if brand_account else ()) %}
+<details class="chirpui-app-shell__brand elbysodic-realm-switcher"
+         x-data="{ open: false }"
+         x-bind:open="open"
+         @toggle="open = $el.open"
+         @click.outside="open = false"
+         @keydown.escape.window="open = false">
+  <summary class="elbysodic-realm-switcher__summary"
+           aria-label="Realm switcher: {{ brand_community.name if brand_community else "Elbysodic" }}">
+    {% if brand_community and brand_community.community_mark_url %}
+    <img class="elbysodic-community-brand__mark"
+         src="{{ brand_community.community_mark_url }}"
+         alt="{{ brand_community.community_mark_alt }}">
+    {% else %}
+    <img class="elbysodic-community-brand__mark elbysodic-product-mark elbysodic-product-mark--brand"
+         src="/elbysodic-static/brand/elbysodic-mark-small.svg"
+         alt="">
+    {% end %}
+    <span class="elbysodic-community-brand__name">{{ brand_community.name if brand_community else "Elbysodic" }}</span>
+  </summary>
+  <div class="elbysodic-realm-switcher__panel">
+    {% if brand_community %}
+    <a class="elbysodic-realm-switcher__link elbysodic-realm-switcher__link--current"
+       href="/"
+       hx-boost="false"
+       aria-current="page">
+      <span>
+        <strong>{{ brand_community.name }}</strong>
+        <small>Current realm home</small>
+      </span>
+      <b>now</b>
+    </a>
+    {% end %}
+    <a class="elbysodic-realm-switcher__link"
+       href="/"
+       data-elbysodic-global-link
+       hx-boost="false">
+      <span>
+        <strong>Elbysodic</strong>
+        <small>Network home</small>
+      </span>
+    </a>
+    <a class="elbysodic-realm-switcher__link"
+       href="/network"
+       data-elbysodic-global-link
+       hx-boost="false">
+      <span>
+        <strong>Explore realms</strong>
+        <small>Browse public previews and wanted hooks</small>
+      </span>
+    </a>
+    {% if brand_identity_options and brand_identity_options | length > 1 %}
+    <div class="elbysodic-realm-switcher__section">
+      <span class="elbysodic-identity-menu__kicker">Your realms</span>
+      <div class="elbysodic-identity-switcher" data-elbysodic-submit-group>
+        {% for option in brand_identity_options %}
+        <form action="/identity"
+              method="post"
+              hx-boost="false"
+              data-elbysodic-submit-label="Entering {{ option.community.name }}...">
+          {{ csrf_field() }}
+          <input type="hidden" name="intent" value="switch_membership">
+          <input type="hidden" name="membership_id" value="{{ option.membership.id }}">
+          <input type="hidden" name="character_id" value="{{ option.current_character.id if option.current_character else 0 }}">
+          <input type="hidden" name="next" value="{{ current_path or "/" if option.is_current and brand_viewer else option.entry_href }}">
+          <button class="elbysodic-identity-switcher__option{{ " elbysodic-identity-switcher__option--current" if option.is_current else "" }}"
+                  type="submit"
+                  {{ "disabled" if option.is_current else "" }}>
+            <span>
+              <strong>{{ option.community.name }}</strong>
+              <small>{{ option.membership.display_name or option.membership.username }} · {{ option.role.name }}{% if option.current_character %} · playing as {{ option.current_character.name }}{% endif %}</small>
+            </span>
+            {% if option.unread_notification_count %}
+            <b>{{ option.unread_notification_count }}</b>
+            {% elif option.is_current %}
+            <b>now</b>
+            {% end %}
+          </button>
+        </form>
+        {% end %}
+      </div>
+    </div>
+    {% end %}
+  </div>
+</details>
 {% end %}
 
 {% def topnav_link(href, label, is_active=False) %}
@@ -291,42 +363,11 @@
         <a href="/my/threads">Threads</a>
         {% end %}
       </div>
-      {% if viewer.identity_options and viewer.identity_options | length > 1 %}
-      <div class="elbysodic-identity-menu__section">
-        <span class="elbysodic-identity-menu__kicker">Studio Network</span>
-        <div class="elbysodic-identity-switcher" data-elbysodic-submit-group>
-          {% for option in viewer.identity_options %}
-          <form action="/identity"
-                method="post"
-                hx-boost="false"
-                data-elbysodic-submit-label="Entering {{ option.community.name }}...">
-        {{ csrf_field() }}
-            <input type="hidden" name="intent" value="switch_membership">
-            <input type="hidden" name="membership_id" value="{{ option.membership.id }}">
-            <input type="hidden" name="character_id" value="{{ option.current_character.id if option.current_character else 0 }}">
-            <input type="hidden" name="next" value="{{ current_path or "/" if option.is_current else option.entry_href }}">
-            <button class="elbysodic-identity-switcher__option{{ " elbysodic-identity-switcher__option--current" if option.is_current else "" }}"
-                    type="submit"
-                    {{ "disabled" if option.is_current else "" }}>
-              <span>
-                <strong>{{ option.community.name }}</strong>
-                <small>{{ option.membership.display_name or option.membership.username }} · {{ option.role.name }}{% if option.current_character %} · playing as {{ option.current_character.name }}{% endif %}</small>
-              </span>
-              {% if option.unread_notification_count %}
-              <b>{{ option.unread_notification_count }}</b>
-              {% elif option.is_current %}
-              <b>now</b>
-              {% end %}
-            </button>
-          </form>
-          {% end %}
-        </div>
-      </div>
-      {% end %}
       {% if viewer.current_character %}
       <form action="/identity" method="post" hx-boost="false" class="elbysodic-identity-menu__face-form">
         {{ csrf_field() }}
         <input type="hidden" name="intent" value="set_default_character">
+        <input type="hidden" name="membership_id" value="{{ viewer.membership.id }}">
         <input type="hidden" name="next" value="{{ current_path or "/" }}">
         <label class="elbysodic-identity-menu__kicker" for="active-character">Playing as</label>
         <select id="active-character"
@@ -342,12 +383,6 @@
       </form>
       {% end %}
       <div class="elbysodic-identity-menu__compact-tools">
-        <a class="elbysodic-identity-menu__notification-link{{ " elbysodic-identity-menu__notification-link--active" if topbar_route.network_active else "" }}"
-           href="/network"
-           {% if topbar_route.network_active %}aria-current="page"{% end %}>
-          Studio Network
-          <span>{{ viewer.identity_options | length }} programs</span>
-        </a>
         <a class="elbysodic-identity-menu__notification-link{{ " elbysodic-identity-menu__notification-link--active" if notifications_active else "" }}"
            href="/notifications"
            {% if notifications_active %}aria-current="page"{% end %}>
@@ -370,12 +405,6 @@
           <span>QA switcher</span>
         </a>
         {% end %}
-        <a class="elbysodic-identity-menu__notification-link{{ " elbysodic-identity-menu__notification-link--active" if topbar_route.login_active else "" }}"
-           href="/login?next={{ current_path or "/" }}"
-           {% if topbar_route.login_active %}aria-current="page"{% end %}>
-          Log in
-          <span>account session</span>
-        </a>
         <a class="elbysodic-identity-menu__notification-link" href="/logout">
           Log out
           <span>clear session</span>
@@ -416,49 +445,9 @@
       {% if signed_in_account.current_community %}
       <div class="elbysodic-identity-menu__quick-links">
         <a href="/request-access" hx-boost="false">Request access</a>
-        <a href="/network" data-elbysodic-global-link>Studio Network</a>
-      </div>
-      {% end %}
-      {% if signed_in_account.identity_options %}
-      <div class="elbysodic-identity-menu__section">
-        <span class="elbysodic-identity-menu__kicker">Your realms</span>
-        <div class="elbysodic-identity-switcher" data-elbysodic-submit-group>
-          {% for option in signed_in_account.identity_options %}
-          <form action="/identity"
-                method="post"
-                hx-boost="false"
-                data-elbysodic-submit-label="Entering {{ option.community.name }}...">
-            {{ csrf_field() }}
-            <input type="hidden" name="intent" value="switch_membership">
-            <input type="hidden" name="membership_id" value="{{ option.membership.id }}">
-            <input type="hidden" name="character_id" value="{{ option.current_character.id if option.current_character else 0 }}">
-            <input type="hidden" name="next" value="{{ option.entry_href }}">
-            <button class="elbysodic-identity-switcher__option{{ " elbysodic-identity-switcher__option--current" if option.is_current else "" }}"
-                    type="submit"
-                    {{ "disabled" if option.is_current else "" }}>
-              <span>
-                <strong>{{ option.community.name }}</strong>
-                <small>{{ option.membership.display_name or option.membership.username }} · {{ option.role.name }}{% if option.current_character %} · playing as {{ option.current_character.name }}{% endif %}</small>
-              </span>
-              {% if option.unread_notification_count %}
-              <b>{{ option.unread_notification_count }}</b>
-              {% elif option.is_current %}
-              <b>now</b>
-              {% end %}
-            </button>
-          </form>
-          {% end %}
-        </div>
       </div>
       {% end %}
       <div class="elbysodic-identity-menu__compact-tools">
-        <a class="elbysodic-identity-menu__notification-link{{ " elbysodic-identity-menu__notification-link--active" if topbar_route.network_active else "" }}"
-           href="/network"
-           data-elbysodic-global-link
-           {% if topbar_route.network_active %}aria-current="page"{% end %}>
-          Studio Network
-          <span>{{ signed_in_account.identity_options | length }} realms</span>
-        </a>
         <div class="elbysodic-identity-menu__theme-row">
           <span>Theme</span>
           {{ theme_toggle() }}

--- a/src/elbysodic/web/pages/boards/{board_slug}/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/page.html
@@ -2,6 +2,7 @@
   {% from "chirpui/breadcrumbs.html" import breadcrumbs %}
   {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
   {% from "_components/boards.html" import board_media_classes, board_media_image, board_stat_row, subboard_card %}
+  {% from "_components/director_controls.html" import director_action_menu, director_context_panel %}
   {% from "_components/facets.html" import facet_pills %}
   {% from "_components/thread_summary.html" import thread_card %}
   {% from "_components/ui.html" import empty_policy_block, event_bridge, inline_nav, inline_nav_link %}
@@ -42,6 +43,13 @@
     {% if can_start_thread %}
     <a class="chirpui-btn chirpui-btn--primary elbysodic-place-action" href="/boards/{{ board.slug }}/threads/new">Start scene here</a>
     {% end %}
+    {% if can_manage_board %}
+    {% call director_action_menu("Manage " ~ ("place" if is_location_board else "board"), "Directors only") %}
+      <a href="/studio/boards/{{ board.slug }}">Edit {{ "place" if is_location_board else "board" }} details</a>
+      <a href="/studio/structure#board-taxonomy">Review board map</a>
+      <a href="/studio/structure#navigation-composer">Check sidebar health</a>
+    {% end %}
+    {% end %}
     </div>
   </div>
 
@@ -75,6 +83,13 @@
       </div>
     </div>
   </section>
+
+  {% if can_manage_board %}
+  {% call director_context_panel("Director controls", "Manage this " ~ ("place" if is_location_board else "board"), "Edit identity, parent/sub-forum placement, sidebar visibility, and media from this object. Studio Structure is the audit view when many boards need review.", "elbysodic-director-context--compact") %}
+    <a class="chirpui-btn chirpui-btn--primary" href="/studio/boards/{{ board.slug }}">Edit {{ board.name }}</a>
+    <a class="chirpui-btn chirpui-btn--secondary" href="/studio/structure#board-taxonomy">Open board map audit</a>
+  {% end %}
+  {% end %}
 
   {% if is_location_board %}
   <section class="elbysodic-location-compass" aria-label="{{ board.name }} throughline">
@@ -145,6 +160,9 @@
       <p class="elbysodic-kicker">Sublocations</p>
       <h2>Choose a door inside {{ board.name }}</h2>
       <p class="elbysodic-copy-section">Rooms, districts, and pressure points that make this location playable.</p>
+      {% if can_manage_board %}
+      <a class="chirpui-btn chirpui-btn--secondary" href="/studio/boards/{{ board.slug }}">Edit location doors</a>
+      {% end %}
     </header>
     <div class="elbysodic-subboard-grid">
       {% for summary in subboards %}

--- a/src/elbysodic/web/pages/boards/{board_slug}/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/page.py
@@ -54,6 +54,7 @@ def get(request: Request, board_slug: str) -> Page:
         filter_options=_filter_options(board_page.board.slug, active_filter),
         next_unread_thread=board_page.next_unread_thread,
         can_start_thread=board_page.can_start_thread,
+        can_manage_board=board_page.can_manage_board,
     )
 
 

--- a/src/elbysodic/web/pages/invite/{invite_token}/page.html
+++ b/src/elbysodic/web/pages/invite/{invite_token}/page.html
@@ -1,6 +1,7 @@
 {% imports %}
   {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "chirpui/surface.html" import surface %}
+  {% from "_components/access.html" import product_identity %}
 {% end %}
 
 {% block page_root %}
@@ -9,12 +10,7 @@
 {% block page_content %}
 {% call container(max_width="42rem") %}
 {% call stack(gap="lg") %}
-  <div class="elbysodic-product-identity">
-    <img class="elbysodic-product-identity__mark"
-         src="/elbysodic-static/brand/elbysodic-mark.svg"
-         alt="">
-    <span class="elbysodic-product-identity__name">Elbysodic</span>
-  </div>
+  {{ product_identity() }}
   {% call section_header("Accept invitation") %}
   Join {{ community.name }} with the writer identity you will use here.
   {% end %}

--- a/src/elbysodic/web/pages/login/page.html
+++ b/src/elbysodic/web/pages/login/page.html
@@ -1,6 +1,7 @@
 {% imports %}
   {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "chirpui/surface.html" import surface %}
+  {% from "_components/access.html" import product_identity %}
 {% end %}
 
 {% block page_root %}
@@ -9,12 +10,7 @@
 {% block page_content %}
 {% call container(max_width="42rem") %}
 {% call stack(gap="lg") %}
-  <div class="elbysodic-product-identity">
-    <img class="elbysodic-product-identity__mark"
-         src="/elbysodic-static/brand/elbysodic-mark.svg"
-         alt="">
-    <span class="elbysodic-product-identity__name">Elbysodic</span>
-  </div>
+  {{ product_identity() }}
   {% call section_header("Log In") %}
   Choose the account first; Elbysodic will resolve the current community membership and active face after that.
   {% end %}
@@ -39,7 +35,7 @@
         {% if show_demo_login_hint %}
         Invite/demo accounts use password: <code>password</code>.
         {% else %}
-        Access is invite-only for this launch; public registration is not open.
+        Already have an account? Use it before requesting realm access so directors can review the linked account request.
         {% end %}
         <a class="chirpui-link" href="/request-access">Request access</a>.
       </p>

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -229,6 +229,24 @@
 </a>
 {% end %}
 
+{% def network_access_posture(viewer=none, account_visitor=none, home=false) %}
+{% if viewer %}
+<section class="elbysodic-network-access-note" aria-label="Network access posture">
+  <strong>Signed in as {{ viewer.membership.display_name }} in {{ viewer.community.name }}</strong>
+  {% if home %}
+  <span>Your account is active; choose a realm card to enter, preview, or request access.</span>
+  {% else %}
+  <span>Explore cards stay public-preview safe; your current realm is marked when it appears.</span>
+  {% end %}
+</section>
+{% elif account_visitor %}
+<section class="elbysodic-network-access-note" aria-label="Network access posture">
+  <strong>{{ account_visitor.display_label }} is signed in</strong>
+  <span>Browse public previews first, then request access from the realm that fits.</span>
+</section>
+{% end %}
+{% end %}
+
 {% block page_root %}
 <div id="page-root" hx-boost="false">
 {% block page_root_inner %}
@@ -257,17 +275,7 @@
     </form>
   </section>
 
-  {% if viewer %}
-  <section class="elbysodic-network-access-note" aria-label="Network access posture">
-    <strong>Signed in as {{ viewer.membership.display_name }} in {{ viewer.community.name }}</strong>
-    <span>Explore cards stay public-preview safe; your current realm is marked when it appears.</span>
-  </section>
-  {% elif account_visitor %}
-  <section class="elbysodic-network-access-note" aria-label="Network access posture">
-    <strong>{{ account_visitor.display_label }} is signed in</strong>
-    <span>Browse public previews first, then request access from the realm that fits.</span>
-  </section>
-  {% end %}
+  {{ network_access_posture(viewer, account_visitor | default(none)) }}
 
   <section class="elbysodic-network-rail" aria-labelledby="explore-results-heading">
     <div class="elbysodic-network-rail__header">
@@ -333,6 +341,7 @@
   </section>
   {% else %}
   {{ home_showcase(featured) }}
+  {{ network_access_posture(viewer, account_visitor | default(none), home=true) }}
 
   <div class="elbysodic-network-home-stack">
     {{ home_portrait_slice(home_slices[0].title, home_slices[0].href, home_slices[0].programs) }}

--- a/src/elbysodic/web/pages/page.html
+++ b/src/elbysodic/web/pages/page.html
@@ -2,6 +2,7 @@
   {% from "chirpui/layout.html" import container, stack %}
   {% from "chirpui/stat.html" import stat %}
   {% from "_components/boards.html" import board_signal, community_board_row %}
+  {% from "_components/director_controls.html" import director_context_panel %}
   {% from "_components/realm_gateway.html" import realm_gateway_home %}
   {% from "_components/thread_summary.html" import activity_item, activity_log_item %}
 {% end %}
@@ -23,7 +24,7 @@
 {% call stack(gap="lg") %}
   {% set home_community = viewer.community if viewer else public_program.community %}
   {% if realm_gateway %}
-  {{ realm_gateway_home(realm_gateway, viewer, account_visitor | default(none)) }}
+  {{ realm_gateway_home(realm_gateway, viewer, account_visitor | default(none), can_manage_home | default(false)) }}
   {% else %}
   {% set hero_treatment = home_community.world_hero_treatment or "split" %}
   {% set hero_uses_media = home_community.world_hero_image_url and hero_treatment != "text" %}
@@ -72,6 +73,13 @@
     </figure>
     {% end %}
   </section>
+  {% if can_manage_home | default(false) %}
+  {% call director_context_panel("Director controls", "Realm home controls", "Tune this home surface here; use Studio Structure only for cross-realm audit and bulk repair.") %}
+    <a class="chirpui-btn chirpui-btn--primary" href="/studio/structure#gateway-curation">Manage home spotlight</a>
+    <a class="chirpui-btn chirpui-btn--secondary" href="/studio/discovery">Edit discovery profile</a>
+    <a class="chirpui-btn chirpui-btn--secondary" href="/studio/appearance">Edit appearance</a>
+  {% end %}
+  {% end %}
   {% end %}
   {% if viewer and not realm_gateway %}
   {{ home_section_header("Locations", "In-character doors into the board's world, conflicts, and current event pressure.") }}

--- a/src/elbysodic/web/pages/page.py
+++ b/src/elbysodic/web/pages/page.py
@@ -9,6 +9,7 @@ from chirp.http.request import Request
 from chirp.templating.returns import Page
 
 from elbysodic.domain.boards import is_community_board, is_desk_board, is_location_board
+from elbysodic.services import policies
 from elbysodic.services.forum import AppServices
 from elbysodic.services.read_models import ForumView, MaterialSummary, WorldHub
 from elbysodic.web.state import get_services
@@ -83,6 +84,7 @@ def get(request: Request) -> Page:
             world_status_label=gateway.atmosphere.title,
             world_status_copy=gateway.atmosphere.copy,
             guidebook=gateway.guidebook,
+            can_manage_home=False,
             show_community_shell=False,
         )
     boards = services.list_boards()
@@ -96,6 +98,7 @@ def get(request: Request) -> Page:
         current_path=request.url,
         viewer=viewer,
         realm_gateway=realm_gateway,
+        can_manage_home=_can_manage_home(viewer),
         world_status_label=world_status_label,
         world_status_copy=world_status_copy,
         boards=boards,
@@ -121,3 +124,10 @@ def _network_services(request: Request) -> tuple[AppServices, ForumView | None]:
         return services, services.viewer()
     except PermissionError:
         return get_services(), None
+
+
+def _can_manage_home(viewer: ForumView) -> bool:
+    return policies.can_manage_navigation(
+        viewer.membership,
+        viewer.role,
+    ) or policies.can_manage_world(viewer.membership, viewer.role)

--- a/src/elbysodic/web/pages/request-access/page.html
+++ b/src/elbysodic/web/pages/request-access/page.html
@@ -1,87 +1,108 @@
 {% imports %}
   {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "chirpui/surface.html" import surface %}
+  {% from "_components/access.html" import access_account_notice, product_identity %}
 {% end %}
 
 {% block page_root %}
 <div id="page-root">
 {% block page_root_inner %}
 {% block page_content %}
-{% call container(max_width="42rem") %}
+{% call container(max_width="56rem") %}
 {% call stack(gap="lg") %}
-  <div class="elbysodic-product-identity">
-    <img class="elbysodic-product-identity__mark"
-         src="/elbysodic-static/brand/elbysodic-mark.svg"
-         alt="">
-    <span class="elbysodic-product-identity__name">Elbysodic</span>
-  </div>
-  {% call section_header("Request access") %}
-  {% if community is defined and community %}
-  {{ community.name }} is invite-only while its director controls first entry.
-  {% else %}
-  Elbysodic is invite-only while the first realm opens.
-  {% end %}
-  {% end %}
+  <header class="elbysodic-access-heading">
+    {{ product_identity() }}
+    <div>
+      <p class="elbysodic-section-kicker">
+        {% if community is defined and community %}{{ community.name }}{% else %}Elbysodic{% end %}
+      </p>
+      <h1>Request access</h1>
+      <p>
+        {% if community is defined and community %}
+        {{ community.name }} is invite-only while its director controls the roster gate.
+        {% else %}
+        Elbysodic is invite-only while the first realm opens.
+        {% end %}
+      </p>
+    </div>
+  </header>
 
   {% call surface(variant="elevated") %}
   <div class="elbysodic-access-panel">
-    <p class="elbysodic-section-kicker">Invite-only</p>
-    <h1>Access opens through a director invitation.</h1>
-    <p>
-      Public registration is closed for now. A director sends invitations so writer
-      names, roles, roster ownership, and first faces start in the right realm.
-    </p>
+    <div class="elbysodic-access-panel__intro">
+      <p class="elbysodic-section-kicker">Invite-only</p>
+      <h2>Access opens through a director invitation.</h2>
+      <p>
+        Directors gate first entry so writer names, roles, roster ownership, and
+        first faces start in the right realm.
+      </p>
+    </div>
     {% if submitted_email %}
     <div class="elbysodic-quiet-empty" role="status">
+      {% if submitted_account | default(false) %}
+      Access request received for your Elbysodic account. A director can review
+      it from Studio Launch before opening the roster gate.
+      {% else %}
       Access request received for {{ submitted_email }}. A director can review it
       from Studio Launch before sending an invitation.
+      {% end %}
     </div>
     {% end %}
     {% if error %}
     <p class="elbysodic-form-error" role="alert">{{ error }}</p>
     {% end %}
+    {{ access_account_notice(account_visitor | default(none), community if community is defined else none) }}
     {% if community is defined and community %}
-    <form class="chirpui-stack chirpui-stack--sm" method="post" action="/request-access" hx-boost="false">
+    <form class="elbysodic-access-form" method="post" action="/request-access" hx-boost="false">
       {{ csrf_field() }}
       <input type="hidden" name="community_slug" value="{{ community.slug }}">
-      <label class="chirpui-field">
+      {% if not (account_visitor | default(none)) %}
+      <label class="chirpui-field elbysodic-access-field">
         <span>Writer email</span>
         <input name="email"
                type="email"
+               class="chirpui-field__input"
                value="{{ form.email }}"
                autocomplete="email"
                required>
       </label>
-      <label class="chirpui-field">
+      {% end %}
+      <label class="chirpui-field elbysodic-access-field">
         <span>Writer name</span>
         <input name="display_name"
+               class="chirpui-field__input"
                value="{{ form.display_name }}"
                autocomplete="name"
                placeholder="The name directors should recognize">
       </label>
-      <label class="chirpui-field">
+      <label class="chirpui-field elbysodic-access-field">
         <span>Face concept</span>
         <input name="face_concept"
+               class="chirpui-field__input"
                value="{{ form.face_concept }}"
                maxlength="500"
                placeholder="Archivist, rebel heir, forbidden envoy">
       </label>
-      <label class="chirpui-field">
+      <label class="chirpui-field elbysodic-access-field">
         <span>Wanted hook or way in</span>
         <input name="wanted_hook"
+               class="chirpui-field__input"
                value="{{ form.wanted_hook }}"
                maxlength="240"
                placeholder="Archive thief, opening pressure, town politics">
       </label>
-      <label class="chirpui-field">
+      <label class="chirpui-field elbysodic-access-field elbysodic-access-field--wide">
         <span>Notes for directors</span>
         <textarea name="notes"
+                  class="chirpui-field__input"
                   rows="4"
                   maxlength="2000"
                   placeholder="Availability, boundaries, prior invite context, or what you want to write">{{ form.notes }}</textarea>
       </label>
-      <div class="elbysodic-access-panel__actions">
-        <button class="chirpui-btn chirpui-btn--primary" type="submit">Send access request</button>
+      <div class="elbysodic-access-form__actions">
+        <button class="chirpui-btn chirpui-btn--primary" type="submit">
+          {% if account_visitor | default(none) %}Request access with this account{% else %}Send access request{% end %}
+        </button>
       </div>
     </form>
     {% else %}
@@ -90,14 +111,23 @@
       know which roster and first-face lane you mean.
     </p>
     {% end %}
-    <div class="elbysodic-access-panel__actions">
-      {% if account_visitor | default(none) %}
-      <a class="chirpui-btn chirpui-btn--primary" href="/network" data-elbysodic-global-link>Browse your realms</a>
-      {% else %}
-      <a class="chirpui-btn chirpui-btn--primary" href="/login?next=/">Log in</a>
-      {% end %}
-      <a class="chirpui-btn chirpui-btn--secondary" href="/network">Explore realms</a>
-    </div>
+    <footer class="elbysodic-access-panel__footer">
+      <span>
+        {% if account_visitor | default(none) %}
+        Want a different realm?
+        {% else %}
+        Already have an Elbysodic account?
+        {% end %}
+      </span>
+      <div class="elbysodic-access-panel__actions">
+        {% if account_visitor | default(none) %}
+        <a class="chirpui-btn chirpui-btn--secondary" href="/network" data-elbysodic-global-link>Browse your realms</a>
+        {% else %}
+        <a class="chirpui-btn chirpui-btn--secondary" href="/login?next={{ current_path or "/" }}">Log in with Elbysodic</a>
+        {% end %}
+        <a class="chirpui-btn chirpui-btn--secondary" href="/network">Explore realms</a>
+      </div>
+    </footer>
   </div>
   {% end %}
 {% end %}

--- a/src/elbysodic/web/pages/request-access/page.py
+++ b/src/elbysodic/web/pages/request-access/page.py
@@ -37,7 +37,7 @@ async def post(request: Request, form: RequestAccessForm) -> Page:
     try:
         access_request = services.create_access_request(
             community_slug,
-            email=form.email,
+            email=account_visitor.user.email if account_visitor else form.email,
             display_name=form.display_name,
             face_concept=form.face_concept,
             wanted_hook=form.wanted_hook,
@@ -52,6 +52,7 @@ async def post(request: Request, form: RequestAccessForm) -> Page:
         request,
         form=RequestAccessForm(),
         submitted_email=access_request.email,
+        submitted_account=account_visitor is not None,
     )
 
 
@@ -61,6 +62,7 @@ def _render_request_access(
     error: str = "",
     form: RequestAccessForm | None = None,
     submitted_email: str = "",
+    submitted_account: bool = False,
 ) -> Page:
     services = get_services()
     tenant_slug = request_tenant_slug(request)
@@ -82,5 +84,6 @@ def _render_request_access(
         form=form,
         error=error,
         submitted_email=submitted_email,
+        submitted_account=submitted_account,
         show_community_shell=False,
     )

--- a/src/elbysodic/web/pages/studio/access-requests/{request_id}/page.html
+++ b/src/elbysodic/web/pages/studio/access-requests/{request_id}/page.html
@@ -20,13 +20,17 @@
     <header class="chirpui-cluster chirpui-cluster--between">
       <div>
         <p class="elbysodic-section-kicker">Writer entry</p>
-        <h1>{{ item.request.display_name or item.request.email }}</h1>
-        <p class="elbysodic-copy-meta">{{ item.request.email }}</p>
+        <h1>{{ item.display_label }}</h1>
+        <p class="elbysodic-copy-meta">{{ item.contact_label }}</p>
       </div>
       {{ badge(item.status_label, variant="success" if item.request.status == "invited" else "muted") }}
     </header>
 
     <dl class="elbysodic-definition-grid">
+      <div>
+        <dt>Request source</dt>
+        <dd>{{ item.account_link_label }}</dd>
+      </div>
       <div>
         <dt>Status</dt>
         <dd>{{ item.status_label }}</dd>

--- a/src/elbysodic/web/pages/studio/appearance/_meta.py
+++ b/src/elbysodic/web/pages/studio/appearance/_meta.py
@@ -1,0 +1,3 @@
+from chirp.pages.types import RouteMeta
+
+META = RouteMeta(title="Appearance Studio", breadcrumb_label="Appearance")

--- a/src/elbysodic/web/pages/studio/appearance/page.py
+++ b/src/elbysodic/web/pages/studio/appearance/page.py
@@ -1,0 +1,15 @@
+"""Director Studio appearance room."""
+
+from chirp.http.request import Request
+from chirp.http.response import Redirect
+from chirp.templating.returns import Page
+
+from elbysodic.web.pages.studio.page import handle_studio_post, render_studio_room
+
+
+def get(request: Request) -> Page | Redirect:
+    return render_studio_room(request, "appearance")
+
+
+async def post(request: Request) -> Page | Redirect:
+    return await handle_studio_post(request, "appearance")

--- a/src/elbysodic/web/pages/studio/boards/{board_slug}/page.html
+++ b/src/elbysodic/web/pages/studio/boards/{board_slug}/page.html
@@ -15,7 +15,7 @@
     <nav class="elbysodic-place-path" aria-label="Studio path">
       <a href="/studio">Studio</a>
       <span class="elbysodic-place-path__separator" aria-hidden="true">/</span>
-      <a href="/studio#board-taxonomy">Board taxonomy</a>
+      <a href="/studio/structure#board-taxonomy">Board map</a>
       <span class="elbysodic-place-path__separator" aria-hidden="true">/</span>
       <span aria-current="page">{{ editor.board.name }}</span>
     </nav>

--- a/src/elbysodic/web/pages/studio/content/_meta.py
+++ b/src/elbysodic/web/pages/studio/content/_meta.py
@@ -1,0 +1,3 @@
+from chirp.pages.types import RouteMeta
+
+META = RouteMeta(title="Studio Content", breadcrumb_label="Content")

--- a/src/elbysodic/web/pages/studio/content/page.py
+++ b/src/elbysodic/web/pages/studio/content/page.py
@@ -1,0 +1,15 @@
+"""Director Studio content room."""
+
+from chirp.http.request import Request
+from chirp.http.response import Redirect
+from chirp.templating.returns import Page
+
+from elbysodic.web.pages.studio.page import handle_studio_post, render_studio_room
+
+
+def get(request: Request) -> Page | Redirect:
+    return render_studio_room(request, "content")
+
+
+async def post(request: Request) -> Page | Redirect:
+    return await handle_studio_post(request, "content")

--- a/src/elbysodic/web/pages/studio/discovery/page.html
+++ b/src/elbysodic/web/pages/studio/discovery/page.html
@@ -64,7 +64,7 @@
 
   <section class="elbysodic-network-two-up" aria-label="Discovery editor">
     {% call surface(variant="elevated") %}
-    <form class="chirpui-stack chirpui-stack--md" method="post" hx-boost="false">
+    <form class="chirpui-stack chirpui-stack--md" method="post" hx-boost="false" data-elbysodic-discovery-preview-form>
       {{ csrf_field() }}
       <div>
         <p class="elbysodic-kicker">Network listing</p>
@@ -115,14 +115,12 @@
         <h2>Network card</h2>
         <p class="elbysodic-copy-section">This is how the realm appears in Network Explore.</p>
       </div>
-      {{ program_card(editor.preview_card) }}
-      {% if editor.tags %}
-      <div class="elbysodic-network-discovery-band">
+      {{ program_card(editor.preview_card, preview=true) }}
+      <div class="elbysodic-network-discovery-band" data-elbysodic-preview-tags {% if not editor.tags %}hidden{% end %}>
         {% for tag in editor.tags %}
         <a href="/network?q={{ tag.tag_key }}">{{ tag.label }}</a>
         {% end %}
       </div>
-      {% end %}
     </section>
   </section>
 {% end %}

--- a/src/elbysodic/web/pages/studio/launch/page.html
+++ b/src/elbysodic/web/pages/studio/launch/page.html
@@ -46,15 +46,15 @@
     <form class="chirpui-stack chirpui-stack--sm" method="post" action="/studio/launch" hx-boost="false">
       {{ csrf_field() }}
       <input type="hidden" name="intent" value="launch_status">
-      <label class="chirpui-field">
-        <span>Opening</span>
+      <label class="chirpui-field chirpui-field--outlined elbysodic-form-field">
+        <span class="chirpui-field__label">Opening</span>
         <select class="chirpui-field__input" name="launch_status">
           <option value="backstage" {{ "selected" if viewer.community.launch_status == "backstage" else "" }}>Backstage</option>
           <option value="invite-only" {{ "selected" if viewer.community.launch_status == "invite-only" else "" }}>Invite-only</option>
           <option value="public-preview" {{ "selected" if viewer.community.launch_status == "public-preview" else "" }}>Public preview</option>
         </select>
       </label>
-      <div class="elbysodic-network-card__actions">
+      <div class="elbysodic-studio-actions">
         <button class="chirpui-btn chirpui-btn--secondary" type="submit">Save opening</button>
       </div>
     </form>
@@ -70,14 +70,15 @@
       </div>
       {{ badge(launch.completed_required_count ~ "/" ~ launch.required_count ~ " required", variant="success" if launch.is_ready else "warning") }}
     </div>
-    <ul class="elbysodic-operations-list">
+    <ul class="elbysodic-launch-checklist" aria-label="Opening checklist lanes">
       {% for item in launch.items %}
-      <li>
-        <div>
+      <li class="elbysodic-launch-checklist__item{% if item.is_complete %} elbysodic-launch-checklist__item--ready{% elif item.is_required %} elbysodic-launch-checklist__item--needed{% else %} elbysodic-launch-checklist__item--optional{% end %}">
+        <span class="elbysodic-launch-checklist__marker" aria-hidden="true"></span>
+        <div class="elbysodic-launch-checklist__copy">
           <strong>{{ item.label }}</strong>
           <span>{{ item.summary }}</span>
         </div>
-        <div class="elbysodic-network-card__actions">
+        <div class="elbysodic-launch-checklist__actions">
           {{ badge(item.status_label, variant=item.status_variant) }}
           <a class="chirpui-btn chirpui-btn--secondary" href="{{ item.href }}">{{ item.cta }}</a>
         </div>
@@ -100,19 +101,19 @@
     <form class="chirpui-stack chirpui-stack--sm" method="post" action="/studio/launch" hx-boost="false">
       {{ csrf_field() }}
       <input type="hidden" name="intent" value="apply_builder">
-      <label class="chirpui-field">
-        <span>Scene hub</span>
-        <input name="scene_hub_name" value="{{ builder_form.scene_hub_name or 'Opening Scenes' }}" required>
+      <label class="chirpui-field chirpui-field--outlined elbysodic-form-field">
+        <span class="chirpui-field__label">Scene hub</span>
+        <input class="chirpui-field__input" name="scene_hub_name" value="{{ builder_form.scene_hub_name or 'Opening Scenes' }}" required>
       </label>
-      <label class="chirpui-field">
-        <span>Premise</span>
-        <textarea name="premise_summary" rows="3">{{ builder_form.premise_summary }}</textarea>
+      <label class="chirpui-field chirpui-field--outlined elbysodic-form-field">
+        <span class="chirpui-field__label">Premise</span>
+        <textarea class="chirpui-field__input" name="premise_summary" rows="3">{{ builder_form.premise_summary }}</textarea>
       </label>
-      <label class="chirpui-field">
-        <span>Application guide</span>
-        <textarea name="application_summary" rows="3">{{ builder_form.application_summary }}</textarea>
+      <label class="chirpui-field chirpui-field--outlined elbysodic-form-field">
+        <span class="chirpui-field__label">Application guide</span>
+        <textarea class="chirpui-field__input" name="application_summary" rows="3">{{ builder_form.application_summary }}</textarea>
       </label>
-      <div class="elbysodic-network-card__actions">
+      <div class="elbysodic-studio-actions">
         <button class="chirpui-btn chirpui-btn--primary" type="submit">Create opening packet</button>
       </div>
     </form>
@@ -126,7 +127,7 @@
     <p class="elbysodic-copy-section">
       This room tracks whether a director has shaped the realm enough for invite-only opening. Public self-serve creator onboarding, billing, custom domains, and Blueprint Apply remain future work.
     </p>
-    <div class="elbysodic-network-card__actions">
+    <div class="elbysodic-studio-actions">
       <a class="chirpui-btn chirpui-btn--secondary" href="/studio/intake#program-blueprint-preview">Preview blueprint</a>
     </div>
   </section>
@@ -166,11 +167,11 @@
     <form class="chirpui-stack chirpui-stack--sm" method="post" action="/studio/launch" hx-boost="false">
       {{ csrf_field() }}
       <input type="hidden" name="intent" value="create_invite">
-      <label class="chirpui-field">
-        <span>Writer email</span>
-        <input name="email" type="email" value="{{ invite_email if invite_error else '' }}" autocomplete="email" required>
+      <label class="chirpui-field chirpui-field--outlined elbysodic-form-field">
+        <span class="chirpui-field__label">Writer email</span>
+        <input class="chirpui-field__input" name="email" type="email" value="{{ invite_email if invite_error else '' }}" autocomplete="email" required>
       </label>
-      <div class="elbysodic-network-card__actions">
+      <div class="elbysodic-studio-actions">
         <button class="chirpui-btn chirpui-btn--primary" type="submit">Create invitation</button>
       </div>
     </form>
@@ -185,7 +186,7 @@
           <span>Raw link is no longer available here. Revoke this pending invitation and create a fresh one if the writer loses it.</span>
           {% end %}
         </div>
-        <div class="elbysodic-network-card__actions">
+        <div class="elbysodic-studio-actions">
           {% if item.can_revoke %}
           <form method="post" action="/studio/launch" hx-boost="false">
             {{ csrf_field() }}
@@ -214,8 +215,9 @@
         {% for item in access_request_items %}
         <li>
           <div>
-            <strong><a class="chirpui-link" href="/studio/access-requests/{{ item.request.id }}">{{ item.request.email }}</a></strong>
-            <span>{{ item.status_label }} · {{ item.request.display_name or "No writer name yet" }}</span>
+            <strong><a class="chirpui-link" href="/studio/access-requests/{{ item.request.id }}">{{ item.display_label }}</a></strong>
+            <span>{{ item.status_label }} · {{ item.account_link_label }}</span>
+            <span>{{ item.contact_label }}</span>
             {% if item.request.face_concept %}
             <span>Face concept: {{ item.request.face_concept }}</span>
             {% end %}
@@ -232,7 +234,7 @@
             <span>{{ item.request.notes }}</span>
             {% end %}
           </div>
-          <div class="elbysodic-network-card__actions">
+          <div class="elbysodic-studio-actions">
             {% if item.request.status == "pending" %}
             <form method="post" action="/studio/launch" hx-boost="false">
               {{ csrf_field() }}

--- a/src/elbysodic/web/pages/studio/launch/page.py
+++ b/src/elbysodic/web/pages/studio/launch/page.py
@@ -9,6 +9,7 @@ from chirp.errors import HTTPError
 from chirp.http.request import Request
 from chirp.templating.returns import Page
 
+from elbysodic.domain.models import CommunityAccessRequest
 from elbysodic.web.state import get_services
 
 
@@ -88,12 +89,12 @@ async def post(request: Request, form: LaunchActionForm) -> Page:
             if form.intent == "review_access_request":
                 updated_request = get_services(request).review_access_request(access_request_id)
                 access_request_message = (
-                    f"Access request from {updated_request.email} was reviewed."
+                    f"Access request from {_access_request_label(updated_request)} was reviewed."
                 )
             else:
                 updated_request = get_services(request).decline_access_request(access_request_id)
                 access_request_message = (
-                    f"Access request from {updated_request.email} was declined."
+                    f"Access request from {_access_request_label(updated_request)} was declined."
                 )
         except PermissionError as exc:
             raise HTTPError(status=403, detail=str(exc)) from exc
@@ -106,7 +107,9 @@ async def post(request: Request, form: LaunchActionForm) -> Page:
         except ValueError:
             return _render_launch(request, access_request_error="access request is required")
         try:
-            created = get_services(request).invite_access_request(access_request_id)
+            services = get_services(request)
+            request_item = services.access_request_detail(access_request_id)
+            created = services.invite_access_request(access_request_id)
         except PermissionError as exc:
             raise HTTPError(status=403, detail=str(exc)) from exc
         except (LookupError, ValueError) as exc:
@@ -116,7 +119,7 @@ async def post(request: Request, form: LaunchActionForm) -> Page:
             invite_path=created.path,
             invite_email=created.invitation.email,
             access_request_message=(
-                f"Invitation created from access request for {created.invitation.email}."
+                f"Invitation created from access request for {request_item.display_label}."
             ),
         )
     if form.intent != "create_invite":
@@ -132,6 +135,14 @@ async def post(request: Request, form: LaunchActionForm) -> Page:
         invite_path=created.path,
         invite_email=created.invitation.email,
     )
+
+
+def _access_request_label(access_request: CommunityAccessRequest) -> str:
+    if access_request.display_name:
+        return access_request.display_name
+    if access_request.account_user_id is not None:
+        return "linked Elbysodic account"
+    return access_request.email
 
 
 def _render_launch(

--- a/src/elbysodic/web/pages/studio/page.html
+++ b/src/elbysodic/web/pages/studio/page.html
@@ -41,6 +41,29 @@
 {% end %}
 {% end %}
 
+{% def studio_room_card(room) %}
+{% call surface(variant="elevated") %}
+<article class="elbysodic-director-lane elbysodic-director-lane--{{ room.variant }}">
+  <div class="elbysodic-director-lane__header">
+    <div>
+      <p class="elbysodic-kicker">{{ room.kicker }}</p>
+      <h2><a class="chirpui-link" href="{{ room.href }}">{{ room.title }}</a></h2>
+    </div>
+    <span class="elbysodic-director-lane__count">{{ room.count }}</span>
+  </div>
+  <p class="elbysodic-copy-summary">{{ room.summary }}</p>
+  {% if room.items %}
+  <ul class="elbysodic-director-list">
+    {% for item in room.items[:3] %}
+    <li>{{ item }}</li>
+    {% end %}
+  </ul>
+  {% end %}
+  <a class="elbysodic-director-action" href="{{ room.href }}">{{ room.cta }}</a>
+</article>
+{% end %}
+{% end %}
+
 {% def navigation_health(studio) %}
 <section class="elbysodic-navigation-health" aria-labelledby="navigation-health-heading">
   <div class="elbysodic-navigation-health__header">
@@ -110,39 +133,133 @@
 </fieldset>
 {% end %}
 
-{% def gateway_curation_section(section, field_name, position_prefix) %}
-<fieldset class="elbysodic-gateway-curation-section">
-  <legend>{{ section.title }}</legend>
-  <p>{{ section.summary }}</p>
-  {% if section.choices %}
-  <div class="elbysodic-gateway-curation-list">
-    {% for choice in section.choices %}
-    <label class="elbysodic-gateway-curation-choice">
-      <input type="checkbox"
-             name="{{ field_name }}"
-             value="{{ choice.target_id }}"
-             {% if choice.is_selected %}checked{% end %}>
-      <span class="elbysodic-gateway-curation-choice__copy">
-        <strong>{{ choice.title }}</strong>
-        <small>{{ choice.summary }}</small>
-        <a class="chirpui-link" href="{{ choice.href }}">Preview</a>
-      </span>
-      <span class="chirpui-field chirpui-field--outlined chirpui-field--dense elbysodic-gateway-curation-choice__position">
-        <span class="chirpui-field__label">Order</span>
-        <input class="chirpui-field__input"
-               type="number"
-               min="1"
-               step="1"
-               name="{{ position_prefix }}{{ choice.target_id }}"
-               value="{{ choice.position_value }}">
-      </span>
-    </label>
-    {% end %}
+{% def spotlight_item(choice, field_name, position_prefix, type_label, selected) %}
+<article class="elbysodic-spotlight-item{% if selected %} elbysodic-spotlight-item--selected{% else %} elbysodic-spotlight-item--available{% end %}"
+         draggable="{{ 'true' if selected else 'false' }}"
+         tabindex="-1"
+         data-elbysodic-gateway-curation-item
+         data-elbysodic-spotlight-item
+         data-elbysodic-spotlight-type="{{ type_label }}"
+         data-elbysodic-spotlight-title="{{ choice.title }}"
+         data-elbysodic-spotlight-summary="{{ choice.summary }}">
+  <input type="checkbox"
+         name="{{ field_name }}"
+         value="{{ choice.target_id }}"
+         aria-label="Show {{ choice.title }} on the public home spotlight"
+         data-elbysodic-gateway-curation-select
+         hidden
+         {% if selected %}checked{% end %}>
+  <input type="hidden"
+         name="{{ position_prefix }}{{ choice.target_id }}"
+         value="{{ choice.position_value }}"
+         data-elbysodic-gateway-curation-position>
+  <button class="elbysodic-spotlight-item__handle"
+          type="button"
+          aria-label="Drag {{ choice.title }} to reorder">
+    Drag
+  </button>
+  <div class="elbysodic-spotlight-item__copy">
+    <span>{{ type_label }}</span>
+    <h4>{{ choice.title }}</h4>
+    <p>{{ choice.summary }}</p>
   </div>
-  {% else %}
-  <p class="elbysodic-empty-state">No eligible items are public right now.</p>
-  {% end %}
-</fieldset>
+  <div class="elbysodic-spotlight-item__actions">
+    <span class="elbysodic-spotlight-item__rank" data-elbysodic-gateway-curation-rank></span>
+    <a class="chirpui-link" href="{{ choice.href }}">Preview</a>
+    <button class="chirpui-btn chirpui-btn--secondary elbysodic-spotlight-item__add"
+            type="button"
+            data-elbysodic-spotlight-add>
+      Add to spotlight
+    </button>
+    <button class="chirpui-btn chirpui-btn--secondary elbysodic-spotlight-item__remove"
+            type="button"
+            data-elbysodic-spotlight-remove>
+      Remove
+    </button>
+    <span class="elbysodic-spotlight-item__move" aria-label="Reorder {{ choice.title }}">
+      <button class="chirpui-btn chirpui-btn--secondary" type="button" aria-label="Move {{ choice.title }} up" data-elbysodic-gateway-curation-up>Move up</button>
+      <button class="chirpui-btn chirpui-btn--secondary" type="button" aria-label="Move {{ choice.title }} down" data-elbysodic-gateway-curation-down>Move down</button>
+    </span>
+  </div>
+</article>
+{% end %}
+
+{% def spotlight_selected_lane(section, field_name, position_prefix, type_label) %}
+<section class="elbysodic-spotlight-lane" aria-labelledby="spotlight-selected-{{ section.slot_type }}">
+  <header class="elbysodic-spotlight-lane__header">
+    <div>
+      <p class="elbysodic-kicker">{{ type_label }}</p>
+      <h3 id="spotlight-selected-{{ section.slot_type }}">{{ section.title }}</h3>
+    </div>
+    <span data-elbysodic-spotlight-count>{{ section.selected_count }}</span>
+  </header>
+  <div class="elbysodic-spotlight-list"
+       data-elbysodic-gateway-curation-list
+       data-elbysodic-spotlight-selected-list
+       data-elbysodic-spotlight-list-for="{{ section.slot_type }}"
+       aria-label="{{ section.title }} spotlight order">
+    {% for choice in section.choices %}
+    {% if choice.is_selected %}
+    {{ spotlight_item(choice, field_name, position_prefix, type_label, true) }}
+    {% end %}
+    {% end %}
+    <p class="elbysodic-empty-state elbysodic-spotlight-empty" data-elbysodic-spotlight-empty>
+      No {{ section.title | lower }} are in the public spotlight yet.
+    </p>
+  </div>
+</section>
+{% end %}
+
+{% def spotlight_library_section(section, field_name, position_prefix, type_label) %}
+<details class="elbysodic-spotlight-library-section" open>
+  <summary>
+    <span>{{ section.title }}</span>
+    <small>{{ section.summary }}</small>
+  </summary>
+  <div class="elbysodic-spotlight-library-list"
+       data-elbysodic-spotlight-library-list
+       data-elbysodic-spotlight-list-for="{{ section.slot_type }}">
+    {% for choice in section.choices %}
+    {% if not choice.is_selected %}
+    {{ spotlight_item(choice, field_name, position_prefix, type_label, false) }}
+    {% end %}
+    {% end %}
+    <p class="elbysodic-empty-state elbysodic-spotlight-empty" data-elbysodic-spotlight-empty>
+      All available {{ section.title | lower }} are already in the spotlight.
+    </p>
+  </div>
+</details>
+{% end %}
+
+{% def spotlight_preview(studio) %}
+<aside class="elbysodic-spotlight-preview" aria-label="Realm home spotlight preview">
+  <div>
+    <p class="elbysodic-kicker">Realm home preview</p>
+    <h3>What visitors see first</h3>
+    <p>Selected items appear as the first public ways into the realm before board map and sidebar choices matter.</p>
+  </div>
+  <ol data-elbysodic-spotlight-preview-list>
+    {% for choice in studio.gateway_curation.scene_hubs.choices %}
+    {% if choice.is_selected %}
+    <li><span>Scene hub</span><strong>{{ choice.title }}</strong></li>
+    {% end %}
+    {% end %}
+    {% for choice in studio.gateway_curation.wanted_hooks.choices %}
+    {% if choice.is_selected %}
+    <li><span>Wanted hook</span><strong>{{ choice.title }}</strong></li>
+    {% end %}
+    {% end %}
+    {% for choice in studio.gateway_curation.guidebook_materials.choices %}
+    {% if choice.is_selected %}
+    <li><span>Guidebook</span><strong>{{ choice.title }}</strong></li>
+    {% end %}
+    {% end %}
+  </ol>
+  <p class="elbysodic-empty-state" data-elbysodic-spotlight-preview-empty>
+    Visitors will see the default realm overview until you add spotlight items.
+  </p>
+  <a class="chirpui-btn chirpui-btn--secondary" href="/c/{{ viewer.community.slug }}">Preview realm home</a>
+</aside>
 {% end %}
 
 {% block page_root %}
@@ -151,13 +268,31 @@
 {% block page_content %}
 {% call container(max_width="76rem") %}
 {% call stack(gap="lg") %}
+  {% if studio_room != "overview" and current_studio_room %}
+  <div class="elbysodic-place-toolbar">
+    <nav class="elbysodic-place-path" aria-label="Studio path">
+      <a href="/studio">Studio</a>
+      <span class="elbysodic-place-path__separator" aria-hidden="true">/</span>
+      <span aria-current="page">{{ current_studio_room.title }}</span>
+    </nav>
+    <div class="chirpui-cluster chirpui-cluster--sm">
+      <a class="chirpui-btn chirpui-btn--secondary" href="/studio/operations">Operations</a>
+      <a class="chirpui-btn chirpui-btn--secondary" href="/c/{{ viewer.community.slug }}">Preview realm</a>
+    </div>
+  </div>
+  {% end %}
+
   <section class="elbysodic-director-hero">
     <div>
       <p class="elbysodic-kicker">Director Studio</p>
-      <h1>Shape {{ viewer.community.name }}</h1>
+      <h1>{% if current_studio_room %}{{ current_studio_room.title }}{% else %}Shape {{ viewer.community.name }}{% end %}</h1>
       <p class="elbysodic-copy-lead">
+        {% if current_studio_room %}
+        {{ current_studio_room.summary }}
+        {% else %}
         A director room for the canon, locations, applications, and hooks that
         need director attention now.
+        {% end %}
       </p>
     </div>
     <aside class="elbysodic-director-hero__signals" aria-label="Studio pulse">
@@ -168,6 +303,21 @@
     </aside>
   </section>
 
+  {% if not studio.can_manage %}
+  <aside class="elbysodic-notice elbysodic-notice--staff" aria-label="Staff preview">
+    <span class="elbysodic-notice__mark" aria-hidden="true">i</span>
+    <span class="elbysodic-notice__label">Staff preview</span>
+    <span class="elbysodic-notice__body">
+      <strong class="elbysodic-notice__title">Director tools are read-only here</strong>
+      <span class="elbysodic-notice__summary">
+        Director Studio is visible as a preview, but only staff memberships can manage
+        community canon and queues.
+      </span>
+    </span>
+  </aside>
+  {% end %}
+
+  {% if studio_room == "overview" %}
   <section class="chirpui-stack chirpui-stack--md" aria-label="Director attention">
     {% call section_header("Director attention") %}
     Queues and opening risks that need movement before writers feel them.
@@ -202,42 +352,78 @@
     {% end %}
   </section>
 
+  <section class="chirpui-stack chirpui-stack--md" aria-label="Studio rooms">
+    {% call section_header("Studio rooms") %}
+    Move through the realm in the order directors usually need: daily desk, opening gates, public presence, structure, intake, appearance, then content pressure.
+    {% end %}
+    <div class="elbysodic-director-grid" aria-label="Studio room shortcuts">
+      {% for room in studio_rooms %}
+      {{ studio_room_card(room) }}
+      {% end %}
+    </div>
+  </section>
+  {% end %}
+
+  {% if studio_room == "structure" %}
   {% if studio.can_manage %}
   <section id="gateway-curation" class="elbysodic-studio-room chirpui-stack chirpui-stack--md" aria-labelledby="gateway-curation-heading">
-  {{ room_header("Community home", "Gateway curation", "Choose the public scene hubs, wanted hooks, and guidebook pages that should lead first-face browsing.", "gateway-curation-heading") }}
+  {{ room_header("Public home", "Home spotlight audit", "Review the first scene hubs, wanted hooks, and guidebook materials visitors see before they request access or make a first face.", "gateway-curation-heading") }}
   {% call surface(variant="elevated") %}
-  <form class="chirpui-stack chirpui-stack--md" method="post">
+  <form class="elbysodic-spotlight-composer chirpui-stack chirpui-stack--md"
+        method="post"
+        data-elbysodic-spotlight-composer>
     {{ csrf_field() }}
     <input type="hidden" name="intent" value="gateway_curation">
     {% if error %}
     <p class="elbysodic-form-error">{{ error }}</p>
     {% end %}
-    <div class="elbysodic-gateway-curation-grid">
-      {{ gateway_curation_section(studio.gateway_curation.scene_hubs, "scene_hub_target_id", "scene_hub_position_") }}
-      {{ gateway_curation_section(studio.gateway_curation.wanted_hooks, "wanted_hook_target_id", "wanted_hook_position_") }}
-      {{ gateway_curation_section(studio.gateway_curation.guidebook_materials, "guidebook_material_target_id", "guidebook_material_position_") }}
+    <div class="elbysodic-spotlight-composer__brief">
+      <p class="elbysodic-kicker">Visitor-facing curation</p>
+      <p>
+        This is the cross-realm audit view. Directors can also open these controls from the realm home.
+      </p>
     </div>
-    <div class="chirpui-cluster">
-      <button class="chirpui-btn chirpui-btn--primary" type="submit">Save gateway curation</button>
-      <a class="chirpui-btn chirpui-btn--secondary" href="/c/{{ viewer.community.slug }}">Preview home</a>
+    <div class="elbysodic-spotlight-composer__layout">
+      <section class="elbysodic-spotlight-sequence" aria-label="Selected public home spotlight">
+        <div class="elbysodic-spotlight-section-heading">
+          <div>
+            <p class="elbysodic-kicker">Shown on home</p>
+            <h3>Selected spotlight</h3>
+          </div>
+          <p>Move selected items into the order visitors should scan them.</p>
+        </div>
+        {{ spotlight_selected_lane(studio.gateway_curation.scene_hubs, "scene_hub_target_id", "scene_hub_position_", "Scene hub") }}
+        {{ spotlight_selected_lane(studio.gateway_curation.wanted_hooks, "wanted_hook_target_id", "wanted_hook_position_", "Wanted hook") }}
+        {{ spotlight_selected_lane(studio.gateway_curation.guidebook_materials, "guidebook_material_target_id", "guidebook_material_position_", "Guidebook") }}
+      </section>
+      <aside class="elbysodic-spotlight-library" aria-label="Available public home spotlight items">
+        <div class="elbysodic-spotlight-section-heading">
+          <div>
+            <p class="elbysodic-kicker">Available</p>
+            <h3>Spotlight library</h3>
+          </div>
+          <p>Add published material without changing board placement.</p>
+        </div>
+        {{ spotlight_library_section(studio.gateway_curation.scene_hubs, "scene_hub_target_id", "scene_hub_position_", "Scene hub") }}
+        {{ spotlight_library_section(studio.gateway_curation.wanted_hooks, "wanted_hook_target_id", "wanted_hook_position_", "Wanted hook") }}
+        {{ spotlight_library_section(studio.gateway_curation.guidebook_materials, "guidebook_material_target_id", "guidebook_material_position_", "Guidebook") }}
+      </aside>
+    </div>
+    {{ spotlight_preview(studio) }}
+    <div class="elbysodic-spotlight-savebar">
+      <span data-elbysodic-spotlight-dirty>Saved spotlight order</span>
+      <button class="chirpui-btn chirpui-btn--primary" type="submit">Save home spotlight</button>
+      <a class="chirpui-btn chirpui-btn--secondary" href="/c/{{ viewer.community.slug }}">Preview realm</a>
     </div>
   </form>
   {% end %}
   </section>
   {% end %}
 
+  {% end %}
+
+  {% if studio_room == "appearance" %}
   {% if not studio.can_manage %}
-  <aside class="elbysodic-notice elbysodic-notice--staff" aria-label="Staff preview">
-    <span class="elbysodic-notice__mark" aria-hidden="true">i</span>
-    <span class="elbysodic-notice__label">Staff preview</span>
-    <span class="elbysodic-notice__body">
-      <strong class="elbysodic-notice__title">Director tools are read-only here</strong>
-      <span class="elbysodic-notice__summary">
-        Director Studio is visible as a preview, but only staff memberships can manage
-        community canon and queues.
-      </span>
-    </span>
-  </aside>
   <section id="identity-appearance" class="elbysodic-studio-room chirpui-stack chirpui-stack--md" aria-labelledby="identity-appearance-heading">
   {{ room_header("Identity and appearance", "The board's visual language", "Preview the accent source and post style vocabulary directors use to guide the board.", "identity-appearance-heading") }}
   {% call surface(variant="elevated") %}
@@ -435,19 +621,23 @@
   {% end %}
   </section>
 
+  {% end %}
+  {% end %}
+
+  {% if studio_room == "structure" and studio.can_manage %}
   <section id="world-structure" class="elbysodic-studio-room chirpui-stack chirpui-stack--md" aria-labelledby="world-structure-heading">
-  {{ room_header("World structure", "Boards, places, and community rooms", "Keep the world map, community boards, desk lanes, and staff spaces legible as the board grows.", "world-structure-heading") }}
+  {{ room_header("Board map", "Boards, places, and community rooms", "Audit the board map after directors edit individual boards from their own pages.", "world-structure-heading") }}
   {% call surface(variant="elevated") %}
   <section id="board-taxonomy" class="chirpui-stack chirpui-stack--md" aria-labelledby="board-taxonomy-heading">
     <div class="chirpui-cluster chirpui-cluster--between">
       <div>
-        <p class="elbysodic-kicker">Community Direction</p>
-        <h2 id="board-taxonomy-heading">Board taxonomy</h2>
+        <p class="elbysodic-kicker">Board placement</p>
+        <h2 id="board-taxonomy-heading">Board map audit and bulk repair</h2>
         <p class="elbysodic-copy-section">
-          Classify each board so World, Desk, Studio, and the sidebar know what kind of place it is.
+          Single-board edits belong on the board's page. Use this room when you need to scan every board at once, repair parent/sub-forum placement, or fix sidebar order in a batch.
         </p>
       </div>
-      <div class="elbysodic-board-taxonomy__pulse" aria-label="Board taxonomy totals">
+      <div class="elbysodic-board-taxonomy__pulse" aria-label="Board map totals">
         {{ studio_signal("Locations", studio.location_count + studio.sublocation_count) }}
         {{ studio_signal("Community", studio.community_board_count + studio.archive_board_count) }}
         {{ studio_signal("Staff", studio.staff_board_count + studio.desk_board_count) }}
@@ -479,8 +669,8 @@
         </div>
         <details class="elbysodic-board-taxonomy-row__editor">
           <summary>
-            <span>Edit placement</span>
-            <small>{{ item.kind_label }} · nav {{ item.board.navigation_order }}</small>
+            <span>Bulk repair placement</span>
+            <small>{{ item.sidebar_section_label }} · nav {{ item.board.navigation_order }}</small>
           </summary>
           <div class="elbysodic-board-taxonomy-row__controls">
             <label class="chirpui-field chirpui-field--outlined elbysodic-form-field">
@@ -513,7 +703,7 @@
               </select>
             </label>
             <label class="chirpui-field chirpui-field--outlined elbysodic-form-field">
-              <span class="chirpui-field__label">Order</span>
+              <span class="chirpui-field__label">Navigation order</span>
               <input class="chirpui-field__input" type="number"
                      name="navigation_order"
                      value="{{ item.board.navigation_order }}"
@@ -537,14 +727,14 @@
   </section>
 
   <section id="navigation" class="elbysodic-studio-room chirpui-stack chirpui-stack--md" aria-labelledby="navigation-heading">
-  {{ room_header("Navigation", "Sidebar language and health", "Shape how writers move through the board while keeping route meaning stable.", "navigation-heading") }}
+  {{ room_header("Navigation", "Sidebar language and health", "Audit how writers move through the board while keeping route meaning stable.", "navigation-heading") }}
   {% call surface(variant="elevated") %}
   <section id="navigation-composer" class="chirpui-stack chirpui-stack--md" aria-labelledby="navigation-composer-heading">
     <div>
       <p class="elbysodic-kicker">Community Direction</p>
-      <h2 id="navigation-composer-heading">Navigation composer</h2>
+      <h2 id="navigation-composer-heading">Sidebar audit</h2>
       <p class="elbysodic-copy-section">
-        Preview how app-owned routes, board taxonomy, and contextual objects compose the sidebars writers actually use.
+        Check the sidebars people will actually see after object-local board edits, sidebar labels, and contextual route choices compose together. Use this to catch boards in the wrong work area, repeated section labels, or sidebars that bury the next useful move.
       </p>
     </div>
     {% if studio.can_manage %}
@@ -597,19 +787,21 @@
       {% for section in studio.navigation_preview_sections %}
       <article class="elbysodic-navigation-preview">
         <div class="elbysodic-navigation-preview__header">
-          <p class="elbysodic-kicker">{{ section.realm_label }}</p>
-          <h3>{{ section.title }}</h3>
-          <p class="elbysodic-copy-summary">{{ section.description }}</p>
-          <p class="elbysodic-copy-meta">
-            {{ "Section label shown" if section.label_visible else "Section label hidden; the route title carries the context." }}
-          </p>
+          <div>
+            <p class="elbysodic-kicker">{{ section.realm_label }} context</p>
+            <h3>{{ section.title }}</h3>
+          </div>
+          <span>{{ "Label shown" if section.label_visible else "Label hidden" }}</span>
         </div>
+        <p class="elbysodic-navigation-preview__goal"><strong>Goal</strong>{{ section.description }}</p>
         <ol class="elbysodic-navigation-preview__list">
           {% for item in section.items %}
           <li>
-            <a href="{{ item.href }}">{{ item.label }}</a>
-            <span>{{ item.source_label }}</span>
-            <small>{{ item.behavior_label }}</small>
+            <a href="{{ item.href }}">
+              <span>{{ item.label }}</span>
+              <small>{{ item.behavior_label }}</small>
+            </a>
+            <em>{{ item.source_label }}</em>
             {% if item.count %}
             <strong>{{ item.count }}</strong>
             {% end %}
@@ -622,7 +814,9 @@
   </section>
   {% end %}
   </section>
+  {% end %}
 
+  {% if studio_room == "appearance" and studio.can_manage %}
   <section id="identity-appearance-style" class="elbysodic-studio-room chirpui-stack chirpui-stack--md" aria-label="Post style vocabulary">
   {% call surface(variant="elevated") %}
   <form class="chirpui-stack chirpui-stack--md" method="post">
@@ -705,20 +899,20 @@
   </section>
   {% end %}
 
-  {% if not studio.can_manage %}
+  {% if studio_room == "structure" and not studio.can_manage %}
   <section id="world-structure" class="elbysodic-studio-room chirpui-stack chirpui-stack--md" aria-labelledby="world-structure-heading">
-  {{ room_header("World structure", "Boards, places, and community rooms", "Preview how the board's places and community rooms are classified.", "world-structure-heading") }}
+  {{ room_header("Board map", "Boards, places, and community rooms", "Preview how object-local board edits classify board kinds, parent and sub-forum relationships, sidebar placement, and navigation order.", "world-structure-heading") }}
   {% call surface(variant="elevated") %}
   <section id="board-taxonomy" class="chirpui-stack chirpui-stack--md" aria-labelledby="board-taxonomy-heading">
     <div class="chirpui-cluster chirpui-cluster--between">
       <div>
-        <p class="elbysodic-kicker">Community Direction</p>
-        <h2 id="board-taxonomy-heading">Board taxonomy</h2>
+        <p class="elbysodic-kicker">Board placement</p>
+        <h2 id="board-taxonomy-heading">Board map audit</h2>
         <p class="elbysodic-copy-section">
-          Classify each board so World, Desk, Studio, and the sidebar know what kind of place it is.
+          Read what each board is, whether it lives under a parent as a sub-forum, which sidebar section owns it, and where it sorts in navigation.
         </p>
       </div>
-      <div class="elbysodic-board-taxonomy__pulse" aria-label="Board taxonomy totals">
+      <div class="elbysodic-board-taxonomy__pulse" aria-label="Board map totals">
         {{ studio_signal("Locations", studio.location_count + studio.sublocation_count) }}
         {{ studio_signal("Community", studio.community_board_count + studio.archive_board_count) }}
         {{ studio_signal("Staff", studio.staff_board_count + studio.desk_board_count) }}
@@ -752,14 +946,14 @@
   {% end %}
   </section>
   <section id="navigation" class="elbysodic-studio-room chirpui-stack chirpui-stack--md" aria-labelledby="navigation-heading">
-  {{ room_header("Navigation", "Sidebar language and health", "Preview the sidebar composer and health notes.", "navigation-heading") }}
+  {{ room_header("Navigation", "Sidebar language and health", "Preview the sidebar audit and health notes.", "navigation-heading") }}
   {% call surface(variant="elevated") %}
   <section id="navigation-composer" class="chirpui-stack chirpui-stack--md" aria-labelledby="navigation-composer-heading">
     <div>
       <p class="elbysodic-kicker">Community Direction</p>
-      <h2 id="navigation-composer-heading">Navigation composer</h2>
+      <h2 id="navigation-composer-heading">Sidebar audit</h2>
       <p class="elbysodic-copy-section">
-        Preview how app-owned routes, board taxonomy, and contextual objects compose the sidebars writers actually use.
+        Check the sidebars people will actually see after board map, sidebar label, and contextual route choices compose together.
       </p>
     </div>
     <div class="elbysodic-sidebar-section-configs" aria-label="Sidebar section settings">
@@ -778,19 +972,21 @@
       {% for section in studio.navigation_preview_sections %}
       <article class="elbysodic-navigation-preview">
         <div class="elbysodic-navigation-preview__header">
-          <p class="elbysodic-kicker">{{ section.realm_label }}</p>
-          <h3>{{ section.title }}</h3>
-          <p class="elbysodic-copy-summary">{{ section.description }}</p>
-          <p class="elbysodic-copy-meta">
-            {{ "Section label shown" if section.label_visible else "Section label hidden; the route title carries the context." }}
-          </p>
+          <div>
+            <p class="elbysodic-kicker">{{ section.realm_label }} context</p>
+            <h3>{{ section.title }}</h3>
+          </div>
+          <span>{{ "Label shown" if section.label_visible else "Label hidden" }}</span>
         </div>
+        <p class="elbysodic-navigation-preview__goal"><strong>Goal</strong>{{ section.description }}</p>
         <ol class="elbysodic-navigation-preview__list">
           {% for item in section.items %}
           <li>
-            <a href="{{ item.href }}">{{ item.label }}</a>
-            <span>{{ item.source_label }}</span>
-            <small>{{ item.behavior_label }}</small>
+            <a href="{{ item.href }}">
+              <span>{{ item.label }}</span>
+              <small>{{ item.behavior_label }}</small>
+            </a>
+            <em>{{ item.source_label }}</em>
             {% if item.count %}
             <strong>{{ item.count }}</strong>
             {% end %}
@@ -805,6 +1001,7 @@
   </section>
   {% end %}
 
+  {% if studio_room == "content" %}
   <section id="casting-applications" class="elbysodic-studio-room chirpui-stack chirpui-stack--md" aria-labelledby="casting-applications-heading">
   {{ room_header("Casting and applications", "Intake, wanted hooks, and review queues", "Keep character growth and casting prompts close to the board's production pulse.", "casting-applications-heading") }}
   <section class="elbysodic-director-grid" aria-label="Director work lanes">
@@ -993,6 +1190,7 @@
   {% end %}
   {% end %}
   </section>
+  {% end %}
 {% end %}
 {% end %}
 {% end %}

--- a/src/elbysodic/web/pages/studio/page.py
+++ b/src/elbysodic/web/pages/studio/page.py
@@ -40,15 +40,32 @@ class StudioCockpitLane:
     variant: str = "attention"
 
 
+@dataclass(frozen=True, slots=True)
+class StudioRoomCard:
+    key: str
+    kicker: str
+    title: str
+    summary: str
+    href: str
+    cta: str
+    count: int
+    items: tuple[str, ...] = ()
+    variant: str = "info"
+
+
 def get(request: Request) -> Page | Redirect:
-    return _render_studio(request)
+    return render_studio_room(request, "overview")
 
 
 async def post(request: Request) -> Page | Redirect:
+    return await handle_studio_post(request, _studio_room_for_path(request.url))
+
+
+async def handle_studio_post(request: Request, room: str) -> Page | Redirect:
     services = get_services(request)
     form = await request.form()
     intent = str(form.get("intent") or "identity_accent")
-    redirect_to = "/studio"
+    redirect_to = _studio_room_href(room)
     try:
         if intent == "board_taxonomy":
             raw_parent_id = str(form.get("parent_board_id") or "")
@@ -68,6 +85,7 @@ async def post(request: Request) -> Page | Redirect:
                 show_in_navigation=form.get("show_in_navigation") == "on",
                 sidebar_section=str(form.get("sidebar_section") or ""),
             )
+            redirect_to = "/studio/structure#board-taxonomy"
         elif intent == "board_navigation":
             services.update_board_navigation(
                 _required_int(form.get("board_id"), "choose a board to update"),
@@ -78,6 +96,7 @@ async def post(request: Request) -> Page | Redirect:
                 show_in_navigation=form.get("show_in_navigation") == "on",
                 sidebar_section=str(form.get("sidebar_section") or ""),
             )
+            redirect_to = "/studio/structure#navigation-composer"
         elif intent == "sidebar_section":
             services.update_sidebar_section_config(
                 str(form.get("section_key") or ""),
@@ -89,6 +108,7 @@ async def post(request: Request) -> Page | Redirect:
                 ),
                 show_label=form.get("show_label") == "on",
             )
+            redirect_to = "/studio/structure#navigation-composer"
         elif intent == "post_style_policy":
             services.update_post_style_policy(
                 enabled_post_profile_variants=_form_values(
@@ -112,6 +132,7 @@ async def post(request: Request) -> Page | Redirect:
                     "enabled_post_densities",
                 ),
             )
+            redirect_to = "/studio/appearance#identity-appearance-style"
         elif intent == "default_theme":
             services.update_default_theme(
                 slug=str(form.get("theme_slug") or ""),
@@ -125,7 +146,7 @@ async def post(request: Request) -> Page | Redirect:
                 light=_theme_mode_values(form, "light"),
                 dark=_theme_mode_values(form, "dark"),
             )
-            redirect_to = "/studio#appearance-theme"
+            redirect_to = "/studio/appearance#appearance-theme"
         elif intent == "community_media":
             services.update_community_media(
                 community_mark_url=str(form.get("community_mark_url") or ""),
@@ -137,14 +158,14 @@ async def post(request: Request) -> Page | Redirect:
                 world_hero_overlay=str(form.get("world_hero_overlay") or ""),
                 world_hero_height=str(form.get("world_hero_height") or ""),
             )
-            redirect_to = "/studio#appearance-media"
+            redirect_to = "/studio/appearance#appearance-media"
         elif intent == "material_status":
             services.update_material_production_state(
                 str(form.get("material_slug") or ""),
                 status=str(form.get("status") or ""),
                 is_featured=form.get("is_featured") == "on",
             )
-            redirect_to = "/studio#continuity-events"
+            redirect_to = "/studio/content#continuity-events"
         elif intent == "gateway_curation":
             services.update_gateway_curation(
                 scene_hub_target_ids=_ordered_targets(
@@ -163,28 +184,42 @@ async def post(request: Request) -> Page | Redirect:
                     "guidebook_material_position_",
                 ),
             )
-            redirect_to = "/studio#gateway-curation"
+            redirect_to = "/studio/structure#gateway-curation"
         else:
             raw_group_id = str(form.get("identity_accent_facet_group_id") or "")
             facet_group_id = int(raw_group_id) if raw_group_id else None
             services.update_identity_accent_group(facet_group_id)
+            redirect_to = "/studio/appearance#identity-appearance"
     except PermissionError as exc:
         raise HTTPError(status=403, detail=str(exc)) from exc
     except (LookupError, ValueError) as exc:
-        return _render_studio(request, error=str(exc))
+        return render_studio_room(request, room, error=str(exc))
     return Redirect(redirect_to)
 
 
-def _render_studio(request: Request, *, error: str | None = None) -> Page | Redirect:
+def render_studio_room(
+    request: Request,
+    room: str,
+    *,
+    error: str | None = None,
+) -> Page | Redirect:
     services = get_services(request)
     studio = services.director_studio()
     if error is None and studio.can_manage and _is_empty_configured_realm(studio):
         return Redirect("/studio/launch")
+    cockpit_lanes = _studio_cockpit_lanes(studio)
+    studio_rooms = _studio_room_cards(studio, cockpit_lanes)
     return Page.mounted(
         "studio/page.html",
         current_path=request.url,
         viewer=services.viewer(),
         studio=studio,
+        studio_room=room,
+        studio_rooms=studio_rooms,
+        current_studio_room=next(
+            (item for item in studio_rooms if item.key == room),
+            None,
+        ),
         error=error,
         post_profile_variant_labels=POST_PROFILE_VARIANT_LABELS,
         post_accent_style_labels=POST_ACCENT_STYLE_LABELS,
@@ -198,12 +233,29 @@ def _render_studio(request: Request, *, error: str | None = None) -> Page | Redi
         theme_radius_labels=RADIUS_LABELS,
         theme_density_labels=DENSITY_LABELS,
         theme_texture_labels=TEXTURE_LABELS,
-        cockpit_lanes=_studio_cockpit_lanes(studio),
+        cockpit_lanes=cockpit_lanes,
     )
 
 
 def _is_empty_configured_realm(studio: DirectorStudio) -> bool:
     return not studio.board_taxonomy and not studio.materials
+
+
+def _studio_room_for_path(current_path: object) -> str:
+    path = str(current_path or "").split("?", 1)[0].split("#", 1)[0].rstrip("/")
+    if path.endswith("/studio/appearance"):
+        return "appearance"
+    if path.endswith("/studio/structure"):
+        return "structure"
+    if path.endswith("/studio/content"):
+        return "content"
+    return "overview"
+
+
+def _studio_room_href(room: str) -> str:
+    if room in {"appearance", "structure", "content"}:
+        return f"/studio/{room}"
+    return "/studio"
 
 
 def _form_values(form: object, name: str) -> list[str]:
@@ -226,9 +278,9 @@ def _ordered_targets(form: object, field_name: str, position_prefix: str) -> lis
         try:
             position = int(raw_position)
         except ValueError:
-            raise ValueError("gateway curation order must be a positive number") from None
+            raise ValueError("spotlight order must be a positive number") from None
         if position < 1:
-            raise ValueError("gateway curation order must be a positive number")
+            raise ValueError("spotlight order must be a positive number")
         return (position, target_id)
 
     return sorted(selected_ids, key=position_for)
@@ -293,7 +345,7 @@ def _studio_cockpit_lanes(studio: DirectorStudio) -> list[StudioCockpitLane]:
                 "Materials",
                 "Draft materials",
                 "Guidebook, event, and canon pages still waiting on director publication.",
-                "/studio#continuity-events",
+                "/studio/content#continuity-events",
                 "Review drafts",
                 len(studio.draft_materials),
                 tuple(item.material.title for item in studio.draft_materials[:4]),
@@ -304,8 +356,8 @@ def _studio_cockpit_lanes(studio: DirectorStudio) -> list[StudioCockpitLane]:
             StudioCockpitLane(
                 "Navigation",
                 "Shell health",
-                "Sidebar, board taxonomy, and route-shape notes that need review.",
-                "/studio#navigation",
+                "Sidebar, board map, and route-shape notes that need review.",
+                "/studio/structure#navigation",
                 "Review navigation",
                 len(studio.navigation_warnings),
                 tuple(warning.title for warning in studio.navigation_warnings[:4]),
@@ -318,7 +370,7 @@ def _studio_cockpit_lanes(studio: DirectorStudio) -> list[StudioCockpitLane]:
                 "Appearance",
                 "Theme health",
                 "Readability warnings in the realm's light or dark palette.",
-                "/studio#appearance-theme",
+                "/studio/appearance#appearance-theme",
                 "Review theme",
                 len(studio.theme_warnings),
                 tuple(warning.title for warning in studio.theme_warnings[:4]),
@@ -341,3 +393,100 @@ def _studio_cockpit_lanes(studio: DirectorStudio) -> list[StudioCockpitLane]:
             )
         )
     return lanes
+
+
+def _studio_room_cards(
+    studio: DirectorStudio,
+    cockpit_lanes: list[StudioCockpitLane],
+) -> tuple[StudioRoomCard, ...]:
+    missing_launch_items = [
+        item for item in studio.launch_readiness.items if item.is_required and not item.is_complete
+    ]
+    structure_count = (
+        studio.navigation_attention_count
+        + studio.navigation_warning_count
+        + studio.navigation_note_count
+    )
+    content_count = len(studio.draft_materials) + len(studio.events)
+    return (
+        StudioRoomCard(
+            "operations",
+            "Today",
+            "Operations",
+            "A daily director desk for reviews, claim conflicts, reserves, hooks, and health signals.",
+            "/studio/operations",
+            "Open operations",
+            len(cockpit_lanes),
+            tuple(lane.title for lane in cockpit_lanes[:4]) or ("No urgent lanes right now.",),
+            "attention" if cockpit_lanes else "success",
+        ),
+        StudioRoomCard(
+            "launch",
+            "Opening",
+            "Launch",
+            "Realm opening checklist, access requests, invitations, and first-writer gates.",
+            "/studio/launch",
+            "Open launch room",
+            len(missing_launch_items),
+            tuple(item.label for item in missing_launch_items[:4])
+            or ("Opening requirements are currently satisfied.",),
+            "warning" if missing_launch_items else "success",
+        ),
+        StudioRoomCard(
+            "discovery",
+            "Public presence",
+            "Discovery profile",
+            "Network listing, premise fit, pace expectations, roster posture, and public realm signals.",
+            "/studio/discovery",
+            "Edit discovery",
+            studio.open_wanted_count,
+            tuple(item.wanted_ad.title for item in studio.open_wanted_ads[:4])
+            or ("No open wanted hooks are advertising right now.",),
+        ),
+        StudioRoomCard(
+            "structure",
+            "Realm shape",
+            "Structure",
+            "Audit the home spotlight, board map, sidebar language, and navigation health after object-local edits.",
+            "/studio/structure",
+            "Open audit",
+            structure_count,
+            tuple(warning.title for warning in studio.navigation_warnings[:4])
+            or ("Navigation is coherent right now.",),
+            "warning" if structure_count else "success",
+        ),
+        StudioRoomCard(
+            "intake",
+            "Applications",
+            "Intake",
+            "Application fields, claims, reserves, and director-defined face requirements.",
+            "/studio/intake",
+            "Edit intake",
+            len(studio.claims.groups),
+            tuple(studio.claims.claim_type_names[:4]) or ("No claim types configured yet.",),
+        ),
+        StudioRoomCard(
+            "appearance",
+            "Skinning",
+            "Appearance",
+            "Theme tokens, realm media, identity accents, and post style vocabulary.",
+            "/studio/appearance",
+            "Open appearance",
+            len(studio.theme_warnings),
+            tuple(warning.title for warning in studio.theme_warnings[:4])
+            or ("Theme contrast is healthy for checked surfaces.",),
+            "warning" if studio.theme_warnings else "success",
+        ),
+        StudioRoomCard(
+            "content",
+            "Canon pressure",
+            "Content",
+            "Guidebook materials, current event pressure, wanted hooks, and location coverage.",
+            "/studio/content",
+            "Open content",
+            content_count,
+            tuple(item.material.title for item in studio.draft_materials[:4])
+            or tuple(studio.event_titles[:4])
+            or ("No guidebook drafts are waiting.",),
+        ),
+    )

--- a/src/elbysodic/web/pages/studio/structure/_meta.py
+++ b/src/elbysodic/web/pages/studio/structure/_meta.py
@@ -1,0 +1,3 @@
+from chirp.pages.types import RouteMeta
+
+META = RouteMeta(title="Studio Structure", breadcrumb_label="Structure")

--- a/src/elbysodic/web/pages/studio/structure/page.py
+++ b/src/elbysodic/web/pages/studio/structure/page.py
@@ -1,0 +1,15 @@
+"""Director Studio structure room."""
+
+from chirp.http.request import Request
+from chirp.http.response import Redirect
+from chirp.templating.returns import Page
+
+from elbysodic.web.pages.studio.page import handle_studio_post, render_studio_room
+
+
+def get(request: Request) -> Page | Redirect:
+    return render_studio_room(request, "structure")
+
+
+async def post(request: Request) -> Page | Redirect:
+    return await handle_studio_post(request, "structure")

--- a/src/elbysodic/web/static/elbysodic-shell.js
+++ b/src/elbysodic/web/static/elbysodic-shell.js
@@ -42,40 +42,49 @@
     return false;
   }
 
-  function setSidebarState(shell, button, hidden) {
+  function setToggleControlState(control, hidden) {
+    control.setAttribute("aria-expanded", hidden ? "false" : "true");
+    const label = hidden ? "Show navigation" : "Hide navigation";
+    control.setAttribute("aria-label", label);
+    control.setAttribute("title", label);
+  }
+
+  function setSidebarState(shell, controls, hidden) {
     document.documentElement.classList.toggle(HIDDEN_CLASS, hidden);
     shell.classList.toggle(HIDDEN_CLASS, hidden);
     setServerHiddenStyle(hidden);
-    button.setAttribute("aria-expanded", hidden ? "false" : "true");
-    const label = hidden ? "Show navigation" : "Hide navigation";
-    button.setAttribute("aria-label", label);
-    button.setAttribute("title", label);
+    controls.forEach((control) => setToggleControlState(control, hidden));
   }
 
   function setupSidebarToggle() {
     const shell = document.querySelector(".chirpui-app-shell");
-    const handle = document.querySelector("[data-elbysodic-sidebar-toggle]");
-    if (!shell || !handle || handle.dataset.elbysodicSidebarReady === "true") {
+    const controls = Array.from(document.querySelectorAll("[data-elbysodic-sidebar-toggle]"));
+    if (!shell || controls.length === 0) {
       return;
     }
 
     function toggle() {
       const hidden = !shell.classList.contains(HIDDEN_CLASS);
-      setSidebarState(shell, handle, hidden);
+      setSidebarState(shell, controls, hidden);
       writeCookiePreference(hidden);
       clearLegacyPreference();
     }
 
-    handle.dataset.elbysodicSidebarReady = "true";
-    setSidebarState(shell, handle, readHiddenPreference());
-    handle.addEventListener("click", toggle);
-    handle.addEventListener("keydown", (event) => {
-      if (event.key !== "Enter" && event.key !== " ") {
+    controls.forEach((control) => {
+      if (control.dataset.elbysodicSidebarReady === "true") {
         return;
       }
-      event.preventDefault();
-      toggle();
+      control.dataset.elbysodicSidebarReady = "true";
+      control.addEventListener("click", toggle);
+      control.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") {
+          return;
+        }
+        event.preventDefault();
+        toggle();
+      });
     });
+    setSidebarState(shell, controls, readHiddenPreference());
   }
 
   function submitControls(scope) {
@@ -121,6 +130,352 @@
     });
   }
 
+  function fieldValue(form, name) {
+    const field = form.elements.namedItem(name);
+    if (!field) {
+      return "";
+    }
+    return String(field.value || "").trim();
+  }
+
+  function selectedText(form, name) {
+    const field = form.elements.namedItem(name);
+    if (!field || !field.options || field.selectedIndex < 0) {
+      return fieldValue(form, name);
+    }
+    return String(field.options[field.selectedIndex].textContent || "").trim();
+  }
+
+  function setText(target, value) {
+    if (!target) {
+      return;
+    }
+    target.textContent = value;
+  }
+
+  function setBadgeText(target, value) {
+    if (!target) {
+      return;
+    }
+    const badge = target.querySelector("[class*='chirpui-badge']");
+    setText(badge || target, value);
+  }
+
+  function tagEntries(source) {
+    return source
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const parts = line.split("|").map((part) => part.trim());
+        return {
+          key: parts[1] || parts[0] || "",
+          label: parts[2] || parts[1] || parts[0] || "",
+        };
+      })
+      .filter((entry) => entry.key && entry.label);
+  }
+
+  function updateDiscoveryPreview(form) {
+    const card = document.querySelector("[data-elbysodic-discovery-preview-card]");
+    if (!card) {
+      return;
+    }
+
+    const summary = card.querySelector("[data-elbysodic-preview-summary]");
+    if (summary && !summary.dataset.elbysodicPreviewDefault) {
+      summary.dataset.elbysodicPreviewDefault = summary.textContent.trim();
+    }
+    const fit = card.querySelector("[data-elbysodic-preview-fit]");
+    const access = card.querySelector("[data-elbysodic-preview-access]");
+    const pace = card.querySelector("[data-elbysodic-preview-pace]");
+    const tags = document.querySelector("[data-elbysodic-preview-tags]");
+
+    const catalogPitch = fieldValue(form, "catalog_pitch");
+    setText(summary, catalogPitch || (summary ? summary.dataset.elbysodicPreviewDefault : ""));
+    setBadgeText(access, selectedText(form, "access_model"));
+    setBadgeText(pace, fieldValue(form, "activity_pace"));
+
+    const fitLabels = [
+      fieldValue(form, "premise_archetype") || "Premise-led realm",
+      fieldValue(form, "lore_aperture"),
+      fieldValue(form, "forum_adjunct"),
+    ].filter(Boolean);
+    setText(fit, fitLabels.join(" · "));
+
+    if (tags) {
+      const entries = tagEntries(fieldValue(form, "discovery_tags"));
+      tags.hidden = entries.length === 0;
+      tags.replaceChildren(
+        ...entries.map((entry) => {
+          const link = document.createElement("a");
+          link.href = `/network?q=${encodeURIComponent(entry.key)}`;
+          link.textContent = entry.label;
+          return link;
+        }),
+      );
+    }
+  }
+
+  function setupDiscoveryPreview(root) {
+    const forms = root.querySelectorAll("[data-elbysodic-discovery-preview-form]");
+    forms.forEach((form) => {
+      if (form.dataset.elbysodicDiscoveryPreviewReady === "true") {
+        return;
+      }
+      form.dataset.elbysodicDiscoveryPreviewReady = "true";
+      updateDiscoveryPreview(form);
+      form.addEventListener("input", () => updateDiscoveryPreview(form));
+      form.addEventListener("change", () => updateDiscoveryPreview(form));
+    });
+  }
+
+  function gatewayItems(list) {
+    return Array.from(list.querySelectorAll("[data-elbysodic-gateway-curation-item]"));
+  }
+
+  function directEmptyState(list) {
+    return Array.from(list.children).find((child) =>
+      child.matches("[data-elbysodic-spotlight-empty]"),
+    );
+  }
+
+  function updateSpotlightEmpty(list) {
+    const empty = directEmptyState(list);
+    if (!empty) {
+      return;
+    }
+    empty.hidden = gatewayItems(list).length > 0;
+  }
+
+  function setSpotlightItemState(item, selected) {
+    const input = item.querySelector("[data-elbysodic-gateway-curation-select]");
+    if (input) {
+      input.checked = selected;
+    }
+    item.classList.toggle("elbysodic-spotlight-item--selected", selected);
+    item.classList.toggle("elbysodic-spotlight-item--available", !selected);
+    item.draggable = selected;
+  }
+
+  function updateGatewayCurationPositions(list) {
+    let selectedIndex = 0;
+    gatewayItems(list).forEach((item, index) => {
+      const position = (index + 1) * 10;
+      const input = item.querySelector("[data-elbysodic-gateway-curation-position]");
+      const rank = item.querySelector("[data-elbysodic-gateway-curation-rank]");
+      const selected = item.querySelector("[data-elbysodic-gateway-curation-select]");
+      if (input) {
+        input.value = String(position);
+      }
+      if (rank) {
+        if (selected && selected.checked) {
+          selectedIndex += 1;
+          rank.textContent = String(selectedIndex).padStart(2, "0");
+        } else {
+          rank.textContent = "";
+        }
+      }
+    });
+    const lane = list.closest(".elbysodic-spotlight-lane");
+    const count = lane ? lane.querySelector("[data-elbysodic-spotlight-count]") : null;
+    if (count) {
+      count.textContent = String(selectedIndex);
+    }
+    updateSpotlightEmpty(list);
+  }
+
+  function moveGatewayCurationItem(item, direction) {
+    const list = item.closest("[data-elbysodic-gateway-curation-list]");
+    if (!list) {
+      return;
+    }
+    if (direction < 0 && item.previousElementSibling) {
+      list.insertBefore(item, item.previousElementSibling);
+    }
+    if (direction > 0 && item.nextElementSibling) {
+      list.insertBefore(item.nextElementSibling, item);
+    }
+    updateGatewayCurationPositions(list);
+    updateSpotlightComposer(list.closest("[data-elbysodic-spotlight-composer]"), true);
+    item.focus({ preventScroll: true });
+  }
+
+  function gatewayCurationDropTarget(list, y) {
+    return gatewayItems(list).find((item) => {
+      if (item.getAttribute("aria-grabbed") === "true") {
+        return false;
+      }
+      const box = item.getBoundingClientRect();
+      return y < box.top + box.height / 2;
+    });
+  }
+
+  function moveSpotlightItem(item, selected) {
+    const composer = item.closest("[data-elbysodic-spotlight-composer]");
+    const currentList = item.closest("[data-elbysodic-spotlight-list-for]");
+    if (!composer || !currentList) {
+      return;
+    }
+    const slotType = currentList.dataset.elbysodicSpotlightListFor;
+    const selector = selected
+      ? "[data-elbysodic-spotlight-selected-list]"
+      : "[data-elbysodic-spotlight-library-list]";
+    const targetList = composer.querySelector(
+      `${selector}[data-elbysodic-spotlight-list-for="${slotType}"]`,
+    );
+    if (!targetList || targetList === currentList) {
+      return;
+    }
+    targetList.appendChild(item);
+    setSpotlightItemState(item, selected);
+    updateSpotlightEmpty(currentList);
+    updateSpotlightEmpty(targetList);
+    const selectedList = composer.querySelector(
+      `[data-elbysodic-spotlight-selected-list][data-elbysodic-spotlight-list-for="${slotType}"]`,
+    );
+    if (selectedList) {
+      updateGatewayCurationPositions(selectedList);
+    }
+    updateSpotlightComposer(composer, true);
+    item.focus({ preventScroll: true });
+  }
+
+  function updateSpotlightPreview(composer) {
+    if (!composer) {
+      return;
+    }
+    const list = composer.querySelector("[data-elbysodic-spotlight-preview-list]");
+    const empty = composer.querySelector("[data-elbysodic-spotlight-preview-empty]");
+    if (!list) {
+      return;
+    }
+    const items = Array.from(
+      composer.querySelectorAll(
+        "[data-elbysodic-spotlight-selected-list] [data-elbysodic-spotlight-item]",
+      ),
+    );
+    list.replaceChildren(
+      ...items.slice(0, 6).map((item) => {
+        const row = document.createElement("li");
+        const type = document.createElement("span");
+        const title = document.createElement("strong");
+        type.textContent = item.dataset.elbysodicSpotlightType || "Spotlight";
+        title.textContent = item.dataset.elbysodicSpotlightTitle || "Untitled";
+        row.append(type, title);
+        return row;
+      }),
+    );
+    if (empty) {
+      empty.hidden = items.length > 0;
+    }
+  }
+
+  function updateSpotlightComposer(composer, dirty) {
+    if (!composer) {
+      return;
+    }
+    composer
+      .querySelectorAll("[data-elbysodic-gateway-curation-list]")
+      .forEach(updateGatewayCurationPositions);
+    composer
+      .querySelectorAll("[data-elbysodic-spotlight-library-list]")
+      .forEach(updateSpotlightEmpty);
+    updateSpotlightPreview(composer);
+    if (dirty) {
+      const label = composer.querySelector("[data-elbysodic-spotlight-dirty]");
+      if (label) {
+        label.textContent = "Unsaved spotlight changes";
+        label.dataset.elbysodicDirty = "true";
+      }
+    }
+  }
+
+  function setupGatewayCuration(root) {
+    const composers = root.querySelectorAll("[data-elbysodic-spotlight-composer]");
+    composers.forEach((composer) => {
+      if (composer.dataset.elbysodicSpotlightComposerReady === "true") {
+        return;
+      }
+      composer.dataset.elbysodicSpotlightComposerReady = "true";
+      composer.addEventListener("click", (event) => {
+        const add = event.target.closest("[data-elbysodic-spotlight-add]");
+        const remove = event.target.closest("[data-elbysodic-spotlight-remove]");
+        if (!add && !remove) {
+          return;
+        }
+        event.preventDefault();
+        const item = event.target.closest("[data-elbysodic-spotlight-item]");
+        if (item) {
+          moveSpotlightItem(item, Boolean(add));
+        }
+      });
+      updateSpotlightComposer(composer, false);
+    });
+
+    const lists = root.querySelectorAll("[data-elbysodic-gateway-curation-list]");
+    lists.forEach((list) => {
+      if (list.dataset.elbysodicGatewayCurationReady === "true") {
+        return;
+      }
+      list.dataset.elbysodicGatewayCurationReady = "true";
+      updateGatewayCurationPositions(list);
+
+      list.addEventListener("click", (event) => {
+        const up = event.target.closest("[data-elbysodic-gateway-curation-up]");
+        const down = event.target.closest("[data-elbysodic-gateway-curation-down]");
+        if (!up && !down) {
+          return;
+        }
+        event.preventDefault();
+        const item = event.target.closest("[data-elbysodic-gateway-curation-item]");
+        if (item) {
+          moveGatewayCurationItem(item, up ? -1 : 1);
+        }
+      });
+
+      list.addEventListener("change", (event) => {
+        if (event.target.matches("[data-elbysodic-gateway-curation-select]")) {
+          updateGatewayCurationPositions(list);
+          updateSpotlightComposer(list.closest("[data-elbysodic-spotlight-composer]"), true);
+        }
+      });
+
+      list.addEventListener("dragstart", (event) => {
+        const item = event.target.closest("[data-elbysodic-gateway-curation-item]");
+        if (!item) {
+          return;
+        }
+        item.setAttribute("aria-grabbed", "true");
+        event.dataTransfer.effectAllowed = "move";
+      });
+
+      list.addEventListener("dragover", (event) => {
+        const dragged = list.querySelector("[aria-grabbed='true']");
+        if (!dragged) {
+          return;
+        }
+        event.preventDefault();
+        const target = gatewayCurationDropTarget(list, event.clientY);
+        if (target) {
+          list.insertBefore(dragged, target);
+        } else {
+          list.appendChild(dragged);
+        }
+        updateGatewayCurationPositions(list);
+      });
+
+      list.addEventListener("dragend", () => {
+        const dragged = list.querySelector("[aria-grabbed='true']");
+        if (dragged) {
+          dragged.removeAttribute("aria-grabbed");
+        }
+        updateGatewayCurationPositions(list);
+        updateSpotlightComposer(list.closest("[data-elbysodic-spotlight-composer]"), true);
+      });
+    });
+  }
+
   function resetSubmitGuard(form) {
     if (!form || form.dataset.elbysodicSubmitPending !== "true") {
       return;
@@ -143,6 +498,8 @@
   function setupEnhancements() {
     setupSidebarToggle();
     setupSubmitGuards(document);
+    setupDiscoveryPreview(document);
+    setupGatewayCuration(document);
   }
 
   if (document.readyState === "loading") {

--- a/src/elbysodic/web/static/elbysodic-theme/20-shell.css
+++ b/src/elbysodic/web/static/elbysodic-theme/20-shell.css
@@ -22,6 +22,12 @@
     color: var(--chirpui-text);
 }
 
+.chirpui-app-shell__topbar {
+    position: sticky;
+    top: 0;
+    z-index: calc(var(--chirpui-z-sticky) + 4);
+}
+
 @supports (backdrop-filter: blur(18px)) or (-webkit-backdrop-filter: blur(18px)) {
     .chirpui-app-shell__topbar,
     .chirpui-app-shell__sidebar {
@@ -421,6 +427,133 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.elbysodic-realm-switcher {
+    min-width: 0;
+    position: relative;
+}
+
+.elbysodic-realm-switcher__summary {
+    align-items: center;
+    color: var(--chirpui-text);
+    cursor: pointer;
+    display: inline-flex;
+    gap: 0.65rem;
+    list-style: none;
+    min-width: 0;
+    text-decoration: none;
+}
+
+.elbysodic-realm-switcher__summary::-webkit-details-marker {
+    display: none;
+}
+
+.elbysodic-realm-switcher__summary::marker {
+    content: "";
+}
+
+.elbysodic-realm-switcher__summary::after {
+    border-left: 0.22rem solid transparent;
+    border-right: 0.22rem solid transparent;
+    border-top: 0.25rem solid var(--chirpui-text-muted);
+    content: "";
+    flex: 0 0 auto;
+}
+
+.elbysodic-realm-switcher[open] .elbysodic-realm-switcher__summary,
+.elbysodic-realm-switcher__summary:hover,
+.elbysodic-realm-switcher__summary:focus-visible {
+    color: var(--chirpui-text);
+}
+
+.elbysodic-realm-switcher__summary:focus-visible {
+    border-radius: var(--chirpui-radius-sm);
+    outline: 2px solid var(--chirpui-focus-ring);
+    outline-offset: 3px;
+}
+
+.elbysodic-realm-switcher__panel {
+    background: var(--elbysodic-glass-bg);
+    border: 1px solid var(--elbysodic-glass-border);
+    border-radius: var(--chirpui-radius-sm);
+    box-shadow: var(--chirpui-shadow-lg);
+    display: grid;
+    gap: 0.45rem;
+    left: 0;
+    max-height: min(36rem, calc(100vh - 5rem));
+    min-width: min(22rem, calc(100vw - 1.5rem));
+    overflow: auto;
+    overscroll-behavior: contain;
+    padding: 0.7rem;
+    position: absolute;
+    top: calc(100% + 0.55rem);
+    transform-origin: top left;
+    z-index: var(--chirpui-z-dropdown);
+}
+
+.elbysodic-realm-switcher__link {
+    align-items: center;
+    background: color-mix(in srgb, var(--chirpui-accent) 5%, var(--chirpui-bg-subtle));
+    border: 1px solid var(--chirpui-border-subtle);
+    border-radius: var(--chirpui-radius-sm);
+    color: var(--chirpui-text);
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 0.55rem 0.65rem;
+    text-decoration: none;
+}
+
+.elbysodic-realm-switcher__link:hover,
+.elbysodic-realm-switcher__link:focus-visible {
+    background: color-mix(in srgb, var(--chirpui-accent) 10%, var(--chirpui-surface));
+    border-color: var(--chirpui-border-strong);
+    color: var(--chirpui-text);
+}
+
+.elbysodic-realm-switcher__link--current {
+    background: color-mix(in srgb, var(--chirpui-accent) 12%, var(--chirpui-surface));
+    border-color: color-mix(in srgb, var(--chirpui-accent) 42%, var(--chirpui-border));
+}
+
+.elbysodic-realm-switcher__link span {
+    display: grid;
+    gap: 0.15rem;
+    min-width: 0;
+}
+
+.elbysodic-realm-switcher__link strong {
+    font-size: var(--chirpui-font-sm);
+    line-height: 1.1;
+}
+
+.elbysodic-realm-switcher__link small {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-xs);
+    font-weight: 800;
+    line-height: 1.25;
+}
+
+.elbysodic-realm-switcher__link b {
+    align-items: center;
+    background: var(--chirpui-surface);
+    border: 1px solid var(--chirpui-border-subtle);
+    border-radius: var(--chirpui-radius-sm);
+    color: var(--chirpui-text-muted);
+    display: inline-flex;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+    min-height: 1.45rem;
+    padding: 0.1rem 0.35rem;
+}
+
+.elbysodic-realm-switcher__section {
+    border-top: 1px solid var(--chirpui-border-subtle);
+    display: grid;
+    gap: 0.45rem;
+    margin-top: 0.1rem;
+    padding-top: 0.6rem;
 }
 
 .elbysodic-sidebar-link {
@@ -883,6 +1016,7 @@
 }
 
 @supports (backdrop-filter: blur(18px)) or (-webkit-backdrop-filter: blur(18px)) {
+    .elbysodic-realm-switcher__panel,
     .elbysodic-identity-menu__panel {
         backdrop-filter: blur(18px) saturate(140%);
         -webkit-backdrop-filter: blur(18px) saturate(140%);
@@ -892,6 +1026,7 @@
 @media (prefers-reduced-transparency: reduce) {
     .chirpui-app-shell__topbar,
     .chirpui-app-shell__sidebar,
+    .elbysodic-realm-switcher__panel,
     .elbysodic-identity-menu__panel {
         backdrop-filter: none;
         -webkit-backdrop-filter: none;
@@ -1105,6 +1240,24 @@
 
     .elbysodic-topbar-search__scope-short {
         display: inline;
+    }
+}
+
+@media (min-width: 48.001rem) and (max-width: 72rem) {
+    .elbysodic-app-shell--sidebar-hidden.chirpui-app-shell,
+    .elbysodic-app-shell--sidebar-hidden .chirpui-app-shell {
+        --chirpui-sidebar-width: var(--elbysodic-primary-rail-width);
+    }
+
+    .elbysodic-app-shell--sidebar-hidden .chirpui-app-shell__sidebar .chirpui-sidebar,
+    .elbysodic-app-shell--sidebar-hidden .chirpui-app-shell__sidebar .elbysodic-thread-context-sidebar {
+        opacity: 0;
+        pointer-events: none;
+        transform: translateX(-0.5rem);
+    }
+
+    .elbysodic-app-shell--sidebar-hidden .elbysodic-sidebar-resize::before {
+        left: 0.35rem;
     }
 }
 

--- a/src/elbysodic/web/static/elbysodic-theme/40-pbp-components.css
+++ b/src/elbysodic/web/static/elbysodic-theme/40-pbp-components.css
@@ -335,7 +335,144 @@ a.elbysodic-metric:focus-visible {
     margin: 0;
 }
 
+.elbysodic-director-context {
+    align-items: center;
+    background: color-mix(in srgb, var(--chirpui-accent) 9%, var(--chirpui-surface));
+    border: 1px solid color-mix(in srgb, var(--chirpui-accent) 36%, var(--chirpui-border));
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 1rem;
+}
+
+.elbysodic-director-context--compact {
+    margin-block-start: -0.25rem;
+}
+
+.elbysodic-director-context__copy {
+    display: grid;
+    gap: 0.2rem;
+    min-inline-size: 0;
+}
+
+.elbysodic-director-context__copy h2,
+.elbysodic-director-context__copy p {
+    margin: 0;
+}
+
+.elbysodic-director-context__copy h2 {
+    font-size: var(--chirpui-font-lg);
+    letter-spacing: 0;
+    line-height: 1.15;
+}
+
+.elbysodic-director-context__copy p:not(.elbysodic-kicker) {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-sm);
+    line-height: 1.45;
+    max-inline-size: 52rem;
+}
+
+.elbysodic-director-context__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    justify-content: end;
+}
+
+.elbysodic-director-menu {
+    position: relative;
+}
+
+.elbysodic-director-menu summary {
+    align-items: center;
+    background: color-mix(in srgb, var(--chirpui-surface) 78%, transparent);
+    border: 1px solid var(--chirpui-border);
+    border-radius: var(--chirpui-radius-sm);
+    color: var(--chirpui-text);
+    cursor: pointer;
+    display: flex;
+    gap: 0.45rem;
+    min-block-size: 2.45rem;
+    padding: 0.55rem 0.8rem;
+    user-select: none;
+}
+
+.elbysodic-director-menu summary::-webkit-details-marker {
+    display: none;
+}
+
+.elbysodic-director-menu summary::marker {
+    content: "";
+}
+
+.elbysodic-director-menu summary span {
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.elbysodic-director-menu summary small {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-xs);
+    font-weight: 800;
+}
+
+.elbysodic-director-menu summary::after {
+    color: var(--chirpui-text-muted);
+    content: "v";
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+}
+
+.elbysodic-director-menu[open] summary {
+    border-color: color-mix(in srgb, var(--chirpui-accent) 52%, var(--chirpui-border));
+}
+
+.elbysodic-director-menu__panel {
+    background: var(--chirpui-surface);
+    border: 1px solid color-mix(in srgb, var(--chirpui-accent) 36%, var(--chirpui-border));
+    border-radius: var(--chirpui-radius-sm);
+    box-shadow: var(--chirpui-shadow-md);
+    display: grid;
+    gap: 0.2rem;
+    inset-block-start: calc(100% + 0.35rem);
+    min-inline-size: 15rem;
+    padding: 0.35rem;
+    position: absolute;
+    right: 0;
+    z-index: 20;
+}
+
+.elbysodic-director-menu__panel a {
+    border-radius: calc(var(--chirpui-radius-sm) - 2px);
+    color: var(--chirpui-text);
+    font-weight: 800;
+    padding: 0.65rem 0.7rem;
+    text-decoration: none;
+}
+
+.elbysodic-director-menu__panel a:hover,
+.elbysodic-director-menu__panel a:focus-visible {
+    background: color-mix(in srgb, var(--chirpui-accent) 10%, transparent);
+}
+
 @media (max-width: 48rem) {
+    .elbysodic-director-context {
+        align-items: start;
+        grid-template-columns: 1fr;
+    }
+
+    .elbysodic-director-context__actions {
+        justify-content: start;
+    }
+
+    .elbysodic-director-menu__panel {
+        left: 0;
+        right: auto;
+    }
+
     .elbysodic-notice {
         align-items: start;
         grid-template-columns: auto minmax(0, 1fr);

--- a/src/elbysodic/web/static/elbysodic-theme/42-threads-queues.css
+++ b/src/elbysodic/web/static/elbysodic-theme/42-threads-queues.css
@@ -1775,9 +1775,142 @@
     gap: 0.65rem;
 }
 
+.elbysodic-access-heading {
+    align-items: center;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: auto 1fr;
+}
+
+.elbysodic-access-heading h1,
+.elbysodic-access-heading p {
+    margin: 0;
+}
+
+.elbysodic-access-heading h1 {
+    font-size: clamp(2rem, 3vw, 3rem);
+    letter-spacing: 0;
+    line-height: 1;
+}
+
+.elbysodic-access-heading > div {
+    display: grid;
+    gap: 0.35rem;
+}
+
 .elbysodic-access-panel {
     display: grid;
+    gap: 1.15rem;
+}
+
+.elbysodic-access-panel__intro {
+    display: grid;
+    gap: 0.5rem;
+    max-width: 42rem;
+}
+
+.elbysodic-access-panel__intro h2 {
+    font-size: clamp(1.8rem, 2.6vw, 2.6rem);
+    letter-spacing: 0;
+    line-height: 1.08;
+    margin: 0;
+}
+
+.elbysodic-access-panel__intro p {
+    font-size: var(--chirpui-font-md);
+    line-height: 1.45;
+}
+
+.elbysodic-access-account {
+    align-items: center;
+    background: color-mix(in srgb, var(--chirpui-accent) 9%, var(--chirpui-surface));
+    border: 1px solid color-mix(in srgb, var(--chirpui-accent) 28%, var(--chirpui-border));
+    border-radius: 8px;
+    display: grid;
     gap: 0.85rem;
+    grid-template-columns: auto 1fr;
+    padding: 0.9rem;
+}
+
+.elbysodic-access-account__avatar {
+    align-items: center;
+    aspect-ratio: 1;
+    background: var(--chirpui-accent);
+    border-radius: 999px;
+    color: var(--chirpui-on-accent);
+    display: inline-flex;
+    font-size: var(--chirpui-font-sm);
+    font-weight: 850;
+    justify-content: center;
+    width: 2.35rem;
+}
+
+.elbysodic-access-account h2,
+.elbysodic-access-account p {
+    margin: 0;
+}
+
+.elbysodic-access-account h2 {
+    font-size: var(--chirpui-font-md);
+    line-height: 1.2;
+}
+
+.elbysodic-access-form {
+    display: grid;
+    gap: 0.95rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.elbysodic-access-field {
+    display: grid;
+    gap: 0.45rem;
+    margin: 0;
+}
+
+.elbysodic-access-field--wide {
+    grid-column: 1 / -1;
+}
+
+.elbysodic-access-field > span {
+    color: var(--chirpui-text);
+    font-size: var(--chirpui-font-sm);
+    font-weight: 800;
+    line-height: 1.2;
+}
+
+.elbysodic-access-field input,
+.elbysodic-access-field textarea {
+    border-radius: 8px;
+    font: inherit;
+    min-height: 2.75rem;
+    padding: 0.72rem 0.85rem;
+    width: 100%;
+}
+
+.elbysodic-access-field textarea {
+    min-height: 8rem;
+    resize: vertical;
+}
+
+.elbysodic-access-form__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    grid-column: 1 / -1;
+}
+
+.elbysodic-access-panel__footer {
+    align-items: center;
+    border-top: 1px solid var(--chirpui-border-subtle);
+    color: var(--chirpui-text-muted);
+    display: flex;
+    flex-wrap: wrap;
+    font-size: var(--chirpui-font-sm);
+    font-weight: 750;
+    gap: 0.75rem 1rem;
+    justify-content: space-between;
+    padding-top: 1rem;
 }
 
 .elbysodic-product-identity {
@@ -1812,6 +1945,22 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.65rem;
+}
+
+@media (max-width: 42rem) {
+    .elbysodic-access-heading {
+        align-items: start;
+        grid-template-columns: 1fr;
+    }
+
+    .elbysodic-access-form {
+        grid-template-columns: 1fr;
+    }
+
+    .elbysodic-access-panel__footer {
+        align-items: stretch;
+        flex-direction: column;
+    }
 }
 
 .elbysodic-thread-card__meta {

--- a/src/elbysodic/web/static/elbysodic-theme/60-studio.css
+++ b/src/elbysodic/web/static/elbysodic-theme/60-studio.css
@@ -270,7 +270,8 @@
 .elbysodic-operations-list li {
     border-top: 1px solid var(--chirpui-border-subtle);
     display: grid;
-    gap: 0.15rem;
+    gap: 0.65rem;
+    grid-template-columns: minmax(0, 1fr) auto;
     padding-top: 0.45rem;
 }
 
@@ -278,6 +279,96 @@
     color: var(--chirpui-text-muted);
     font-size: var(--chirpui-font-sm);
     font-weight: 750;
+}
+
+.elbysodic-launch-checklist {
+    display: grid;
+    gap: 0.35rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.elbysodic-launch-checklist__item {
+    align-items: center;
+    border-top: 1px solid var(--chirpui-border-subtle);
+    display: grid;
+    gap: 0.8rem;
+    grid-template-columns: 0.75rem minmax(0, 1fr) auto;
+    min-block-size: 3.25rem;
+    padding: 0.65rem 0;
+}
+
+.elbysodic-launch-checklist__item:first-child {
+    border-top: 0;
+}
+
+.elbysodic-launch-checklist__marker {
+    background: var(--chirpui-text-muted);
+    border-radius: 999px;
+    block-size: 0.55rem;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--chirpui-text-muted) 18%, transparent);
+    inline-size: 0.55rem;
+}
+
+.elbysodic-launch-checklist__item--ready .elbysodic-launch-checklist__marker {
+    background: var(--chirpui-success);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--chirpui-success) 18%, transparent);
+}
+
+.elbysodic-launch-checklist__item--needed .elbysodic-launch-checklist__marker {
+    background: var(--chirpui-warning);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--chirpui-warning) 18%, transparent);
+}
+
+.elbysodic-launch-checklist__copy {
+    display: grid;
+    gap: 0.2rem;
+}
+
+.elbysodic-launch-checklist__copy strong {
+    color: var(--chirpui-text);
+    font-size: var(--chirpui-font-md);
+    font-weight: 850;
+    line-height: 1.2;
+}
+
+.elbysodic-launch-checklist__copy span {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-sm);
+    font-weight: 500;
+    line-height: 1.45;
+    max-inline-size: 48rem;
+}
+
+.elbysodic-launch-checklist__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    justify-content: flex-end;
+}
+
+.elbysodic-launch-checklist__actions .chirpui-badge {
+    font-size: var(--chirpui-font-xs);
+    opacity: 0.78;
+}
+
+.elbysodic-launch-checklist__actions .chirpui-btn {
+    min-inline-size: 7.75rem;
+}
+
+.elbysodic-studio-actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    justify-content: flex-end;
+    min-inline-size: min(100%, 12rem);
+}
+
+.elbysodic-studio-actions form {
+    margin: 0;
 }
 
 .elbysodic-operations-columns {
@@ -434,18 +525,49 @@
 }
 
 .elbysodic-gateway-curation-choice {
-    align-items: start;
+    align-items: center;
     border-top: 1px solid var(--chirpui-border-subtle);
     display: grid;
     gap: 0.65rem;
-    grid-template-columns: auto minmax(0, 1fr) 5.5rem;
+    grid-template-columns: auto minmax(0, 1fr);
     margin: 0;
-    padding-top: 0.65rem;
+    padding: 0.65rem 0 0;
 }
 
 .elbysodic-gateway-curation-choice:first-child {
     border-top: 0;
     padding-top: 0;
+}
+
+.elbysodic-gateway-curation-choice[aria-grabbed="true"] {
+    opacity: 0.72;
+}
+
+.elbysodic-gateway-curation-choice__handle {
+    background: color-mix(in srgb, var(--chirpui-accent) 8%, var(--chirpui-bg-subtle));
+    border: 1px solid var(--chirpui-border-subtle);
+    border-radius: var(--chirpui-radius-sm);
+    color: var(--chirpui-text-muted);
+    cursor: grab;
+    font: inherit;
+    font-size: var(--chirpui-font-sm);
+    font-weight: 850;
+    inline-size: 2.1rem;
+    min-block-size: 2.25rem;
+    padding: 0;
+}
+
+.elbysodic-gateway-curation-choice__handle:active {
+    cursor: grabbing;
+}
+
+.elbysodic-gateway-curation-choice__select {
+    align-items: start;
+    display: grid;
+    gap: 0.55rem;
+    grid-template-columns: auto minmax(0, 1fr);
+    margin: 0;
+    min-inline-size: 0;
 }
 
 .elbysodic-gateway-curation-choice__copy {
@@ -464,8 +586,352 @@
     line-height: 1.35;
 }
 
-.elbysodic-gateway-curation-choice__position {
+.elbysodic-gateway-curation-choice__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    grid-column: 2;
+    justify-content: flex-start;
+    justify-self: start;
+}
+
+.elbysodic-gateway-curation-choice__rank {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-xs);
+    font-weight: 850;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.elbysodic-gateway-curation-choice__controls {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.35rem;
+    justify-content: flex-end;
+}
+
+.elbysodic-gateway-curation-choice__controls .chirpui-btn {
+    inline-size: 2.1rem;
+    min-block-size: 2.1rem;
+    padding: 0;
+}
+
+.elbysodic-spotlight-composer {
+    container-type: inline-size;
+}
+
+.elbysodic-spotlight-composer__brief {
+    background: color-mix(in srgb, var(--chirpui-accent) 8%, var(--chirpui-bg-subtle));
+    border: 1px solid color-mix(in srgb, var(--chirpui-accent) 28%, var(--chirpui-border-subtle));
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    gap: 0.2rem;
+    padding: 0.8rem 0.9rem;
+}
+
+.elbysodic-spotlight-composer__brief p {
     margin: 0;
+}
+
+.elbysodic-spotlight-composer__brief p:not(.elbysodic-kicker) {
+    color: var(--chirpui-text-muted);
+    line-height: 1.45;
+}
+
+.elbysodic-spotlight-composer__layout {
+    align-items: start;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1.35fr) minmax(min(100%, 24rem), 0.75fr);
+}
+
+.elbysodic-spotlight-sequence,
+.elbysodic-spotlight-library,
+.elbysodic-spotlight-preview {
+    background: color-mix(in srgb, var(--chirpui-bg-subtle) 56%, transparent);
+    border: 1px solid var(--chirpui-border-subtle);
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    gap: 0.9rem;
+    padding: 1rem;
+}
+
+.elbysodic-spotlight-section-heading {
+    align-items: start;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+}
+
+.elbysodic-spotlight-section-heading h3,
+.elbysodic-spotlight-section-heading p {
+    margin: 0;
+}
+
+.elbysodic-spotlight-section-heading h3 {
+    font-size: var(--chirpui-font-xl);
+    letter-spacing: 0;
+}
+
+.elbysodic-spotlight-section-heading > p {
+    color: var(--chirpui-text-muted);
+    line-height: 1.4;
+    max-inline-size: 24rem;
+}
+
+.elbysodic-spotlight-lane {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.elbysodic-spotlight-lane__header {
+    align-items: center;
+    border-top: 1px solid var(--chirpui-border-subtle);
+    display: flex;
+    gap: 0.75rem;
+    justify-content: space-between;
+    padding-top: 0.75rem;
+}
+
+.elbysodic-spotlight-lane__header h3,
+.elbysodic-spotlight-lane__header p {
+    margin: 0;
+}
+
+.elbysodic-spotlight-lane__header h3 {
+    font-size: var(--chirpui-font-lg);
+    letter-spacing: 0;
+}
+
+.elbysodic-spotlight-lane__header > span {
+    align-items: center;
+    background: color-mix(in srgb, var(--chirpui-accent) 16%, var(--chirpui-surface));
+    border: 1px solid color-mix(in srgb, var(--chirpui-accent) 32%, var(--chirpui-border));
+    border-radius: 999px;
+    color: var(--chirpui-text);
+    display: inline-flex;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+    min-block-size: 1.5rem;
+    min-inline-size: 1.5rem;
+    justify-content: center;
+    padding: 0 0.45rem;
+}
+
+.elbysodic-spotlight-list,
+.elbysodic-spotlight-library-list {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.elbysodic-spotlight-item {
+    align-items: start;
+    background: color-mix(in srgb, var(--chirpui-surface) 68%, transparent);
+    border: 1px solid var(--chirpui-border-subtle);
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 0.8rem;
+}
+
+.elbysodic-spotlight-item--selected {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.elbysodic-spotlight-item[aria-grabbed="true"] {
+    opacity: 0.72;
+}
+
+.elbysodic-spotlight-item__handle {
+    align-self: stretch;
+    background: color-mix(in srgb, var(--chirpui-accent) 9%, var(--chirpui-bg-subtle));
+    border: 1px solid var(--chirpui-border-subtle);
+    border-radius: var(--chirpui-radius-sm);
+    color: var(--chirpui-text-muted);
+    cursor: grab;
+    font: inherit;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+    min-block-size: 100%;
+    padding: 0.35rem 0.45rem;
+    text-transform: uppercase;
+}
+
+.elbysodic-spotlight-item__handle:active {
+    cursor: grabbing;
+}
+
+.elbysodic-spotlight-item__copy {
+    display: grid;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.elbysodic-spotlight-item__copy span,
+.elbysodic-spotlight-item__rank {
+    color: var(--chirpui-accent);
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+    text-transform: uppercase;
+}
+
+.elbysodic-spotlight-item__copy h4,
+.elbysodic-spotlight-item__copy p {
+    margin: 0;
+}
+
+.elbysodic-spotlight-item__copy h4 {
+    font-size: var(--chirpui-font-md);
+    letter-spacing: 0;
+}
+
+.elbysodic-spotlight-item__copy p {
+    color: var(--chirpui-text-muted);
+    line-height: 1.4;
+}
+
+.elbysodic-spotlight-item__actions {
+    align-items: end;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.elbysodic-spotlight-item__move {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    justify-content: flex-end;
+}
+
+.elbysodic-spotlight-item__move .chirpui-btn {
+    min-block-size: 2rem;
+    padding-inline: 0.55rem;
+}
+
+.elbysodic-spotlight-item--available .elbysodic-spotlight-item__handle,
+.elbysodic-spotlight-item--available .elbysodic-spotlight-item__rank,
+.elbysodic-spotlight-item--available .elbysodic-spotlight-item__remove,
+.elbysodic-spotlight-item--available .elbysodic-spotlight-item__move {
+    display: none;
+}
+
+.elbysodic-spotlight-item--selected .elbysodic-spotlight-item__add {
+    display: none;
+}
+
+.elbysodic-spotlight-library-section {
+    border-top: 1px solid var(--chirpui-border-subtle);
+    display: grid;
+    gap: 0.65rem;
+    padding-top: 0.75rem;
+}
+
+.elbysodic-spotlight-library-section summary {
+    cursor: pointer;
+    display: grid;
+    gap: 0.2rem;
+    list-style: none;
+}
+
+.elbysodic-spotlight-library-section summary::-webkit-details-marker {
+    display: none;
+}
+
+.elbysodic-spotlight-library-section summary::marker {
+    content: "";
+}
+
+.elbysodic-spotlight-library-section summary span {
+    color: var(--chirpui-text);
+    font-weight: 900;
+}
+
+.elbysodic-spotlight-library-section summary small {
+    color: var(--chirpui-text-muted);
+    line-height: 1.35;
+}
+
+.elbysodic-spotlight-empty[hidden] {
+    display: none;
+}
+
+.elbysodic-spotlight-preview {
+    grid-template-columns: minmax(0, 0.85fr) minmax(0, 1fr) auto;
+}
+
+.elbysodic-spotlight-preview h3,
+.elbysodic-spotlight-preview p {
+    margin: 0;
+}
+
+.elbysodic-spotlight-preview h3 {
+    font-size: var(--chirpui-font-lg);
+    letter-spacing: 0;
+}
+
+.elbysodic-spotlight-preview p:not(.elbysodic-kicker) {
+    color: var(--chirpui-text-muted);
+    line-height: 1.4;
+}
+
+.elbysodic-spotlight-preview ol {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.elbysodic-spotlight-preview li {
+    background: color-mix(in srgb, var(--chirpui-accent) 8%, var(--chirpui-surface));
+    border: 1px solid var(--chirpui-border-subtle);
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    gap: 0.1rem;
+    min-inline-size: min(14rem, 100%);
+    padding: 0.55rem 0.65rem;
+}
+
+.elbysodic-spotlight-preview li span {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+    text-transform: uppercase;
+}
+
+.elbysodic-spotlight-preview li strong {
+    font-size: var(--chirpui-font-sm);
+}
+
+.elbysodic-spotlight-preview [data-elbysodic-spotlight-preview-empty][hidden] {
+    display: none;
+}
+
+.elbysodic-spotlight-savebar {
+    align-items: center;
+    background: color-mix(in srgb, var(--chirpui-bg-subtle) 82%, transparent);
+    border: 1px solid var(--chirpui-border-subtle);
+    border-radius: var(--chirpui-radius-sm);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    justify-content: flex-end;
+    padding: 0.75rem;
+}
+
+.elbysodic-spotlight-savebar > span {
+    color: var(--chirpui-text-muted);
+    font-size: var(--chirpui-font-sm);
+    font-weight: 800;
+    margin-right: auto;
+}
+
+.elbysodic-spotlight-savebar > span[data-elbysodic-dirty="true"] {
+    color: var(--chirpui-accent);
 }
 
 .elbysodic-theme-preview {
@@ -928,18 +1394,49 @@
 }
 
 .elbysodic-navigation-preview__header {
-    display: grid;
-    gap: 0.3rem;
+    align-items: start;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: space-between;
 }
 
 .elbysodic-navigation-preview__header h3,
-.elbysodic-navigation-preview__header p {
+.elbysodic-navigation-preview__header p,
+.elbysodic-navigation-preview__goal {
     margin: 0;
 }
 
 .elbysodic-navigation-preview__header h3 {
     font-size: var(--chirpui-font-xl);
     letter-spacing: 0;
+}
+
+.elbysodic-navigation-preview__header > span {
+    border: 1px solid var(--chirpui-border-subtle);
+    border-radius: 999px;
+    color: var(--chirpui-text-muted);
+    flex: 0 0 auto;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+    padding: 0.12rem 0.45rem;
+    text-transform: uppercase;
+}
+
+.elbysodic-navigation-preview__goal {
+    background: color-mix(in srgb, var(--chirpui-surface) 55%, transparent);
+    border-left: 2px solid var(--chirpui-accent);
+    color: var(--chirpui-text-muted);
+    line-height: 1.4;
+    padding: 0.55rem 0.7rem;
+}
+
+.elbysodic-navigation-preview__goal strong {
+    color: var(--chirpui-text);
+    display: block;
+    font-size: var(--chirpui-font-xs);
+    font-weight: 900;
+    margin-bottom: 0.15rem;
+    text-transform: uppercase;
 }
 
 .elbysodic-navigation-preview__header p {
@@ -975,21 +1472,28 @@
 
 .elbysodic-navigation-preview__list a {
     color: var(--chirpui-text);
+    display: grid;
+    gap: 0.1rem;
     font-weight: 850;
     min-width: 0;
     text-decoration: none;
 }
 
-.elbysodic-navigation-preview__list span,
-.elbysodic-navigation-preview__list small {
+.elbysodic-navigation-preview__list a span {
+    min-width: 0;
+}
+
+.elbysodic-navigation-preview__list small,
+.elbysodic-navigation-preview__list em {
     color: var(--chirpui-text-muted);
     font-size: var(--chirpui-font-xs);
     font-weight: 800;
 }
 
-.elbysodic-navigation-preview__list span {
+.elbysodic-navigation-preview__list em {
     border: 1px solid var(--chirpui-border-subtle);
     border-radius: 999px;
+    font-style: normal;
     padding: 0.12rem 0.4rem;
 }
 
@@ -1131,6 +1635,23 @@
     margin: 0;
 }
 
+@media (max-width: 72rem) {
+    .elbysodic-spotlight-composer__layout,
+    .elbysodic-spotlight-preview {
+        grid-template-columns: 1fr;
+    }
+
+    .elbysodic-spotlight-section-heading,
+    .elbysodic-spotlight-savebar {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .elbysodic-spotlight-savebar > span {
+        margin-right: 0;
+    }
+}
+
 @media (max-width: 48rem) {
     .elbysodic-director-hero,
     .elbysodic-operations-hero {
@@ -1152,8 +1673,28 @@
     .elbysodic-sidebar-section-config,
     .elbysodic-sidebar-section-configs,
     .elbysodic-gateway-curation-choice,
+    .elbysodic-spotlight-item,
+    .elbysodic-spotlight-item--selected,
+    .elbysodic-operations-list li,
+    .elbysodic-launch-checklist__item,
     .elbysodic-navigation-preview__list li {
         grid-template-columns: 1fr;
+    }
+
+    .elbysodic-launch-checklist__marker {
+        display: none;
+    }
+
+    .elbysodic-launch-checklist__actions {
+        justify-content: flex-start;
+    }
+
+    .elbysodic-studio-actions {
+        justify-content: flex-start;
+    }
+
+    .elbysodic-spotlight-item__actions {
+        align-items: flex-start;
     }
 
     .elbysodic-sidebar-section-config .chirpui-btn {

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -475,7 +475,7 @@ def test_concurrent_rendered_get_navigation_stays_stable(tmp_path: Path) -> None
         services = create_services(path=tmp_path / "rapid-navigation.sqlite3")
         app = create_app(debug=False, services=services)
         routes = [
-            ("/network", "Studio Network"),
+            ("/network", "Find a realm that fits the story you want to write."),
             ("/c/rl-nyc/my/threads", "RL NYC"),
             ("/c/rl-small-town/boards/town-hall?filter=mine", "RL Small Town"),
             ("/c/jurassic-park-universe/world", "Jurassic Park Universe"),
@@ -663,7 +663,7 @@ def test_scaled_signed_in_network_stays_within_batched_query_budget() -> None:
                 response = await client.get("/network")
 
         assert response.status == 200
-        assert "Studio Network" in response.text
+        assert "Find a realm that fits the story you want to write." in response.text
         assert "Hosted Program" in response.text
         assert trace.count <= 85
 
@@ -845,8 +845,10 @@ def test_tenant_prefixed_route_keeps_scoped_links_inside_prefix() -> None:
         assert (
             'name="next" value="/c/jurassic-park-universe/boards/paddock-twelve"' in response.text
         )
+        assert "/login?next=%2Fboards%2Fpaddock-twelve" not in response.text
         assert (
-            "/login?next=%2Fc%2Fjurassic-park-universe%2Fboards%2Fpaddock-twelve" in response.text
+            "/login?next=%2Fc%2Fjurassic-park-universe%2Fboards%2Fpaddock-twelve"
+            not in response.text
         )
         assert 'href="/elbysodic-static/elbysodic-theme.css' in response.text
         assert 'href="/c/jurassic-park-universe/elbysodic-static' not in response.text
@@ -987,12 +989,20 @@ def test_shell_brand_navigation_uses_full_boundary_navigation() -> None:
             response = await client.get("/boards/cerebro")
 
         assert response.status == 200
-        brand_link = re.search(
-            r'<a href="/"[^>]*class="[^"]*elbysodic-community-brand[^"]*"[^>]*>',
+        realm_switcher = re.search(
+            r'<summary class="elbysodic-realm-switcher__summary"'
+            r'[^>]*aria-label="Realm switcher: X-Men Apocalypse"',
             response.text,
         )
-        assert brand_link is not None
-        assert 'hx-boost="false"' in brand_link.group(0)
+        assert realm_switcher is not None
+        product_home_link = re.search(
+            r'<a class="[^"]*elbysodic-realm-switcher__link[^"]*"'
+            r'\s+href="/"[^>]*data-elbysodic-global-link[^>]*hx-boost="false"',
+            response.text,
+        )
+        assert product_home_link is not None
+        assert "<strong>Elbysodic</strong>" in response.text
+        assert "<small>Network home</small>" in response.text
         assert re.search(
             r'<a class="[^"]*elbysodic-primary-rail__link[^"]*"\s+href="/locations"'
             r'[^>]*aria-label="Locations"[^>]*hx-sync="#main:replace"',
@@ -1365,7 +1375,7 @@ def test_dev_persona_switcher_can_change_seeded_user_and_membership() -> None:
         assert studio.status == 200
         assert "Staff in X-Men Apocalypse" in studio.text
         assert "playing as Moira MacTaggert" in studio.text
-        assert "Save theme tokens" in studio.text
+        assert 'href="/studio/appearance"' in studio.text
         assert "Director Studio is visible as a preview" not in studio.text
 
     asyncio.run(run())
@@ -1430,7 +1440,7 @@ def test_login_route_creates_account_session_and_membership_context() -> None:
         assert any(cookie.startswith("elbysodic_dev_identity=") for cookie in set_cookies)
         assert studio.status == 200
         assert "Staff in X-Men Apocalypse" in studio.text
-        assert "Save theme tokens" in studio.text
+        assert 'href="/studio/appearance"' in studio.text
 
     asyncio.run(run())
 
@@ -2813,9 +2823,9 @@ def test_studio_gateway_curation_updates_public_home_slots() -> None:
         app = create_app(debug=False, services=staff_services)
 
         async with TestClient(app) as client:
-            studio = await client.get("/studio")
+            studio = await client.get("/studio/structure")
             save = await client.post(
-                "/studio",
+                "/studio/structure",
                 body=urlencode(
                     {
                         "intent": "gateway_curation",
@@ -2829,16 +2839,30 @@ def test_studio_gateway_curation_updates_public_home_slots() -> None:
                 ).encode(),
                 headers=_FORM,
             )
-            updated_studio = await client.get("/studio")
+            updated_studio = await client.get("/studio/structure")
             home = await client.get("/c/x-men-apocalypse")
 
         assert studio.status == 200
-        assert "Gateway curation" in studio.text
+        assert "Home spotlight audit" in studio.text
         assert "Danger Room" in studio.text
         assert "Human UN liaison for B-24 talks" in studio.text
         assert "B-24 Winter" in studio.text
+        assert "Selected spotlight" in studio.text
+        assert "Spotlight library" in studio.text
+        assert "Realm home preview" in studio.text
+        assert "Add to spotlight" in studio.text
+        assert "This is the cross-realm audit view." in studio.text
+        assert "data-elbysodic-spotlight-composer" in studio.text
+        assert "data-elbysodic-spotlight-selected-list" in studio.text
+        assert "data-elbysodic-spotlight-library-list" in studio.text
+        assert "data-elbysodic-spotlight-preview-list" in studio.text
+        assert "data-elbysodic-gateway-curation-list" in studio.text
+        assert "data-elbysodic-gateway-curation-item" in studio.text
+        assert "data-elbysodic-gateway-curation-position" in studio.text
+        assert "Board map audit and bulk repair" in studio.text
+        assert "Single-board edits belong on the board" in studio.text
         assert save.status == 302
-        assert _response_header(save, "location") == "/studio#gateway-curation"
+        assert _response_header(save, "location") == "/studio/structure#gateway-curation"
 
         slots = services.repo.list_community_gateway_slots(community.id)
         assert {(slot.slot_type, slot.target_id, slot.position) for slot in slots} >= {
@@ -2847,7 +2871,11 @@ def test_studio_gateway_curation_updates_public_home_slots() -> None:
             ("guidebook_material", material.id, 10),
         }
         assert re.search(
-            rf'name="scene_hub_target_id"\s+value="{board.id}"\s+checked',
+            rf'name="scene_hub_target_id"[^>]*value="{board.id}"[^>]*checked',
+            updated_studio.text,
+        )
+        assert re.search(
+            rf'name="scene_hub_position_{board.id}"[^>]*value="10"',
             updated_studio.text,
         )
         assert home.status == 200
@@ -2872,7 +2900,7 @@ def test_studio_gateway_curation_rejects_invalid_selected_order() -> None:
 
         async with TestClient(app) as client:
             response = await client.post(
-                "/studio",
+                "/studio/structure",
                 body=urlencode(
                     {
                         "intent": "gateway_curation",
@@ -2884,7 +2912,7 @@ def test_studio_gateway_curation_rejects_invalid_selected_order() -> None:
             )
 
         assert response.status == 200
-        assert "gateway curation order must be a positive number" in response.text
+        assert "spotlight order must be a positive number" in response.text
         assert (
             services.repo.list_community_gateway_slots(
                 staff.community.id,
@@ -3015,7 +3043,7 @@ def test_root_renders_elbysodic_network_home_not_default_community() -> None:
         assert "/elbysodic-static/brand/elbysodic-favicon.svg" in root.text
         assert "/elbysodic-static/brand/elbysodic-mark-small.svg" in root.text
         assert '<span class="elbysodic-community-brand__name">Elbysodic</span>' in root.text
-        assert "Studio Network" in root.text
+        assert "Explore realms" in root.text
         assert "Featured realm" in root.text
         assert "Top 10 realms" in root.text
         assert "Premise engines" not in root.text
@@ -3066,6 +3094,11 @@ def test_shell_groups_community_modes_in_topbar_and_context_in_sidebar() -> None
                 '<span class="elbysodic-community-brand__name">X-Men Apocalypse</span>'
                 in index.text
             )
+            assert 'class="elbysodic-realm-switcher__summary"' in index.text
+            assert 'aria-label="Realm switcher: X-Men Apocalypse"' in index.text
+            assert "<strong>Elbysodic</strong>" in index.text
+            assert "<small>Network home</small>" in index.text
+            assert "<strong>Explore realms</strong>" in index.text
             assert 'data-rail-tooltip="Built on Elbysodic"' in index.text
             assert re.search(
                 r'<a class="elbysodic-primary-rail__link elbysodic-primary-rail__link--platform"\s+href="/"',
@@ -3588,6 +3621,9 @@ def test_director_studio_surfaces_community_production_work() -> None:
         async with TestClient(app) as client:
             studio = await client.get("/studio")
             operations = await client.get("/studio/operations")
+            structure = await client.get("/studio/structure")
+            appearance = await client.get("/studio/appearance")
+            content = await client.get("/studio/content")
 
             assert studio.status == 200
             assert "Director Studio" in studio.text
@@ -3595,58 +3631,57 @@ def test_director_studio_surfaces_community_production_work() -> None:
             assert "Director attention" in studio.text
             assert "No director queues need attention right now." in studio.text
             assert "Production calm" in studio.text
-            assert "Public discovery profile" not in studio.text
-            assert 'href="/studio/discovery"' not in studio.text
-            assert "Studio rooms" not in studio.text
-            assert 'id="chirp-shell-actions"' in studio.text
-            assert 'href="/studio/operations"' not in _page_content(studio.text)
+            assert "Studio rooms" in studio.text
+            assert "Operations" in studio.text
+            assert "Discovery profile" in studio.text
+            assert "Structure" in studio.text
+            assert "Intake" in studio.text
+            assert "Appearance" in studio.text
+            assert "Content" in studio.text
+            assert 'href="/studio/operations"' in studio.text
+            assert 'href="/studio/launch"' in studio.text
+            assert 'href="/studio/discovery"' in studio.text
+            assert 'href="/studio/structure"' in studio.text
             assert 'href="/studio/intake"' in studio.text
-            assert 'href="/wanted"' in studio.text
-            assert 'href="/studio/launch"' not in _page_content(studio.text)
+            assert 'href="/studio/appearance"' in studio.text
+            assert 'href="/studio/content"' in studio.text
+            assert 'id="chirp-shell-actions"' in studio.text
             assert "Daily director console" not in studio.text
-            assert "Realm opening checklist" not in studio.text
-            assert 'href="#world-structure"' not in studio.text
-            assert 'href="#navigation"' not in studio.text
-            assert 'href="#identity-appearance"' not in studio.text
-            assert 'href="#casting-applications"' not in studio.text
-            assert 'href="#continuity-events"' not in studio.text
-            assert 'id="world-structure"' in studio.text
-            assert 'id="navigation"' in studio.text
-            assert 'id="identity-appearance"' in studio.text
-            assert 'id="casting-applications"' in studio.text
-            assert 'id="continuity-events"' in studio.text
-            assert "World structure" in studio.text
-            assert "Navigation composer" in studio.text
-            assert "Identity and appearance" in studio.text
-            assert "World Bible" in studio.text
-            assert "Location Studio" in studio.text
-            assert "Event Studio" in studio.text
-            assert "Applications and hooks" in studio.text
-            assert "Board taxonomy" in studio.text
-            assert "Navigation composer" in studio.text
-            assert "Sidebar section settings" in studio.text
-            assert "Navigation Health" in studio.text
-            assert "Navigation is coherent right now." in studio.text
-            assert "World sidebar" in studio.text
-            assert "Desk sidebar" in studio.text
-            assert "Studio sidebar" in studio.text
-            assert "Casting sidebar" in studio.text
-            assert "App-owned" in studio.text
-            assert "Board-derived" in studio.text
-            assert "Material-derived" in studio.text
-            assert "Identity-derived" in studio.text
-            assert "Wanted-derived" in studio.text
-            assert "Community board" in studio.text
-            assert "Sublocation" in studio.text
-            assert "Announcements" in studio.text
-            assert "Classify each board" in studio.text
-            assert 'href="/studio#board-taxonomy"' in studio.text
-            assert 'href="/studio#navigation-composer"' in studio.text
-            assert 'href="/studio/boards/announcements"' in studio.text
-            assert 'href="/world/b-24-winter"' in studio.text
-            assert 'href="/applications"' in studio.text
-            assert 'href="/wanted"' in studio.text
-            assert "Current event" in studio.text
+            assert 'id="world-structure"' not in _page_content(studio.text)
+            assert 'id="navigation"' not in _page_content(studio.text)
+            assert 'id="identity-appearance"' not in _page_content(studio.text)
+            assert 'id="casting-applications"' not in _page_content(studio.text)
+            assert 'id="continuity-events"' not in _page_content(studio.text)
+            assert structure.status == 200
+            assert "data-elbysodic-spotlight-composer" not in structure.text
+            assert "Board map" in structure.text
+            assert "Board map audit" in structure.text
+            assert "Sidebar audit" in structure.text
+            assert "Navigation Health" in structure.text
+            assert "Check the sidebars people will actually see" in structure.text
+            assert "Goal</strong>" in structure.text
+            assert "Help visitors move from the realm overview" in structure.text
+            assert "Keep director production rooms and staff boards separate" in structure.text
+            assert "Fixed route" in structure.text
+            assert "App-owned" not in structure.text
+            assert "World sidebar" in structure.text
+            assert "Desk sidebar" in structure.text
+            assert "Studio sidebar" in structure.text
+            assert "Casting sidebar" in structure.text
+            assert "Announcements" in structure.text
+            assert 'href="/studio/boards/announcements"' in structure.text
+            assert appearance.status == 200
+            assert "Identity and appearance" in appearance.text
+            assert "Inherited accents" in appearance.text
+            assert content.status == 200
+            assert "World Bible" in content.text
+            assert "Location Studio" in content.text
+            assert "Event Studio" in content.text
+            assert "Applications and hooks" in content.text
+            assert 'href="/world/b-24-winter"' in content.text
+            assert 'href="/applications"' in content.text
+            assert 'href="/wanted"' in content.text
+            assert "Current event" in content.text
             assert operations.status == 200
             assert "Director desk" in operations.text
             assert "What needs a director?" in operations.text
@@ -3681,6 +3716,9 @@ def test_director_studio_surfaces_community_production_work() -> None:
         assert "Open realm" in launch.text
         assert "Open the realm with the writing surface intact." in launch.text
         assert "Opening checklist" in launch.text
+        assert 'class="elbysodic-launch-checklist"' in launch.text
+        assert "elbysodic-launch-checklist__item--ready" in launch.text
+        assert "elbysodic-launch-checklist__copy" in launch.text
         assert "Realm identity" in launch.text
         assert "Scene hubs" in launch.text
         assert "Director materials" in launch.text
@@ -3690,6 +3728,53 @@ def test_director_studio_surfaces_community_production_work() -> None:
         assert "Invite-only before public self-serve." in launch.text
         assert "Open Studio" not in _page_content(launch.text)
         assert 'href="/studio/intake#program-blueprint-preview"' in launch.text
+
+    asyncio.run(run())
+
+
+def test_director_context_controls_live_on_home_and_board_surfaces() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        staff = resolve_seed_persona(services.repo, "xmen_staff")
+        staff_app = create_app(
+            debug=False,
+            services=AppServices(
+                services.repo,
+                DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+            ),
+        )
+
+        async with TestClient(staff_app) as client:
+            home = await client.get("/c/x-men-apocalypse")
+            board = await client.get("/boards/xavier-institute")
+
+        writer = resolve_seed_persona(services.repo, "xmen_writer")
+        writer_app = create_app(
+            debug=False,
+            services=AppServices(
+                services.repo,
+                DemoSeed(writer.community, writer.user, writer.membership, writer.character),
+            ),
+        )
+        async with TestClient(writer_app) as client:
+            writer_home = await client.get("/c/x-men-apocalypse")
+            writer_board = await client.get("/boards/xavier-institute")
+
+        assert home.status == 200
+        assert "Realm home controls" in home.text
+        assert "/studio/structure#gateway-curation" in home.text
+        assert "/studio/discovery" in home.text
+        assert board.status == 200
+        assert "Manage place" in board.text
+        assert "Manage this place" in board.text
+        assert "/studio/boards/xavier-institute" in board.text
+        assert "/studio/structure#board-taxonomy" in board.text
+
+        assert writer_home.status == 200
+        assert "Realm home controls" not in writer_home.text
+        assert writer_board.status == 200
+        assert "Manage this place" not in writer_board.text
+        assert "/studio/boards/xavier-institute" not in writer_board.text
 
     asyncio.run(run())
 
@@ -3799,6 +3884,16 @@ def test_studio_launch_moderates_access_requests() -> None:
         assert "Exchange student" in launch.text
         assert "Mark reviewed" in launch.text
         assert "Decline request" in launch.text
+        assert "elbysodic-studio-actions" in launch.text
+        assert "elbysodic-network-card__actions" not in launch.text
+        assert (
+            launch.text.count('class="chirpui-field chirpui-field--outlined elbysodic-form-field"')
+            >= 4
+        )
+        assert '<input class="chirpui-field__input" name="scene_hub_name"' in launch.text
+        assert '<textarea class="chirpui-field__input" name="premise_summary"' in launch.text
+        assert '<textarea class="chirpui-field__input" name="application_summary"' in launch.text
+        assert '<input class="chirpui-field__input" name="email" type="email"' in launch.text
         assert reviewed.status == 200
         assert "was reviewed" in reviewed.text
         assert "Reviewed" in launch_after_review.text
@@ -3875,6 +3970,43 @@ def test_director_reads_access_request_detail() -> None:
         assert "Secret transfer" in detail.text
         assert "PRIVATE ACCESS NOTE" in detail.text
         assert "Create invitation" in detail.text
+
+    asyncio.run(run())
+
+
+def test_director_access_request_queue_labels_linked_accounts_without_email() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        staff = resolve_seed_persona(services.repo, "xmen_staff")
+        account = services.repo.create_user("linked-account@example.com", "hash")
+        access_request = services.repo.create_community_access_request(
+            staff.community.id,
+            email=account.email,
+            display_name="Linked Account Prospect",
+            face_concept="Nocturne exchange student",
+            wanted_hook="Danger Room opening",
+            notes="Already has an Elbysodic account.",
+            account_user_id=account.id,
+        )
+        app = create_app(
+            debug=False,
+            services=AppServices(
+                services.repo,
+                DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+            ),
+        )
+
+        async with TestClient(app) as client:
+            launch = await client.get("/studio/launch")
+            detail = await client.get(f"/studio/access-requests/{access_request.id}")
+
+        assert launch.status == 200
+        assert detail.status == 200
+        for response in (launch, detail):
+            assert "Linked Account Prospect" in response.text
+            assert "Linked Elbysodic account" in response.text
+            assert "Elbysodic account on file" in response.text
+            assert "linked-account@example.com" not in response.text
 
     asyncio.run(run())
 
@@ -4053,9 +4185,7 @@ def test_studio_launch_invites_writer_from_access_request() -> None:
         assert launch.status == 200
         assert "Create invitation" in launch.text
         assert invited.status == 200
-        assert "Invitation created from access request for invite-prospect@example.com." in (
-            invited.text
-        )
+        assert "Invitation created from access request for Invite Prospect." in (invited.text)
         assert "/invite/" in invited.text
         assert updated.status == "invited"
         assert updated.invitation_id is not None
@@ -4262,6 +4392,10 @@ def test_director_can_update_discovery_profile_from_studio() -> None:
         assert editor.status == 200
         assert "Discovery profile" in editor.text
         assert "X-Men Apocalypse" in editor.text
+        assert "data-elbysodic-discovery-preview-form" in editor.text
+        assert "data-elbysodic-discovery-preview-card" in editor.text
+        assert "data-elbysodic-preview-summary" in editor.text
+        assert "data-elbysodic-preview-tags" in editor.text
         assert updated.status == 302
         assert _response_header(updated, "location") == "/studio/discovery"
         assert restored.status == 200
@@ -4948,7 +5082,7 @@ def test_director_studio_updates_sidebar_section_language() -> None:
 
         async with TestClient(app) as client:
             response = await client.post(
-                "/studio",
+                "/studio/structure",
                 body=urlencode(
                     {
                         "intent": "sidebar_section",
@@ -4981,7 +5115,7 @@ def test_director_studio_updates_sidebar_section_language() -> None:
                 re.S,
             )
 
-            studio = await client.get("/studio")
+            studio = await client.get("/studio/structure")
             assert studio.status == 200
             assert "playable map language" in studio.text
             assert "Realms" in studio.text
@@ -5110,7 +5244,7 @@ def test_director_studio_updates_board_taxonomy() -> None:
 
         async with TestClient(app) as client:
             response = await client.post(
-                "/studio",
+                "/studio/structure",
                 body=urlencode(
                     {
                         "intent": "board_taxonomy",
@@ -5133,7 +5267,7 @@ def test_director_studio_updates_board_taxonomy() -> None:
             assert updated.show_in_navigation is True
 
             invalid = await client.post(
-                "/studio",
+                "/studio/structure",
                 body=urlencode(
                     {
                         "intent": "board_taxonomy",
@@ -5170,7 +5304,7 @@ def test_director_studio_hides_board_from_navigation_without_hiding_route() -> N
 
         async with TestClient(app) as client:
             response = await client.post(
-                "/studio",
+                "/studio/structure",
                 body=urlencode(
                     {
                         "intent": "board_taxonomy",
@@ -5472,13 +5606,13 @@ def test_board_sidebar_section_controls_direct_board_sidebar_realm() -> None:
             board_page = await client.get("/boards/applications")
 
             assert board_page.status == 200
-            assert 'href="/studio#board-taxonomy"' in board_page.text
+            assert 'href="/studio/structure"' in board_page.text
             assert re.search(
                 r'<a class="[^"]*elbysodic-sidebar-link[^"]*"'
                 r'[^>]*href="/boards/applications"[^>]*aria-current="page"',
                 board_page.text,
             )
-            assert "Board taxonomy" in board_page.text
+            assert "Structure" in board_page.text
 
     asyncio.run(run())
 
@@ -5552,7 +5686,7 @@ def test_sidebar_modes_follow_major_product_paths() -> None:
             assert studio.status == 200
             assert "Director Studio" in studio.text
             assert "Production" in studio.text
-            assert "Wanted board" in studio.text
+            assert "Studio rooms" in studio.text
             assert "World Map" not in studio.text
             assert 'class="chirpui-sidebar__section-title">In Studio</span>' not in studio.text
             assert 'class="chirpui-sidebar__section-title">Production</span>' not in studio.text
@@ -5583,7 +5717,7 @@ def test_sidebar_modes_follow_major_product_paths() -> None:
         assert staff_studio.status == 200
         assert 'aria-label="Studio"' in staff_studio.text
         assert 'class="chirpui-sidebar__section-title">In Studio</span>' in staff_studio.text
-        assert 'class="chirpui-sidebar__section-title">Production</span>' in staff_studio.text
+        assert 'class="chirpui-sidebar__section-title">Production</span>' not in staff_studio.text
 
     asyncio.run(run())
 
@@ -5595,8 +5729,8 @@ def test_sidebar_hidden_preference_is_cookie_backed_and_server_rendered() -> Non
             world = await client.get("/boards/xavier-institute")
             assert world.status == 200
             assert 'var cookieName = "elbysodic_sidebar_hidden_v2";' in world.text
-            assert "elbysodic-theme.css?v=sidebar-reexpand-1" in world.text
-            assert "elbysodic-shell.js?v=sidebar-cookie-2" in world.text
+            assert "elbysodic-theme.css?v=sticky-topbar-1" in world.text
+            assert "elbysodic-shell.js?v=sidebar-rail-toggle-1" in world.text
             assert "elbysodic-composer.js?v=scene-context-inspector-1" in world.text
             assert 'id="elbysodic-sidebar-cookie-state"' not in world.text
             assert 'aria-label="Primary community rooms"' in world.text
@@ -5618,13 +5752,22 @@ def test_sidebar_hidden_preference_is_cookie_backed_and_server_rendered() -> Non
 
             stylesheet_text = await _stylesheet_text_with_imports(client)
             assert "--elbysodic-primary-rail-width" in stylesheet_text
+            assert ".chirpui-app-shell__topbar" in stylesheet_text
+            assert "position: sticky;" in stylesheet_text
             assert '.elbysodic-primary-rail__link[aria-current="page"]' in stylesheet_text
+            assert ".elbysodic-primary-rail__toggle" not in stylesheet_text
             assert ".elbysodic-app-shell--sidebar-hidden .chirpui-app-shell" in stylesheet_text
+            assert ".elbysodic-app-shell--sidebar-hidden.chirpui-app-shell" in stylesheet_text
+            assert "@media (min-width: 48.001rem) and (max-width: 72rem)" in stylesheet_text
+            assert (
+                "--chirpui-sidebar-width: var(--elbysodic-primary-rail-width);" in stylesheet_text
+            )
 
             script = await client.get("/elbysodic-static/elbysodic-shell.js")
             assert script.status == 200
             assert 'const COOKIE_NAME = "elbysodic_sidebar_hidden_v2";' in script.text
             assert 'document.getElementById("elbysodic-sidebar-cookie-state")' in script.text
+            assert 'querySelectorAll("[data-elbysodic-sidebar-toggle]")' in script.text
             assert "serverStyle.disabled = !hidden" in script.text
             assert "document.documentElement.classList.toggle(HIDDEN_CLASS, hidden)" in script.text
             assert 'window.localStorage.removeItem("chirpui-sidebar-collapsed")' in script.text
@@ -5826,7 +5969,7 @@ def test_topbar_marks_active_community_mode() -> None:
                 claims.text,
             )
 
-            studio = await client.get("/studio")
+            studio = await client.get("/studio/content")
             assert studio.status == 200
             assert not re.search(
                 r'<a class="[^"]*elbysodic-primary-rail__link[^"]*"'
@@ -6897,7 +7040,7 @@ def test_directors_can_publish_draft_materials_from_studio_queue() -> None:
         member_app = create_app(debug=False, services=member_services)
         async with TestClient(member_app) as member_client:
             forbidden = await member_client.post(
-                "/studio",
+                "/studio/content",
                 body=urlencode(
                     {
                         "intent": "material_status",
@@ -6920,13 +7063,13 @@ def test_directors_can_publish_draft_materials_from_studio_queue() -> None:
         )
         app = create_app(debug=False, services=admin_services)
         async with TestClient(app) as client:
-            studio = await client.get("/studio")
+            studio = await client.get("/studio/content")
             assert studio.status == 200
             assert "New Canon Pulse" in studio.text
             assert "Publish as current" in studio.text
 
             response = await client.post(
-                "/studio",
+                "/studio/content",
                 body=urlencode(
                     {
                         "intent": "material_status",
@@ -6938,10 +7081,10 @@ def test_directors_can_publish_draft_materials_from_studio_queue() -> None:
                 headers=_FORM,
             )
             assert response.status == 302
-            assert _response_header(response, "location") == "/studio#continuity-events"
+            assert _response_header(response, "location") == "/studio/content#continuity-events"
 
             world = await client.get("/world/new-canon-pulse")
-            studio_after = await client.get("/studio")
+            studio_after = await client.get("/studio/content")
 
         updated = repo.get_material_by_slug(community.id, draft_event.slug)
         old_event = repo.get_material_by_slug(community.id, "b-24-winter")
@@ -7943,7 +8086,7 @@ def test_claims_directory_renders_seeded_claims_and_studio_summary() -> None:
             magneto_claims = await client.get("/claims?q=magneto")
             claimed_brotherhood = await client.get("/claims?status=claimed&q=brotherhood")
             no_results = await client.get("/claims?q=not-a-real-claim")
-            studio = await client.get("/studio")
+            studio = await client.get("/studio/content")
 
         assert claims.status == 200
         assert "What is claimed, reserved, and open." in claims.text
@@ -10368,7 +10511,7 @@ def test_studio_post_style_policy_filters_character_controls() -> None:
 
         async with TestClient(app) as client:
             response = await client.post(
-                "/studio",
+                "/studio/appearance",
                 body=urlencode(
                     {
                         "intent": "post_style_policy",
@@ -10426,13 +10569,13 @@ def test_studio_can_set_identity_accent_source() -> None:
 
         async with TestClient(app) as client:
             response = await client.post(
-                "/studio",
+                "/studio/appearance",
                 body=f"identity_accent_facet_group_id={species.id}".encode(),
                 headers=_FORM,
             )
 
             assert response.status == 302
-            assert dict(response.headers)["location"] == "/studio"
+            assert dict(response.headers)["location"] == "/studio/appearance#identity-appearance"
             assert repo.get_community(community.id).identity_accent_facet_group_id == species.id
 
     asyncio.run(run())
@@ -10493,7 +10636,7 @@ def test_director_studio_updates_default_theme_tokens() -> None:
 
         async with TestClient(app) as client:
             response = await client.post(
-                "/studio",
+                "/studio/appearance",
                 body=urlencode(body).encode(),
                 headers=_FORM,
             )
@@ -10501,7 +10644,7 @@ def test_director_studio_updates_default_theme_tokens() -> None:
 
         theme = repo.get_default_theme(community.id)
         assert response.status == 302
-        assert _response_header(response, "location") == "/studio#appearance-theme"
+        assert _response_header(response, "location") == "/studio/appearance#appearance-theme"
         assert theme is not None
         assert theme.slug == "gothic-folk-horror"
         assert theme.name == "Gothic Folk Horror"
@@ -10574,7 +10717,7 @@ def test_director_studio_surfaces_theme_health_warnings() -> None:
         app = create_app(debug=False, services=admin_services)
 
         async with TestClient(app) as client:
-            studio = await client.get("/studio")
+            studio = await client.get("/studio/appearance")
 
         assert studio.status == 200
         assert "Theme Health" in studio.text
@@ -10601,7 +10744,7 @@ def test_director_studio_updates_world_hero_media() -> None:
 
         async with TestClient(app) as client:
             response = await client.post(
-                "/studio",
+                "/studio/appearance",
                 body=urlencode(
                     {
                         "intent": "community_media",
@@ -10618,11 +10761,11 @@ def test_director_studio_updates_world_hero_media() -> None:
                 headers=_FORM,
             )
             home = await client.get("/c/x-men-apocalypse")
-            studio = await client.get("/studio")
+            studio = await client.get("/studio/appearance")
 
         updated = repo.get_community(community.id)
         assert response.status == 302
-        assert _response_header(response, "location") == "/studio#appearance-media"
+        assert _response_header(response, "location") == "/studio/appearance#appearance-media"
         assert updated.world_hero_image_url == "https://example.test/world.jpg"
         assert updated.world_hero_treatment == "background"
         assert updated.world_hero_focal_point == "top"
@@ -10656,7 +10799,7 @@ def test_director_studio_rejects_unsupported_hero_treatment() -> None:
 
         async with TestClient(app) as client:
             response = await client.post(
-                "/studio",
+                "/studio/appearance",
                 body=urlencode(
                     {
                         "intent": "community_media",

--- a/tests/test_shell_navigation.py
+++ b/tests/test_shell_navigation.py
@@ -103,10 +103,19 @@ def test_shell_navigation_builds_inner_sections_from_shared_model() -> None:
         "roster",
         "plotting",
     ]
-    assert [(section.key, section.label) for section in staff.sidebar_sections[:2]] == [
+    assert [(section.key, section.label) for section in staff.sidebar_sections] == [
         ("studio", "In Studio"),
-        ("production", "Production"),
     ]
+    assert [item.key for item in staff.sidebar_sections[0].items] == [
+        "operations",
+        "launch",
+        "discovery",
+        "structure",
+        "intake",
+        "appearance",
+        "content",
+    ]
+    assert all(item.href.startswith("/studio") for item in staff.sidebar_sections[0].items)
 
 
 def _viewer(*, is_admin: bool) -> SimpleNamespace:

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -174,8 +174,8 @@ def test_production_seed_password_requires_demo_mode(monkeypatch) -> None:
             )
 
         assert response.status == 200
-        assert "Access is invite-only for this launch" in page.text
-        assert "public registration is not open" in page.text
+        assert "Already have an account?" in page.text
+        assert "linked account request" in page.text
         assert "Invite/demo accounts use password" not in page.text
         assert "email or password is incorrect" in response.text
         assert "elbysodic_session=" not in "\n".join(_response_headers(response, "set-cookie"))
@@ -241,7 +241,7 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert "Staff in X-Men Apocalypse" not in login.text
         assert request_access.status == 200
         assert "Access opens through a director invitation." in request_access.text
-        assert "Public registration is closed for now." in request_access.text
+        assert "Directors gate first entry" in request_access.text
         assert "_csrf_token" not in request_access.text
         assert "chirpui-sidebar__section-title" not in request_access.text
         assert studio.status == 302
@@ -335,7 +335,6 @@ def test_production_signed_in_non_member_sees_account_posture_on_public_realm(
                 body=urlencode(
                     {
                         "community_slug": "afterlight-accord",
-                        "email": "moira@example.com",
                         "display_name": "Moira",
                         "face_concept": "Archivist with a sealed branch",
                         "wanted_hook": "Archive thief",
@@ -377,10 +376,13 @@ def test_production_signed_in_non_member_sees_account_posture_on_public_realm(
         assert 'href="/c/afterlight-accord/request-access"' in wanted_detail.text
         assert 'href="/network"' in wanted_detail.text
         assert "Access opens through a director invitation." in request_access.text
-        assert "Writer email" in request_access.text
+        assert "Existing Elbysodic account" in request_access.text
+        assert "Request access with this account" in request_access.text
+        assert "Writer email" not in request_access.text
         assert "Face concept" in request_access.text
         assert request_access_post.status == 200
-        assert "Access request received for moira@example.com" in request_access_post.text
+        assert "Access request received for your Elbysodic account" in request_access_post.text
+        assert "Access request received for moira@example.com" not in request_access_post.text
         access_requests = services.repo.list_community_access_requests(
             services.repo.get_community_by_slug("afterlight-accord").id
         )
@@ -604,14 +606,25 @@ def test_signed_in_network_marks_current_realm_without_leaking_staff(monkeypatch
 
         async with TestClient(app) as client:
             _login, cookies = await _production_login(client, email="writer@example.com")
+            root = await client.get("/", headers={"Cookie": _cookie_header(cookies)})
             network = await client.get(
                 "/network?q=x-men",
                 headers={"Cookie": _cookie_header(cookies)},
             )
 
+        assert root.status == 200
+        assert "Signed in as Lane in X-Men Apocalypse" in root.text
+        assert (
+            "Your account is active; choose a realm card to enter, preview, or request access."
+            in (root.text)
+        )
+        assert "Log in" not in root.text
+        assert "Log out" in root.text
         assert network.status == 200
         assert "Signed in as Lane in X-Men Apocalypse" in network.text
         assert "Explore cards stay public-preview safe" in network.text
+        assert "Log in" not in network.text
+        assert "Log out" in network.text
         assert "current membership" in network.text
         assert 'href="/c/x-men-apocalypse/request-access"' not in network.text
         assert "Staff in X-Men Apocalypse" not in network.text


### PR DESCRIPTION
## Summary
- Split Studio into progressive rooms for operations, launch, discovery, structure, intake, appearance, and content while keeping Studio navigation scoped to Studio.
- Polished access/request/login surfaces with account-linked request handling and shared components.
- Added contextual director controls, realm switcher/home paths, sticky shell fixes, discovery preview behavior, and clearer structure/spotlight management.

## Verification
- uv run ruff check .
- uv run ruff format . --check
- uv run pytest -q --tb=short
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"