### PR TITLE
[codex] harden backend trust spine

### DIFF
--- a/src/elbysodic/db/repositories/base.py
+++ b/src/elbysodic/db/repositories/base.py
@@ -34,16 +34,20 @@ class RepositoryBase:
         self._transaction_depth += 1
         try:
             yield
-        except Exception:
+        except BaseException:
             self._transaction_depth -= 1
             if outermost:
                 self.connection.rollback()
-            self._transaction_lock.release()
             raise
         else:
             self._transaction_depth -= 1
             if outermost:
-                self._commit()
+                try:
+                    self._commit()
+                except BaseException:
+                    self.connection.rollback()
+                    raise
+        finally:
             self._transaction_lock.release()
 
     def _commit(self) -> None:

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -1576,6 +1576,60 @@ class IdentityRepositoryMixin(RepositoryBase):
             SELECT table_name, row_id, community_id, reason
             FROM (
                 SELECT
+                    'communities' AS table_name,
+                    community.id AS row_id,
+                    community.id AS community_id,
+                    CASE
+                        WHEN theme.id IS NULL
+                            AND community.default_theme_id IS NOT NULL
+                            THEN 'community default theme belongs to another community'
+                        WHEN facet_group.id IS NULL
+                            AND community.identity_accent_facet_group_id IS NOT NULL
+                            THEN 'community identity accent facet group belongs to another community'
+                        ELSE 'community tenant pair is invalid'
+                    END AS reason
+                FROM communities AS community
+                LEFT JOIN themes AS theme
+                    ON theme.id = community.default_theme_id
+                    AND theme.community_id = community.id
+                LEFT JOIN facet_groups AS facet_group
+                    ON facet_group.id = community.identity_accent_facet_group_id
+                    AND facet_group.community_id = community.id
+                WHERE (
+                        community.default_theme_id IS NOT NULL
+                        AND theme.id IS NULL
+                    )
+                    OR (
+                        community.identity_accent_facet_group_id IS NOT NULL
+                        AND facet_group.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'boards' AS table_name,
+                    board.id AS row_id,
+                    board.community_id,
+                    CASE
+                        WHEN board.parent_board_id = board.id THEN 'board cannot be its own parent'
+                        WHEN parent.id IS NULL
+                            AND board.parent_board_id IS NOT NULL
+                            THEN 'board parent belongs to another community'
+                        ELSE 'board tenant pair is invalid'
+                    END AS reason
+                FROM boards AS board
+                LEFT JOIN boards AS parent
+                    ON parent.id = board.parent_board_id
+                    AND parent.community_id = board.community_id
+                WHERE board.parent_board_id IS NOT NULL
+                    AND (
+                        board.parent_board_id = board.id
+                        OR parent.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
                     'threads' AS table_name,
                     thread.id AS row_id,
                     thread.community_id,
@@ -1603,6 +1657,624 @@ class IdentityRepositoryMixin(RepositoryBase):
                 UNION ALL
 
                 SELECT
+                    'community_invitations' AS table_name,
+                    invitation.id AS row_id,
+                    invitation.community_id,
+                    CASE
+                        WHEN role.id IS NULL THEN 'community invitation role belongs to another community'
+                        WHEN invited_by.id IS NULL THEN 'community invitation invited-by membership belongs to another community'
+                        WHEN accepted_membership.id IS NULL
+                            AND invitation.accepted_membership_id IS NOT NULL
+                            THEN 'community invitation accepted membership belongs to another community'
+                        WHEN accepted_membership.user_id != invitation.accepted_user_id
+                            AND invitation.accepted_membership_id IS NOT NULL
+                            AND invitation.accepted_user_id IS NOT NULL
+                            THEN 'community invitation accepted membership does not match accepted user'
+                        ELSE 'community invitation tenant pair is invalid'
+                    END AS reason
+                FROM community_invitations AS invitation
+                LEFT JOIN roles AS role
+                    ON role.id = invitation.role_id
+                    AND role.community_id = invitation.community_id
+                LEFT JOIN community_memberships AS invited_by
+                    ON invited_by.id = invitation.invited_by_membership_id
+                    AND invited_by.community_id = invitation.community_id
+                LEFT JOIN community_memberships AS accepted_membership
+                    ON accepted_membership.id = invitation.accepted_membership_id
+                    AND accepted_membership.community_id = invitation.community_id
+                WHERE role.id IS NULL
+                    OR invited_by.id IS NULL
+                    OR (
+                        invitation.accepted_membership_id IS NOT NULL
+                        AND accepted_membership.id IS NULL
+                    )
+                    OR (
+                        invitation.accepted_membership_id IS NOT NULL
+                        AND invitation.accepted_user_id IS NOT NULL
+                        AND accepted_membership.user_id != invitation.accepted_user_id
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'community_access_requests' AS table_name,
+                    request.id AS row_id,
+                    request.community_id,
+                    CASE
+                        WHEN invitation.id IS NULL
+                            AND request.invitation_id IS NOT NULL
+                            THEN 'community access request invitation belongs to another community'
+                        ELSE 'community access request tenant pair is invalid'
+                    END AS reason
+                FROM community_access_requests AS request
+                LEFT JOIN community_invitations AS invitation
+                    ON invitation.id = request.invitation_id
+                    AND invitation.community_id = request.community_id
+                WHERE request.invitation_id IS NOT NULL
+                    AND invitation.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'community_access_request_events' AS table_name,
+                    event.id AS row_id,
+                    event.community_id,
+                    CASE
+                        WHEN request.id IS NULL THEN 'community access request event request belongs to another community'
+                        WHEN actor.id IS NULL
+                            AND event.actor_membership_id IS NOT NULL
+                            THEN 'community access request event actor membership belongs to another community'
+                        WHEN invitation.id IS NULL
+                            AND event.invitation_id IS NOT NULL
+                            THEN 'community access request event invitation belongs to another community'
+                        ELSE 'community access request event tenant pair is invalid'
+                    END AS reason
+                FROM community_access_request_events AS event
+                LEFT JOIN community_access_requests AS request
+                    ON request.id = event.access_request_id
+                    AND request.community_id = event.community_id
+                LEFT JOIN community_memberships AS actor
+                    ON actor.id = event.actor_membership_id
+                    AND actor.community_id = event.community_id
+                LEFT JOIN community_invitations AS invitation
+                    ON invitation.id = event.invitation_id
+                    AND invitation.community_id = event.community_id
+                WHERE request.id IS NULL
+                    OR (
+                        event.actor_membership_id IS NOT NULL
+                        AND actor.id IS NULL
+                    )
+                    OR (
+                        event.invitation_id IS NOT NULL
+                        AND invitation.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'community_gateway_slots' AS table_name,
+                    slot.id AS row_id,
+                    slot.community_id,
+                    CASE
+                        WHEN slot.slot_type = 'scene_hub' AND board.id IS NULL
+                            THEN 'community gateway slot scene hub board belongs to another community'
+                        WHEN slot.slot_type = 'wanted_hook' AND wanted.id IS NULL
+                            THEN 'community gateway slot wanted hook belongs to another community'
+                        WHEN slot.slot_type = 'guidebook_material' AND material.id IS NULL
+                            THEN 'community gateway slot guidebook material belongs to another community'
+                        ELSE 'community gateway slot tenant pair is invalid'
+                    END AS reason
+                FROM community_gateway_slots AS slot
+                LEFT JOIN boards AS board
+                    ON board.id = slot.target_id
+                    AND board.community_id = slot.community_id
+                    AND slot.slot_type = 'scene_hub'
+                LEFT JOIN wanted_ads AS wanted
+                    ON wanted.id = slot.target_id
+                    AND wanted.community_id = slot.community_id
+                    AND slot.slot_type = 'wanted_hook'
+                LEFT JOIN materials AS material
+                    ON material.id = slot.target_id
+                    AND material.community_id = slot.community_id
+                    AND slot.slot_type = 'guidebook_material'
+                WHERE (
+                        slot.slot_type = 'scene_hub'
+                        AND board.id IS NULL
+                    )
+                    OR (
+                        slot.slot_type = 'wanted_hook'
+                        AND wanted.id IS NULL
+                    )
+                    OR (
+                        slot.slot_type = 'guidebook_material'
+                        AND material.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'community_discovery_profiles' AS table_name,
+                    profile.community_id AS row_id,
+                    profile.community_id,
+                    CASE
+                        WHEN material.id IS NULL
+                            AND profile.featured_event_material_id IS NOT NULL
+                            THEN 'community discovery profile featured event belongs to another community'
+                        ELSE 'community discovery profile tenant pair is invalid'
+                    END AS reason
+                FROM community_discovery_profiles AS profile
+                LEFT JOIN materials AS material
+                    ON material.id = profile.featured_event_material_id
+                    AND material.community_id = profile.community_id
+                WHERE profile.featured_event_material_id IS NOT NULL
+                    AND material.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'applications' AS table_name,
+                    application.id AS row_id,
+                    application.community_id,
+                    CASE
+                        WHEN membership.id IS NULL THEN 'application membership belongs to another community'
+                        WHEN character.id IS NULL THEN 'application character does not match community and membership'
+                        ELSE 'application tenant pair is invalid'
+                    END AS reason
+                FROM applications AS application
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = application.membership_id
+                    AND membership.community_id = application.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = application.character_id
+                    AND character.community_id = application.community_id
+                    AND character.membership_id = application.membership_id
+                WHERE membership.id IS NULL
+                    OR character.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'application_events' AS table_name,
+                    event.id AS row_id,
+                    event.community_id,
+                    CASE
+                        WHEN application.id IS NULL THEN 'application event application belongs to another community'
+                        WHEN membership.id IS NULL THEN 'application event actor membership belongs to another community'
+                        WHEN character.id IS NULL
+                            AND event.actor_character_id IS NOT NULL
+                            THEN 'application event actor character does not match community and membership'
+                        ELSE 'application event tenant pair is invalid'
+                    END AS reason
+                FROM application_events AS event
+                LEFT JOIN applications AS application
+                    ON application.id = event.application_id
+                    AND application.community_id = event.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = event.actor_membership_id
+                    AND membership.community_id = event.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = event.actor_character_id
+                    AND character.community_id = event.community_id
+                    AND character.membership_id = event.actor_membership_id
+                WHERE application.id IS NULL
+                    OR membership.id IS NULL
+                    OR (
+                        event.actor_character_id IS NOT NULL
+                        AND character.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'application_template_fields' AS table_name,
+                    field.id AS row_id,
+                    field.community_id,
+                    CASE
+                        WHEN claim_type.id IS NULL
+                            AND field.maps_to_claim_type_id IS NOT NULL
+                            THEN 'application template field mapped claim type belongs to another community'
+                        ELSE 'application template field tenant pair is invalid'
+                    END AS reason
+                FROM application_template_fields AS field
+                LEFT JOIN claim_types AS claim_type
+                    ON claim_type.id = field.maps_to_claim_type_id
+                    AND claim_type.community_id = field.community_id
+                WHERE field.maps_to_claim_type_id IS NOT NULL
+                    AND claim_type.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'application_field_values' AS table_name,
+                    value.id AS row_id,
+                    value.community_id,
+                    CASE
+                        WHEN application.id IS NULL THEN 'application field value application belongs to another community'
+                        WHEN field.id IS NULL THEN 'application field value field belongs to another community'
+                        ELSE 'application field value tenant pair is invalid'
+                    END AS reason
+                FROM application_field_values AS value
+                LEFT JOIN applications AS application
+                    ON application.id = value.application_id
+                    AND application.community_id = value.community_id
+                LEFT JOIN application_template_fields AS field
+                    ON field.id = value.field_id
+                    AND field.community_id = value.community_id
+                WHERE application.id IS NULL
+                    OR field.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'character_claims' AS table_name,
+                    claim.id AS row_id,
+                    claim.community_id,
+                    CASE
+                        WHEN claim_type.id IS NULL THEN 'character claim type belongs to another community'
+                        WHEN character.id IS NULL
+                            AND claim.character_id IS NOT NULL
+                            THEN 'character claim character belongs to another community'
+                        WHEN application.id IS NULL
+                            AND claim.application_id IS NOT NULL
+                            THEN 'character claim application belongs to another community'
+                        WHEN reserve.id IS NULL
+                            AND claim.source_reserve_id IS NOT NULL
+                            THEN 'character claim source reserve belongs to another community'
+                        ELSE 'character claim tenant pair is invalid'
+                    END AS reason
+                FROM character_claims AS claim
+                LEFT JOIN claim_types AS claim_type
+                    ON claim_type.id = claim.claim_type_id
+                    AND claim_type.community_id = claim.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = claim.character_id
+                    AND character.community_id = claim.community_id
+                LEFT JOIN applications AS application
+                    ON application.id = claim.application_id
+                    AND application.community_id = claim.community_id
+                LEFT JOIN character_reserves AS reserve
+                    ON reserve.id = claim.source_reserve_id
+                    AND reserve.community_id = claim.community_id
+                WHERE claim_type.id IS NULL
+                    OR (
+                        claim.character_id IS NOT NULL
+                        AND character.id IS NULL
+                    )
+                    OR (
+                        claim.application_id IS NOT NULL
+                        AND application.id IS NULL
+                    )
+                    OR (
+                        claim.source_reserve_id IS NOT NULL
+                        AND reserve.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'character_reserves' AS table_name,
+                    reserve.id AS row_id,
+                    reserve.community_id,
+                    CASE
+                        WHEN membership.id IS NULL THEN 'character reserve membership belongs to another community'
+                        WHEN character.id IS NULL THEN 'character reserve character does not match community and membership'
+                        WHEN wanted_ad.id IS NULL
+                            AND reserve.wanted_ad_id IS NOT NULL
+                            THEN 'character reserve wanted hook belongs to another community'
+                        WHEN interest.id IS NULL
+                            AND reserve.wanted_ad_interest_id IS NOT NULL
+                            THEN 'character reserve wanted interest does not match reserve owner'
+                        ELSE 'character reserve tenant pair is invalid'
+                    END AS reason
+                FROM character_reserves AS reserve
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = reserve.membership_id
+                    AND membership.community_id = reserve.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = reserve.character_id
+                    AND character.community_id = reserve.community_id
+                    AND character.membership_id = reserve.membership_id
+                LEFT JOIN wanted_ads AS wanted_ad
+                    ON wanted_ad.id = reserve.wanted_ad_id
+                    AND wanted_ad.community_id = reserve.community_id
+                LEFT JOIN wanted_ad_interests AS interest
+                    ON interest.id = reserve.wanted_ad_interest_id
+                    AND interest.community_id = reserve.community_id
+                    AND interest.membership_id = reserve.membership_id
+                    AND interest.character_id = reserve.character_id
+                    AND (
+                        reserve.wanted_ad_id IS NULL
+                        OR interest.wanted_ad_id = reserve.wanted_ad_id
+                    )
+                WHERE membership.id IS NULL
+                    OR character.id IS NULL
+                    OR (
+                        reserve.wanted_ad_id IS NOT NULL
+                        AND wanted_ad.id IS NULL
+                    )
+                    OR (
+                        reserve.wanted_ad_interest_id IS NOT NULL
+                        AND interest.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'wanted_ads' AS table_name,
+                    wanted.id AS row_id,
+                    wanted.community_id,
+                    CASE
+                        WHEN membership.id IS NULL THEN 'wanted hook creator membership belongs to another community'
+                        WHEN character.id IS NULL
+                            AND wanted.creator_character_id IS NOT NULL
+                            THEN 'wanted hook creator character does not match community and membership'
+                        WHEN material.id IS NULL
+                            AND wanted.related_material_id IS NOT NULL
+                            THEN 'wanted hook related material belongs to another community'
+                        ELSE 'wanted hook tenant pair is invalid'
+                    END AS reason
+                FROM wanted_ads AS wanted
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = wanted.creator_membership_id
+                    AND membership.community_id = wanted.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = wanted.creator_character_id
+                    AND character.community_id = wanted.community_id
+                    AND character.membership_id = wanted.creator_membership_id
+                LEFT JOIN materials AS material
+                    ON material.id = wanted.related_material_id
+                    AND material.community_id = wanted.community_id
+                WHERE membership.id IS NULL
+                    OR (
+                        wanted.creator_character_id IS NOT NULL
+                        AND character.id IS NULL
+                    )
+                    OR (
+                        wanted.related_material_id IS NOT NULL
+                        AND material.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'wanted_ad_interests' AS table_name,
+                    interest.id AS row_id,
+                    interest.community_id,
+                    CASE
+                        WHEN wanted.id IS NULL THEN 'wanted interest wanted hook belongs to another community'
+                        WHEN membership.id IS NULL THEN 'wanted interest membership belongs to another community'
+                        WHEN character.id IS NULL
+                            AND interest.character_id IS NOT NULL
+                            THEN 'wanted interest character does not match community and membership'
+                        ELSE 'wanted interest tenant pair is invalid'
+                    END AS reason
+                FROM wanted_ad_interests AS interest
+                LEFT JOIN wanted_ads AS wanted
+                    ON wanted.id = interest.wanted_ad_id
+                    AND wanted.community_id = interest.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = interest.membership_id
+                    AND membership.community_id = interest.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = interest.character_id
+                    AND character.community_id = interest.community_id
+                    AND character.membership_id = interest.membership_id
+                WHERE wanted.id IS NULL
+                    OR membership.id IS NULL
+                    OR (
+                        interest.character_id IS NOT NULL
+                        AND character.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'wanted_ad_related_characters' AS table_name,
+                    related.id AS row_id,
+                    related.community_id,
+                    CASE
+                        WHEN wanted.id IS NULL THEN 'wanted related face wanted hook belongs to another community'
+                        WHEN character.id IS NULL THEN 'wanted related face character belongs to another community'
+                        ELSE 'wanted related face tenant pair is invalid'
+                    END AS reason
+                FROM wanted_ad_related_characters AS related
+                LEFT JOIN wanted_ads AS wanted
+                    ON wanted.id = related.wanted_ad_id
+                    AND wanted.community_id = related.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = related.character_id
+                    AND character.community_id = related.community_id
+                WHERE wanted.id IS NULL
+                    OR character.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'character_plot_hooks' AS table_name,
+                    hook.id AS row_id,
+                    hook.community_id,
+                    CASE
+                        WHEN membership.id IS NULL THEN 'plot hook author membership belongs to another community'
+                        WHEN character.id IS NULL THEN 'plot hook character does not match community and membership'
+                        WHEN material.id IS NULL
+                            AND hook.related_material_id IS NOT NULL
+                            THEN 'plot hook related material belongs to another community'
+                        ELSE 'plot hook tenant pair is invalid'
+                    END AS reason
+                FROM character_plot_hooks AS hook
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = hook.author_membership_id
+                    AND membership.community_id = hook.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = hook.character_id
+                    AND character.community_id = hook.community_id
+                    AND character.membership_id = hook.author_membership_id
+                LEFT JOIN materials AS material
+                    ON material.id = hook.related_material_id
+                    AND material.community_id = hook.community_id
+                WHERE membership.id IS NULL
+                    OR character.id IS NULL
+                    OR (
+                        hook.related_material_id IS NOT NULL
+                        AND material.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'character_plot_hook_interests' AS table_name,
+                    interest.id AS row_id,
+                    interest.community_id,
+                    CASE
+                        WHEN hook.id IS NULL THEN 'plot hook interest hook belongs to another community'
+                        WHEN membership.id IS NULL THEN 'plot hook interest membership belongs to another community'
+                        WHEN character.id IS NULL THEN 'plot hook interest character does not match community and membership'
+                        ELSE 'plot hook interest tenant pair is invalid'
+                    END AS reason
+                FROM character_plot_hook_interests AS interest
+                LEFT JOIN character_plot_hooks AS hook
+                    ON hook.id = interest.plot_hook_id
+                    AND hook.community_id = interest.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = interest.membership_id
+                    AND membership.community_id = interest.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = interest.character_id
+                    AND character.community_id = interest.community_id
+                    AND character.membership_id = interest.membership_id
+                WHERE hook.id IS NULL
+                    OR membership.id IS NULL
+                    OR character.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'character_facets' AS table_name,
+                    assignment.id AS row_id,
+                    assignment.community_id,
+                    CASE
+                        WHEN character.id IS NULL THEN 'character facet character belongs to another community'
+                        WHEN facet.id IS NULL THEN 'character facet facet belongs to another community'
+                        ELSE 'character facet tenant pair is invalid'
+                    END AS reason
+                FROM character_facets AS assignment
+                LEFT JOIN characters AS character
+                    ON character.id = assignment.character_id
+                    AND character.community_id = assignment.community_id
+                LEFT JOIN facets AS facet
+                    ON facet.id = assignment.facet_id
+                    AND facet.community_id = assignment.community_id
+                WHERE character.id IS NULL
+                    OR facet.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'board_facets' AS table_name,
+                    assignment.id AS row_id,
+                    assignment.community_id,
+                    CASE
+                        WHEN board.id IS NULL THEN 'board facet board belongs to another community'
+                        WHEN facet.id IS NULL THEN 'board facet facet belongs to another community'
+                        ELSE 'board facet tenant pair is invalid'
+                    END AS reason
+                FROM board_facets AS assignment
+                LEFT JOIN boards AS board
+                    ON board.id = assignment.board_id
+                    AND board.community_id = assignment.community_id
+                LEFT JOIN facets AS facet
+                    ON facet.id = assignment.facet_id
+                    AND facet.community_id = assignment.community_id
+                WHERE board.id IS NULL
+                    OR facet.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'material_facets' AS table_name,
+                    assignment.id AS row_id,
+                    assignment.community_id,
+                    CASE
+                        WHEN material.id IS NULL THEN 'material facet material belongs to another community'
+                        WHEN facet.id IS NULL THEN 'material facet facet belongs to another community'
+                        ELSE 'material facet tenant pair is invalid'
+                    END AS reason
+                FROM material_facets AS assignment
+                LEFT JOIN materials AS material
+                    ON material.id = assignment.material_id
+                    AND material.community_id = assignment.community_id
+                LEFT JOIN facets AS facet
+                    ON facet.id = assignment.facet_id
+                    AND facet.community_id = assignment.community_id
+                WHERE material.id IS NULL
+                    OR facet.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'wanted_ad_facets' AS table_name,
+                    assignment.id AS row_id,
+                    assignment.community_id,
+                    CASE
+                        WHEN wanted.id IS NULL THEN 'wanted hook facet wanted hook belongs to another community'
+                        WHEN facet.id IS NULL THEN 'wanted hook facet facet belongs to another community'
+                        ELSE 'wanted hook facet tenant pair is invalid'
+                    END AS reason
+                FROM wanted_ad_facets AS assignment
+                LEFT JOIN wanted_ads AS wanted
+                    ON wanted.id = assignment.wanted_ad_id
+                    AND wanted.community_id = assignment.community_id
+                LEFT JOIN facets AS facet
+                    ON facet.id = assignment.facet_id
+                    AND facet.community_id = assignment.community_id
+                WHERE wanted.id IS NULL
+                    OR facet.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'character_plot_hook_facets' AS table_name,
+                    assignment.id AS row_id,
+                    assignment.community_id,
+                    CASE
+                        WHEN hook.id IS NULL THEN 'plot hook facet hook belongs to another community'
+                        WHEN facet.id IS NULL THEN 'plot hook facet facet belongs to another community'
+                        ELSE 'plot hook facet tenant pair is invalid'
+                    END AS reason
+                FROM character_plot_hook_facets AS assignment
+                LEFT JOIN character_plot_hooks AS hook
+                    ON hook.id = assignment.plot_hook_id
+                    AND hook.community_id = assignment.community_id
+                LEFT JOIN facets AS facet
+                    ON facet.id = assignment.facet_id
+                    AND facet.community_id = assignment.community_id
+                WHERE hook.id IS NULL
+                    OR facet.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'thread_facets' AS table_name,
+                    assignment.id AS row_id,
+                    assignment.community_id,
+                    CASE
+                        WHEN thread.id IS NULL THEN 'thread facet thread belongs to another community'
+                        WHEN facet.id IS NULL THEN 'thread facet facet belongs to another community'
+                        ELSE 'thread facet tenant pair is invalid'
+                    END AS reason
+                FROM thread_facets AS assignment
+                LEFT JOIN threads AS thread
+                    ON thread.id = assignment.thread_id
+                    AND thread.community_id = assignment.community_id
+                LEFT JOIN facets AS facet
+                    ON facet.id = assignment.facet_id
+                    AND facet.community_id = assignment.community_id
+                WHERE thread.id IS NULL
+                    OR facet.id IS NULL
+
+                UNION ALL
+
+                SELECT
                     'posts' AS table_name,
                     post.id AS row_id,
                     post.community_id,
@@ -1626,6 +2298,155 @@ class IdentityRepositoryMixin(RepositoryBase):
                 WHERE thread.id IS NULL
                     OR membership.id IS NULL
                     OR character.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'post_revisions' AS table_name,
+                    revision.id AS row_id,
+                    revision.community_id,
+                    CASE
+                        WHEN post.id IS NULL THEN 'post revision post belongs to another community'
+                        WHEN membership.id IS NULL THEN 'post revision editor membership belongs to another community'
+                        ELSE 'post revision tenant pair is invalid'
+                    END AS reason
+                FROM post_revisions AS revision
+                LEFT JOIN posts AS post
+                    ON post.id = revision.post_id
+                    AND post.community_id = revision.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = revision.editor_membership_id
+                    AND membership.community_id = revision.community_id
+                WHERE post.id IS NULL
+                    OR membership.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'realm_interaction_responses' AS table_name,
+                    response.id AS row_id,
+                    response.community_id,
+                    CASE
+                        WHEN interaction.id IS NULL THEN 'realm interaction response interaction belongs to another community'
+                        WHEN membership.id IS NULL THEN 'realm interaction response membership belongs to another community'
+                        WHEN character.id IS NULL
+                            AND response.character_id IS NOT NULL
+                            THEN 'realm interaction response character does not match community and membership'
+                        ELSE 'realm interaction response tenant pair is invalid'
+                    END AS reason
+                FROM realm_interaction_responses AS response
+                LEFT JOIN realm_interactions AS interaction
+                    ON interaction.id = response.interaction_id
+                    AND interaction.community_id = response.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = response.membership_id
+                    AND membership.community_id = response.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = response.character_id
+                    AND character.community_id = response.community_id
+                    AND character.membership_id = response.membership_id
+                WHERE interaction.id IS NULL
+                    OR membership.id IS NULL
+                    OR (
+                        response.character_id IS NOT NULL
+                        AND character.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'realm_interaction_answers' AS table_name,
+                    answer.id AS row_id,
+                    answer.community_id,
+                    CASE
+                        WHEN response.id IS NULL THEN 'realm interaction answer response belongs to another community'
+                        WHEN question.id IS NULL THEN 'realm interaction answer question does not match response interaction'
+                        WHEN option.id IS NULL
+                            AND answer.option_id IS NOT NULL
+                            THEN 'realm interaction answer option does not match question'
+                        ELSE 'realm interaction answer tenant pair is invalid'
+                    END AS reason
+                FROM realm_interaction_answers AS answer
+                LEFT JOIN realm_interaction_responses AS response
+                    ON response.id = answer.response_id
+                    AND response.community_id = answer.community_id
+                LEFT JOIN realm_interaction_questions AS question
+                    ON question.id = answer.question_id
+                    AND question.community_id = answer.community_id
+                    AND question.interaction_id = response.interaction_id
+                LEFT JOIN realm_interaction_options AS option
+                    ON option.id = answer.option_id
+                    AND option.community_id = answer.community_id
+                    AND option.question_id = answer.question_id
+                WHERE response.id IS NULL
+                    OR question.id IS NULL
+                    OR (
+                        answer.option_id IS NOT NULL
+                        AND option.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'thread_participants' AS table_name,
+                    participant.id AS row_id,
+                    participant.community_id,
+                    CASE
+                        WHEN thread.id IS NULL THEN 'thread participant thread belongs to another community'
+                        WHEN character.id IS NULL THEN 'thread participant character belongs to another community'
+                        ELSE 'thread participant tenant pair is invalid'
+                    END AS reason
+                FROM thread_participants AS participant
+                LEFT JOIN threads AS thread
+                    ON thread.id = participant.thread_id
+                    AND thread.community_id = participant.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = participant.character_id
+                    AND character.community_id = participant.community_id
+                WHERE thread.id IS NULL
+                    OR character.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'thread_reads' AS table_name,
+                    read.id AS row_id,
+                    read.community_id,
+                    CASE
+                        WHEN thread.id IS NULL THEN 'thread read thread belongs to another community'
+                        WHEN membership.id IS NULL THEN 'thread read membership belongs to another community'
+                        ELSE 'thread read tenant pair is invalid'
+                    END AS reason
+                FROM thread_reads AS read
+                LEFT JOIN threads AS thread
+                    ON thread.id = read.thread_id
+                    AND thread.community_id = read.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = read.membership_id
+                    AND membership.community_id = read.community_id
+                WHERE thread.id IS NULL
+                    OR membership.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'thread_watches' AS table_name,
+                    watch.id AS row_id,
+                    watch.community_id,
+                    CASE
+                        WHEN thread.id IS NULL THEN 'thread watch thread belongs to another community'
+                        WHEN membership.id IS NULL THEN 'thread watch membership belongs to another community'
+                        ELSE 'thread watch tenant pair is invalid'
+                    END AS reason
+                FROM thread_watches AS watch
+                LEFT JOIN threads AS thread
+                    ON thread.id = watch.thread_id
+                    AND thread.community_id = watch.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = watch.membership_id
+                    AND membership.community_id = watch.community_id
+                WHERE thread.id IS NULL
+                    OR membership.id IS NULL
 
                 UNION ALL
 
@@ -1667,6 +2488,70 @@ class IdentityRepositoryMixin(RepositoryBase):
                     OR (
                         notification.character_id IS NOT NULL
                         AND target_character.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'plotting_room_participants' AS table_name,
+                    participant.id AS row_id,
+                    participant.community_id,
+                    CASE
+                        WHEN room.id IS NULL THEN 'plotting room participant room belongs to another community'
+                        WHEN membership.id IS NULL THEN 'plotting room participant membership belongs to another community'
+                        WHEN character.id IS NULL
+                            AND participant.character_id IS NOT NULL
+                            THEN 'plotting room participant character does not match community and membership'
+                        ELSE 'plotting room participant tenant pair is invalid'
+                    END AS reason
+                FROM plotting_room_participants AS participant
+                LEFT JOIN plotting_rooms AS room
+                    ON room.id = participant.plotting_room_id
+                    AND room.community_id = participant.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = participant.membership_id
+                    AND membership.community_id = participant.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = participant.character_id
+                    AND character.community_id = participant.community_id
+                    AND character.membership_id = participant.membership_id
+                WHERE room.id IS NULL
+                    OR membership.id IS NULL
+                    OR (
+                        participant.character_id IS NOT NULL
+                        AND character.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'plotting_room_messages' AS table_name,
+                    message.id AS row_id,
+                    message.community_id,
+                    CASE
+                        WHEN room.id IS NULL THEN 'plotting room message room belongs to another community'
+                        WHEN membership.id IS NULL THEN 'plotting room message author membership belongs to another community'
+                        WHEN character.id IS NULL
+                            AND message.author_character_id IS NOT NULL
+                            THEN 'plotting room message author character does not match community and membership'
+                        ELSE 'plotting room message tenant pair is invalid'
+                    END AS reason
+                FROM plotting_room_messages AS message
+                LEFT JOIN plotting_rooms AS room
+                    ON room.id = message.plotting_room_id
+                    AND room.community_id = message.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = message.author_membership_id
+                    AND membership.community_id = message.community_id
+                LEFT JOIN characters AS character
+                    ON character.id = message.author_character_id
+                    AND character.community_id = message.community_id
+                    AND character.membership_id = message.author_membership_id
+                WHERE room.id IS NULL
+                    OR membership.id IS NULL
+                    OR (
+                        message.author_character_id IS NOT NULL
+                        AND character.id IS NULL
                     )
             )
             ORDER BY table_name, community_id, row_id

--- a/src/elbysodic/db/repositories/notifications.py
+++ b/src/elbysodic/db/repositories/notifications.py
@@ -516,28 +516,51 @@ class NotificationRepositoryMixin(CharacterRepositoryMixin):
         ).fetchone()
         return int(row["count"] if row is not None else 0)
 
-    def mark_notification_read(self, community_id: int, notification_id: int) -> Notification:
+    def mark_notification_read(
+        self,
+        community_id: int,
+        membership_id: int,
+        notification_id: int,
+    ) -> Notification:
         notification = self.get_notification(community_id, notification_id)
+        self.get_membership(community_id, membership_id)
+        if notification.membership_id != membership_id:
+            raise LookupError(
+                f"notification not found for membership {membership_id}: {notification_id}"
+            )
         if notification.read_at is None:
             self.connection.execute(
                 """
                 UPDATE notifications
                 SET read_at = ?
-                WHERE community_id = ? AND id = ?
+                WHERE community_id = ? AND membership_id = ? AND id = ?
                 """,
-                (_utc_now(), community_id, notification_id),
+                (_utc_now(), community_id, membership_id, notification_id),
             )
             self._commit()
         return self.get_notification(community_id, notification_id)
 
-    def mark_all_notifications_read(self, community_id: int, membership_id: int) -> None:
+    def mark_notifications_read(
+        self,
+        community_id: int,
+        membership_id: int,
+        notification_ids: list[int],
+    ) -> None:
+        if not notification_ids:
+            return
         self.get_membership(community_id, membership_id)
+        notification_ids_json = json.dumps(notification_ids)
         self.connection.execute(
             """
             UPDATE notifications
             SET read_at = COALESCE(read_at, ?)
-            WHERE community_id = ? AND membership_id = ?
+            WHERE community_id = ?
+              AND membership_id = ?
+              AND id IN (
+                  SELECT CAST(value AS INTEGER)
+                  FROM json_each(?)
+              )
             """,
-            (_utc_now(), community_id, membership_id),
+            (_utc_now(), community_id, membership_id, notification_ids_json),
         )
         self._commit()

--- a/src/elbysodic/db/repositories/threads.py
+++ b/src/elbysodic/db/repositories/threads.py
@@ -698,6 +698,8 @@ class ThreadRepositoryMixin(ReserveRepositoryMixin):
         return self.get_thread_watch(community_id, thread_id, membership_id)
 
     def unwatch_thread(self, community_id: int, thread_id: int, membership_id: int) -> None:
+        self.get_thread(community_id, thread_id)
+        self.get_membership(community_id, membership_id)
         self.connection.execute(
             """
             DELETE FROM thread_watches

--- a/src/elbysodic/services/claims.py
+++ b/src/elbysodic/services/claims.py
@@ -14,6 +14,7 @@ from elbysodic.domain.models import (
     CharacterClaim,
     ClaimType,
 )
+from elbysodic.services import policies
 from elbysodic.services.read_models import (
     ApplicationClaimCheck,
     ApplicationFieldValueView,
@@ -180,6 +181,7 @@ def claims_directory(
         groups=groups,
         status_filter=status_filter,
         search_query=cleaned_search_query,
+        can_manage=policies.can_manage_applications(viewer.membership, viewer.role),
     )
 
 

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -6,6 +6,7 @@ import os
 import re
 import secrets
 import sqlite3
+import sys
 from contextlib import AbstractContextManager, suppress
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
@@ -495,18 +496,23 @@ class AppServices:
         if self._database is not None:
             repo_context = self._database.repository()
             repo = repo_context.__enter__()
-            identity_resolver = RequestIdentityResolver(
-                repo,
-                _default_request_identity(self._seed),
-                allow_development_identity=self._allow_development_identity,
-                require_session=self._require_session,
-            )
+            try:
+                identity_resolver = RequestIdentityResolver(
+                    repo,
+                    _default_request_identity(self._seed),
+                    allow_development_identity=self._allow_development_identity,
+                    require_session=self._require_session,
+                )
+                identity_context = identity_resolver.resolve(request)
+            except BaseException:
+                repo_context.__exit__(*sys.exc_info())
+                raise
             return AppServices(
                 repo,
                 self._seed,
                 database=self._database,
                 identity_resolver=identity_resolver,
-                identity_context=identity_resolver.resolve(request),
+                identity_context=identity_context,
                 allow_development_identity=self._allow_development_identity,
                 require_session=self._require_session,
                 repo_context=repo_context,
@@ -1391,6 +1397,13 @@ class AppServices:
         except PermissionError:
             viewer = None
         return _network_home(cards, viewer)
+
+    def can_manage_realm_home(self) -> bool:
+        viewer = self.viewer()
+        return policies.can_manage_navigation(
+            viewer.membership,
+            viewer.role,
+        ) or policies.can_manage_world(viewer.membership, viewer.role)
 
     def network_explore(self, query: str = "") -> NetworkExploreView:
         cards = self._public_catalog_cards()

--- a/src/elbysodic/services/notifications.py
+++ b/src/elbysodic/services/notifications.py
@@ -71,9 +71,19 @@ class NotificationRepository(PostViewRepository, Protocol):
 
     def count_unread_notifications(self, community_id: int, membership_id: int) -> int: ...
 
-    def mark_notification_read(self, community_id: int, notification_id: int) -> Notification: ...
+    def mark_notification_read(
+        self,
+        community_id: int,
+        membership_id: int,
+        notification_id: int,
+    ) -> Notification: ...
 
-    def mark_all_notifications_read(self, community_id: int, membership_id: int) -> None: ...
+    def mark_notifications_read(
+        self,
+        community_id: int,
+        membership_id: int,
+        notification_ids: list[int],
+    ) -> None: ...
 
     def list_thread_watch_membership_ids(
         self,
@@ -131,11 +141,11 @@ def count_visible_unread_notifications(
     membership: CommunityMembership,
     role: Role | None,
 ) -> int:
+    notifications = _unread_notifications_for_membership(repo, community_id, membership.id)
     return sum(
         1
-        for notification in repo.list_notifications(community_id, membership.id, limit=1000)
-        if notification.read_at is None
-        and _can_view_notification_target(repo, community_id, membership, role, notification)
+        for notification in notifications
+        if _can_view_notification_target(repo, community_id, membership, role, notification)
     )
 
 
@@ -172,12 +182,38 @@ def open_notification(
     item = notification_item(repo, viewer, notification)
     if item is None:
         raise LookupError(f"notification target not found: {notification.id}")
-    repo.mark_notification_read(viewer.community.id, notification.id)
+    repo.mark_notification_read(viewer.community.id, viewer.membership.id, notification.id)
     return item.href
 
 
 def mark_all_notifications_read(repo: NotificationRepository, viewer: ForumView) -> None:
-    repo.mark_all_notifications_read(viewer.community.id, viewer.membership.id)
+    readable_ids = [
+        notification.id
+        for notification in _unread_notifications_for_membership(
+            repo,
+            viewer.community.id,
+            viewer.membership.id,
+        )
+        if _can_view_notification_target(
+            repo,
+            viewer.community.id,
+            viewer.membership,
+            viewer.role,
+            notification,
+        )
+    ]
+    repo.mark_notifications_read(viewer.community.id, viewer.membership.id, readable_ids)
+
+
+def _unread_notifications_for_membership(
+    repo: NotificationRepository,
+    community_id: int,
+    membership_id: int,
+) -> list[Notification]:
+    return repo.list_unread_notifications_for_memberships([(community_id, membership_id)]).get(
+        (community_id, membership_id),
+        [],
+    )
 
 
 def notify_post_created(
@@ -310,6 +346,8 @@ def notification_item(
             viewer.community.id,
             notification.character_plot_hook_id,
         )
+        if not _can_view_plot_hook_notification(viewer.membership, viewer.role, plot_hook):
+            return None
         character = repo.get_character(viewer.community.id, plot_hook.character_id)
         return NotificationItem(
             notification=notification,
@@ -433,6 +471,12 @@ def _can_view_notification_target(
                 wanted_ad,
                 interest,
             )
+        if notification.character_plot_hook_id is not None:
+            plot_hook = repo.get_character_plot_hook(
+                community_id,
+                notification.character_plot_hook_id,
+            )
+            return _can_view_plot_hook_notification(membership, role, plot_hook)
         if notification.character_id is not None:
             character = repo.get_character(community_id, notification.character_id)
             return character.membership_id == membership.id or policies.can_manage_casting(
@@ -441,6 +485,17 @@ def _can_view_notification_target(
     except LookupError:
         return False
     return True
+
+
+def _can_view_plot_hook_notification(
+    membership: CommunityMembership,
+    role: Role | None,
+    plot_hook: CharacterPlotHook,
+) -> bool:
+    return plot_hook.author_membership_id == membership.id or policies.can_manage_casting(
+        membership,
+        role,
+    )
 
 
 def _can_view_wanted_interest_notification(

--- a/src/elbysodic/services/posting.py
+++ b/src/elbysodic/services/posting.py
@@ -139,6 +139,8 @@ class PostingRepository(NotificationRepository, Protocol):
         limit: int = 10,
     ) -> list[CommunityMembership]: ...
 
+    def list_community_characters(self, community_id: int) -> list[Character]: ...
+
 
 def search_mentionables(
     repo: PostingRepository,
@@ -384,9 +386,19 @@ def start_thread(
         raise ValueError("opening post is required")
     cleaned_status = clean_thread_status(status)
     cleaned_posting_mode = clean_posting_mode(posting_mode)
-    cleaned_participant_ids = clean_participant_ids([character.id, *(participant_ids or [])])
-    for participant_id in cleaned_participant_ids:
-        repo.get_character(viewer.community.id, participant_id)
+    taggable_ids = {
+        item.id
+        for item in taggable_characters(
+            repo.list_community_characters(viewer.community.id),
+            viewer.roster,
+        )
+    }
+    tag_ids = [
+        participant_id
+        for participant_id in clean_participant_ids(participant_ids or [])
+        if participant_id in taggable_ids
+    ]
+    cleaned_participant_ids = clean_participant_ids([character.id, *tag_ids])
     slug = unique_thread_slug(repo, viewer.community.id, board.id, cleaned_title)
     with repo.transaction():
         thread = repo.create_thread(

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -877,6 +877,7 @@ class ClaimsDirectory:
     groups: list[ClaimTypeDirectory]
     status_filter: str | None = None
     search_query: str = ""
+    can_manage: bool = False
 
     @property
     def claim_count(self) -> int:

--- a/src/elbysodic/web/pages/claims/page.py
+++ b/src/elbysodic/web/pages/claims/page.py
@@ -12,7 +12,6 @@ from chirp.http.response import Redirect
 from chirp.templating.returns import Page
 
 from elbysodic.db.repositories.base import TenantBoundaryError
-from elbysodic.services import policies
 from elbysodic.web.state import get_services
 
 
@@ -87,7 +86,7 @@ def _render_claims(
         current_path=request.url,
         viewer=viewer,
         directory=directory,
-        can_manage=policies.can_manage_applications(viewer.membership, viewer.role),
+        can_manage=directory.can_manage,
         characters=services.claimable_characters(),
         error=error,
         search_query_encoded=quote_plus(directory.search_query),

--- a/src/elbysodic/web/pages/page.py
+++ b/src/elbysodic/web/pages/page.py
@@ -9,7 +9,6 @@ from chirp.http.request import Request
 from chirp.templating.returns import Page
 
 from elbysodic.domain.boards import is_community_board, is_desk_board, is_location_board
-from elbysodic.services import policies
 from elbysodic.services.forum import AppServices
 from elbysodic.services.read_models import ForumView, MaterialSummary, WorldHub
 from elbysodic.web.state import get_services
@@ -98,7 +97,7 @@ def get(request: Request) -> Page:
         current_path=request.url,
         viewer=viewer,
         realm_gateway=realm_gateway,
-        can_manage_home=_can_manage_home(viewer),
+        can_manage_home=services.can_manage_realm_home(),
         world_status_label=world_status_label,
         world_status_copy=world_status_copy,
         boards=boards,
@@ -124,10 +123,3 @@ def _network_services(request: Request) -> tuple[AppServices, ForumView | None]:
         return services, services.viewer()
     except PermissionError:
         return get_services(), None
-
-
-def _can_manage_home(viewer: ForumView) -> bool:
-    return policies.can_manage_navigation(
-        viewer.membership,
-        viewer.role,
-    ) or policies.can_manage_world(viewer.membership, viewer.role)

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from elbysodic.db import ForumRepository, connect
+from elbysodic.services import create_services
+from elbysodic.web.state import close_request_services, configure_services, get_services
+
+REPO_ROOT = Path(__file__).parents[1]
+WEB_DIR = REPO_ROOT / "src" / "elbysodic" / "web"
+WEB_PAGES_DIR = WEB_DIR / "pages"
+SERVICES_DIR = REPO_ROOT / "src" / "elbysodic" / "services"
+
+
+class RequestStub:
+    def __init__(self) -> None:
+        self._cache: dict[str, object] = {}
+
+
+class HeaderRequestStub(RequestStub):
+    def __init__(self, headers: dict[str, str]) -> None:
+        super().__init__()
+        self.headers = headers
+        self.cookies: dict[str, str] = {}
+
+
+class TrackingRepositoryContext:
+    def __init__(self, database_path: Path) -> None:
+        self.database_path = database_path
+        self.connection: sqlite3.Connection | None = None
+        self.exited = False
+
+    def __enter__(self) -> ForumRepository:
+        self.connection = connect(self.database_path, check_same_thread=False)
+        return ForumRepository(self.connection)
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.exited = True
+        assert self.connection is not None
+        self.connection.close()
+
+
+class TrackingDatabase:
+    def __init__(self, database_path: Path) -> None:
+        self.database_path = database_path
+        self.context: TrackingRepositoryContext | None = None
+
+    def repository(self) -> TrackingRepositoryContext:
+        self.context = TrackingRepositoryContext(self.database_path)
+        return self.context
+
+
+def test_file_backed_request_services_are_cached_and_closed(tmp_path: Path) -> None:
+    root_services = create_services(path=tmp_path / "elbysodic.sqlite3")
+    configure_services(root_services)
+    request = RequestStub()
+
+    try:
+        first = get_services(request)
+        second = get_services(request)
+
+        assert first is second
+        assert first is not root_services
+        assert first.repo.connection.execute("SELECT COUNT(*) FROM communities").fetchone()[0] > 0
+
+        close_request_services(request)
+
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            first.repo.connection.execute("SELECT 1")
+        assert request._cache == {}
+        assert (
+            root_services.repo.connection.execute("SELECT COUNT(*) FROM communities").fetchone()[0]
+            > 0
+        )
+    finally:
+        close_request_services(request)
+        root_services.close()
+
+
+def test_file_backed_request_services_close_when_identity_resolution_fails(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "elbysodic.sqlite3"
+    root_services = create_services(path=database_path)
+    tracking_database = TrackingDatabase(database_path)
+    cast(Any, root_services)._database = tracking_database
+    request = HeaderRequestStub({"x-elbysodic-membership-id": "999999"})
+
+    try:
+        with pytest.raises(LookupError, match="membership not found"):
+            root_services.for_request(request)
+
+        assert tracking_database.context is not None
+        assert tracking_database.context.exited is True
+        assert tracking_database.context.connection is not None
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            tracking_database.context.connection.execute("SELECT 1")
+    finally:
+        root_services.close()
+
+
+def test_request_service_cleanup_rolls_back_open_transactions(tmp_path: Path) -> None:
+    root_services = create_services(path=tmp_path / "elbysodic.sqlite3")
+    configure_services(root_services)
+    request = RequestStub()
+
+    try:
+        request_services = get_services(request)
+        request_services.repo.connection.execute(
+            """
+            INSERT INTO communities (slug, name, created_at, updated_at)
+            VALUES ('cleanup-rollback', 'Cleanup Rollback', '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')
+            """
+        )
+        assert request_services.repo.connection.in_transaction
+
+        close_request_services(request)
+
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            request_services.repo.connection.execute("SELECT 1")
+        with pytest.raises(LookupError, match="community not found"):
+            root_services.repo.get_community_by_slug("cleanup-rollback")
+    finally:
+        close_request_services(request)
+        root_services.close()
+
+
+def test_repository_transaction_rolls_back_and_recovers_when_commit_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+
+    def fail_commit() -> None:
+        raise RuntimeError("simulated commit failure")
+
+    monkeypatch.setattr(repo, "_commit", fail_commit)
+    with pytest.raises(RuntimeError, match="simulated commit failure"), repo.transaction():
+        repo.connection.execute(
+            """
+            INSERT INTO communities (slug, name, created_at, updated_at)
+            VALUES ('commit-failure', 'Commit Failure', '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')
+            """
+        )
+
+    assert repo._transaction_depth == 0
+    assert not repo.connection.in_transaction
+    with pytest.raises(LookupError, match="community not found"):
+        repo.get_community_by_slug("commit-failure")
+
+    monkeypatch.undo()
+    recovered = repo.create_community("commit-recovered", "Commit Recovered")
+    assert repo.get_community_by_slug("commit-recovered") == recovered
+    services.close()
+
+
+def test_web_entrypoints_do_not_manually_scope_services() -> None:
+    offenders: list[str] = []
+    for path in sorted(WEB_DIR.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "get_services().for_request(" in source:
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    assert offenders == []
+
+
+def test_web_handlers_do_not_run_sql_directly() -> None:
+    database_call_patterns = (
+        re.compile(r"\.connection\b"),
+        re.compile(r"\.execute\("),
+        re.compile(r"\bexecutemany\("),
+        re.compile(r"\bsqlite3\b"),
+        re.compile(r"\bconnect\("),
+    )
+    offenders: list[str] = []
+
+    for path in sorted(WEB_DIR.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if any(pattern.search(source) for pattern in database_call_patterns):
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    assert offenders == []
+
+
+def test_web_page_handlers_do_not_make_policy_decisions_directly() -> None:
+    offenders: list[str] = []
+    for path in sorted(WEB_PAGES_DIR.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "policies." in source or "from elbysodic.services import policies" in source:
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    assert offenders == []
+
+
+def test_service_raw_sql_stays_limited_to_lifecycle_and_operations_diagnostics() -> None:
+    exact_allowed = {
+        (
+            "src/elbysodic/services/forum.py",
+            'connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")',
+        ),
+        (
+            "src/elbysodic/services/forum.py",
+            'connection.execute("PRAGMA database_list").fetchall()',
+        ),
+        (
+            "src/elbysodic/services/forum.py",
+            'return any(row["file"] for row in connection.execute("PRAGMA database_list").fetchall())',
+        ),
+        (
+            "src/elbysodic/services/operations.py",
+            'database_row = connection.execute("PRAGMA database_list").fetchone()',
+        ),
+        (
+            "src/elbysodic/services/operations.py",
+            'user_version = connection.execute("PRAGMA user_version").fetchone()[0]',
+        ),
+        (
+            "src/elbysodic/services/operations.py",
+            'community_count = connection.execute("SELECT COUNT(*) AS count FROM communities").fetchone()',
+        ),
+    }
+    prefix_allowed = {
+        ("src/elbysodic/services/operations.py", "migration_row = connection.execute("),
+    }
+    offenders: list[str] = []
+
+    for path in sorted(SERVICES_DIR.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(source.splitlines(), start=1):
+            if ".execute(" not in line and "executemany(" not in line:
+                continue
+            relative = str(path.relative_to(REPO_ROOT))
+            stripped = line.strip()
+            if (relative, stripped) in exact_allowed:
+                continue
+            if (relative, stripped) in prefix_allowed:
+                continue
+            if any(
+                relative == allowed_path and stripped.startswith(allowed_prefix)
+                for allowed_path, allowed_prefix in prefix_allowed
+            ):
+                continue
+            else:
+                offenders.append(f"{relative}:{line_number}: {stripped}")
+
+    assert offenders == []

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -22,6 +22,11 @@ from elbysodic.db.seed import DemoSeed, resolve_seed_persona, seed_demo_forum
 from elbysodic.domain import Community, Thread
 from elbysodic.services import AppServices, create_services, default_database_path
 from elbysodic.services.access import TENANT_SLUG_CACHE_KEY
+from elbysodic.services.notifications import (
+    count_visible_unread_notifications,
+    mark_all_notifications_read,
+    visible_unread_notification_counts,
+)
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_scoped_path, scope_response_urls
@@ -668,6 +673,139 @@ def test_scaled_signed_in_network_stays_within_batched_query_budget() -> None:
         assert trace.count <= 85
 
     asyncio.run(run())
+
+
+def test_visible_unread_notification_counts_use_batched_membership_query() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    assert services.seed.default_character is not None
+    contexts = [
+        (
+            services.seed.community.id,
+            services.seed.membership,
+            repo.get_role(services.seed.community.id, services.seed.membership.role_id),
+            services.seed.default_character.id,
+        )
+    ]
+    for index in range(12):
+        community, _user_id, membership_id, character_id = _add_hosted_membership(
+            services,
+            slug=f"notify-scale-{index}",
+            user_id=services.seed.user.id,
+            username=f"notify-scale-{index}",
+        )
+        membership = repo.get_membership(community.id, membership_id)
+        contexts.append(
+            (
+                community.id,
+                membership,
+                repo.get_role(community.id, membership.role_id),
+                character_id,
+            )
+        )
+    for community_id, membership, _role, character_id in contexts:
+        repo.create_notification(
+            community_id,
+            membership.id,
+            kind="character",
+            character_id=character_id,
+            actor_membership_id=membership.id,
+            actor_character_id=character_id,
+        )
+
+    with trace_sql(repo.connection) as trace:
+        counts = visible_unread_notification_counts(
+            repo,
+            [(community_id, membership, role) for community_id, membership, role, _ in contexts],
+        )
+
+    assert counts == {membership.id: 1 for _community_id, membership, _role, _ in contexts}
+    batch_queries = [
+        statement
+        for statement in trace.statements
+        if "JOIN requested" in statement and "notifications.read_at IS NULL" in statement
+    ]
+    per_membership_notification_queries = [
+        statement
+        for statement in trace.statements
+        if "FROM notifications" in statement
+        and "WHERE community_id" in statement
+        and "membership_id" in statement
+        and "LIMIT" in statement
+    ]
+    assert len(batch_queries) == 1
+    assert per_membership_notification_queries == []
+
+
+def test_mark_all_notifications_read_has_no_visible_count_cap() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    viewer = services.viewer()
+    assert services.seed.default_character is not None
+    other_membership = repo.create_membership(
+        viewer.community.id,
+        repo.create_user("hidden-notify@example.com", "hash").id,
+        viewer.membership.role_id,
+        "hidden-notify",
+        "Hidden Notify",
+    )
+    hidden_character = repo.create_character(
+        viewer.community.id,
+        other_membership.id,
+        "hidden-notify-face",
+        "Hidden Notify Face",
+    )
+
+    with repo.transaction():
+        for _index in range(1001):
+            repo.create_notification(
+                viewer.community.id,
+                viewer.membership.id,
+                kind="character",
+                character_id=services.seed.default_character.id,
+                actor_membership_id=viewer.membership.id,
+                actor_character_id=services.seed.default_character.id,
+            )
+        hidden_notification = repo.create_notification(
+            viewer.community.id,
+            viewer.membership.id,
+            kind="character",
+            character_id=hidden_character.id,
+            actor_membership_id=other_membership.id,
+            actor_character_id=hidden_character.id,
+        )
+
+    assert (
+        count_visible_unread_notifications(
+            repo,
+            viewer.community.id,
+            viewer.membership,
+            viewer.role,
+        )
+        == 1001
+    )
+
+    with trace_sql(repo.connection) as trace:
+        mark_all_notifications_read(repo, viewer)
+
+    assert (
+        count_visible_unread_notifications(
+            repo,
+            viewer.community.id,
+            viewer.membership,
+            viewer.role,
+        )
+        == 0
+    )
+    assert repo.count_unread_notifications(viewer.community.id, viewer.membership.id) == 1
+    assert repo.get_notification(viewer.community.id, hidden_notification.id).read_at is None
+    notification_updates = [
+        statement
+        for statement in trace.statements
+        if statement.strip().upper().startswith("UPDATE notifications".upper())
+    ]
+    assert len(notification_updates) == 1
+    assert "json_each" in notification_updates[0]
 
 
 def test_request_identity_resolves_membership_inside_selected_community() -> None:
@@ -8445,7 +8583,10 @@ def test_character_plot_hooks_render_create_and_notify_interest() -> None:
             assert "Coffee before the crisis" in discover.text
 
             services = get_services()
-            outsider_services, _character_id = _outsider_services(services, prefix="hookfan")
+            outsider_services, outsider_character_id = _outsider_services(
+                services,
+                prefix="hookfan",
+            )
             outsider_app = create_app(debug=False, services=outsider_services)
             async with TestClient(outsider_app) as outsider_client:
                 outsider_detail = await outsider_client.get(
@@ -8472,6 +8613,46 @@ def test_character_plot_hooks_render_create_and_notify_interest() -> None:
                 "coffee-before-the-crisis",
             )
             interest = repo.list_character_plot_hook_interests(community.id, hook.id)[0]
+            leak_services, _leak_character_id = _outsider_services(
+                services,
+                prefix="hookleak",
+            )
+            leak_notification = repo.create_notification(
+                community.id,
+                leak_services.seed.membership.id,
+                kind="plot_hook_interest",
+                character_plot_hook_id=hook.id,
+                actor_membership_id=outsider_services.seed.membership.id,
+                actor_character_id=outsider_character_id,
+            )
+            leak_app = create_app(debug=False, services=leak_services)
+            async with TestClient(leak_app) as leak_client:
+                leak_inbox = await leak_client.get("/notifications")
+                leak_mark_all = await leak_client.post(
+                    "/notifications",
+                    body=b"intent=mark_all_read",
+                    headers=_FORM,
+                )
+                leak_open = await leak_client.post(
+                    "/notifications",
+                    body=urlencode(
+                        {
+                            "intent": "open",
+                            "notification_id": str(leak_notification.id),
+                        }
+                    ).encode(),
+                    headers=_FORM,
+                )
+
+            assert leak_services.viewer().unread_notification_count == 0
+            assert leak_services.notifications().unread_count == 0
+            assert leak_inbox.status == 200
+            assert "No notifications are waiting on you." in leak_inbox.text
+            assert "Coffee before the crisis" not in leak_inbox.text
+            assert "Hookfan Face" not in leak_inbox.text
+            assert leak_mark_all.status == 302
+            assert repo.get_notification(community.id, leak_notification.id).read_at is None
+            assert leak_open.status == 404
 
             owner_app = create_app(debug=False, services=AppServices(repo, services.seed))
             async with TestClient(owner_app) as owner_client:
@@ -9675,6 +9856,20 @@ def test_notifications_track_watched_thread_replies_and_open_read_state() -> Non
             assert "new" in notifications.text
 
             item = services.notifications().items[0]
+            marked_all = await client.post(
+                "/notifications",
+                body=b"intent=mark_all_read",
+                headers=_FORM,
+            )
+            assert marked_all.status == 302
+            assert (
+                services.repo.get_notification(
+                    services.seed.community.id,
+                    item.notification.id,
+                ).read_at
+                is not None
+            )
+
             opened = await client.post(
                 "/notifications",
                 body=f"intent=open&notification_id={item.notification.id}".encode(),
@@ -11212,6 +11407,7 @@ def test_start_thread_creates_opening_post_as_selected_character() -> None:
         services = get_services()
         roster = services.viewer().roster
         magneto = next(character for character in roster if character.name == "Magneto")
+        rogue = next(character for character in roster if character.name == "Rogue")
         xavier = services.repo.get_character_by_slug(
             services.seed.community.id,
             "charles-xavier",
@@ -11250,7 +11446,7 @@ def test_start_thread_creates_opening_post_as_selected_character() -> None:
                 body=urlencode(
                     {
                         "character_id": magneto.id,
-                        "participant_ids": [xavier.id],
+                        "participant_ids": [xavier.id, rogue.id],
                         "title": "Metal and Memory",
                         "status": "open",
                         "location": "Sublevel 3",
@@ -11296,6 +11492,18 @@ def test_start_thread_creates_opening_post_as_selected_character() -> None:
             assert "Before breakfast" in thread.text
             assert "Magneto tags Xavier into an unreasonable simulation." in thread.text
             assert "/characters/charles-xavier" in thread.text
+            created_thread = services.repo.get_thread_by_slug(
+                services.seed.community.id,
+                services.repo.get_board_by_slug(services.seed.community.id, "danger-room").id,
+                "metal-and-memory",
+            )
+            assert {
+                character.slug
+                for character in services.repo.list_thread_participants(
+                    services.seed.community.id,
+                    created_thread.id,
+                )
+            } == {"magneto", "charles-xavier"}
 
             board = await client.get("/boards/danger-room")
             assert "Metal and Memory" in board.text

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -559,6 +559,38 @@ def test_community_access_requests_are_tenant_scoped(repo: ForumRepository) -> N
     default = repo.get_community(1)
     hosted = repo.create_community("access-hosted", "Access Hosted")
     user = repo.create_user("access-request@example.com", "hash")
+    default_role = repo.create_role(default.id, "access-member", "Access Member")
+    hosted_role = repo.create_role(hosted.id, "access-member", "Access Member")
+    default_director = repo.create_membership(
+        default.id,
+        user.id,
+        default_role.id,
+        "access-director",
+        "Access Director",
+    )
+    hosted_director = repo.create_membership(
+        hosted.id,
+        user.id,
+        hosted_role.id,
+        "access-director",
+        "Access Director Elsewhere",
+    )
+    default_invitation = repo.create_community_invitation(
+        default.id,
+        email="writer@example.com",
+        role_id=default_role.id,
+        invited_by_membership_id=default_director.id,
+        token_hash=token_hex(16),
+        expires_at=None,
+    )
+    hosted_invitation = repo.create_community_invitation(
+        hosted.id,
+        email="writer@example.com",
+        role_id=hosted_role.id,
+        invited_by_membership_id=hosted_director.id,
+        token_hash=token_hex(16),
+        expires_at=None,
+    )
 
     default_request = repo.create_community_access_request(
         default.id,
@@ -608,6 +640,52 @@ def test_community_access_requests_are_tenant_scoped(repo: ForumRepository) -> N
     )
     with pytest.raises(LookupError, match="access request not found"):
         repo.get_community_access_request(hosted.id, default_request.id)
+
+    reviewed_with_invitation = repo.update_community_access_request_status(
+        default.id,
+        default_request.id,
+        status="invited",
+        invitation_id=default_invitation.id,
+    )
+    invited_event = repo.create_community_access_request_event(
+        default.id,
+        default_request.id,
+        event_type="invited",
+        from_status="reviewed",
+        to_status="invited",
+        actor_membership_id=default_director.id,
+        invitation_id=default_invitation.id,
+    )
+    assert reviewed_with_invitation.invitation_id == default_invitation.id
+    repo.connection.execute(
+        """
+        UPDATE community_access_requests
+        SET invitation_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_invitation.id, default.id, default_request.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE community_access_request_events
+        SET actor_membership_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_director.id, default.id, invited_event.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("community_access_requests", default_request.id)] == (
+        "community access request invitation belongs to another community"
+    )
+    assert issue_map[("community_access_request_events", invited_event.id)] == (
+        "community access request event actor membership belongs to another community"
+    )
 
 
 def test_community_access_request_status_transitions(repo: ForumRepository) -> None:
@@ -737,6 +815,25 @@ def test_discovery_profiles_and_tags_are_tenant_scoped(repo: ForumRepository) ->
     assert {tag.community_id for tag in tags[default.id]} == {default.id}
     assert repo.get_discovery_tag(hosted.id, "premise", "weird-town").label == "Weird town"
 
+    repo.connection.execute(
+        """
+        UPDATE community_discovery_profiles
+        SET featured_event_material_id = ?
+        WHERE community_id = ?
+        """,
+        (hosted_event.id, default.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("community_discovery_profiles", default.id)] == (
+        "community discovery profile featured event belongs to another community"
+    )
+
 
 def test_discovery_profile_rejects_cross_community_featured_event(
     repo: ForumRepository,
@@ -855,6 +952,11 @@ def test_gateway_slots_are_tenant_scoped_and_validate_eligible_targets(
         "public-guidebook-material",
         "Public guidebook material",
     )
+    hosted_material = repo.create_material(
+        hosted.id,
+        "public-guidebook-material",
+        "Hosted public guidebook material",
+    )
     draft_material = repo.create_material(
         default.id,
         "draft-guidebook-material",
@@ -913,6 +1015,48 @@ def test_gateway_slots_are_tenant_scoped_and_validate_eligible_targets(
         )
     with pytest.raises(ValueError, match="gateway slot type must be one of:"):
         repo.create_community_gateway_slot(default.id, "public_scene", hosted_scene_hub.id)
+
+    diagnostic_scene = repo.create_community_gateway_slot(default.id, "scene_hub", scene_hub.id)
+    repo.connection.execute(
+        """
+        UPDATE community_gateway_slots
+        SET target_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_scene_hub.id, default.id, diagnostic_scene.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE community_gateway_slots
+        SET target_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_wanted.id, default.id, second.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE community_gateway_slots
+        SET target_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_material.id, default.id, third.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("community_gateway_slots", diagnostic_scene.id)] == (
+        "community gateway slot scene hub board belongs to another community"
+    )
+    assert issue_map[("community_gateway_slots", second.id)] == (
+        "community gateway slot wanted hook belongs to another community"
+    )
+    assert issue_map[("community_gateway_slots", third.id)] == (
+        "community gateway slot guidebook material belongs to another community"
+    )
 
 
 def test_community_invitation_lifecycle_is_tenant_scoped(repo: ForumRepository) -> None:
@@ -993,6 +1137,36 @@ def test_community_invitation_lifecycle_is_tenant_scoped(repo: ForumRepository) 
     assert accepted.accepted_at is not None
     assert revoked.status == "revoked"
     assert revoked.revoked_at is not None
+
+    repo.connection.execute(
+        """
+        UPDATE community_invitations
+        SET role_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (default_role.id, hosted.id, invitation.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE community_invitations
+        SET accepted_membership_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (default_director.id, hosted.id, second_invitation.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("community_invitations", invitation.id)] == (
+        "community invitation role belongs to another community"
+    )
+    assert issue_map[("community_invitations", second_invitation.id)] == (
+        "community invitation accepted membership belongs to another community"
+    )
 
 
 def test_schema_migrates_existing_posts_for_thread_local_public_numbers() -> None:
@@ -1259,6 +1433,19 @@ def test_tenant_pair_integrity_issues_detect_wrong_face_authorship(
         "hosted-authorship",
         "Hosted Authorship",
     )
+    other_default_membership = repo.create_membership(
+        default.id,
+        repo.create_user("other-authorship@example.com", "hash").id,
+        default_role.id,
+        "other-authorship",
+        "Other Authorship",
+    )
+    other_default_character = repo.create_character(
+        default.id,
+        other_default_membership.id,
+        "other-authorship",
+        "Other Authorship",
+    )
     board = repo.create_board(default.id, "authorship", "Authorship")
     thread = repo.create_thread(
         default.id,
@@ -1275,6 +1462,53 @@ def test_tenant_pair_integrity_issues_detect_wrong_face_authorship(
         character_id=default_character.id,
         actor_membership_id=default_membership.id,
         actor_character_id=default_character.id,
+    )
+
+    with pytest.raises(LookupError, match="character not found"):
+        repo.create_notification(
+            default.id,
+            default_membership.id,
+            kind="character",
+            character_id=default_character.id,
+            actor_membership_id=default_membership.id,
+            actor_character_id=hosted_character.id,
+        )
+    with pytest.raises(TenantBoundaryError, match="does not belong to membership"):
+        repo.create_notification(
+            default.id,
+            default_membership.id,
+            kind="character",
+            character_id=default_character.id,
+            actor_membership_id=default_membership.id,
+            actor_character_id=other_default_character.id,
+        )
+
+    wanted = repo.create_wanted_ad(default.id, default_membership.id, "authorship", "Authorship")
+    interest = repo.create_wanted_ad_interest(
+        default.id,
+        wanted.id,
+        other_default_membership.id,
+        other_default_character.id,
+    )
+    room = repo.create_plotting_room(
+        default.id,
+        default_membership.id,
+        "Authorship Room",
+        source_wanted_ad_id=wanted.id,
+        source_wanted_ad_interest_id=interest.id,
+    )
+    participant = repo.create_plotting_room_participant(
+        default.id,
+        room.id,
+        default_membership.id,
+        character_id=default_character.id,
+    )
+    message = repo.create_plotting_room_message(
+        default.id,
+        room.id,
+        default_membership.id,
+        "A clean planning note.",
+        author_character_id=default_character.id,
     )
 
     repo.connection.execute(
@@ -1295,11 +1529,35 @@ def test_tenant_pair_integrity_issues_detect_wrong_face_authorship(
     )
     repo.connection.execute(
         """
+        UPDATE thread_participants
+        SET character_id = ?
+        WHERE community_id = ? AND thread_id = ? AND character_id = ?
+        """,
+        (hosted_character.id, default.id, thread.id, default_character.id),
+    )
+    repo.connection.execute(
+        """
         UPDATE notifications
         SET actor_character_id = ?
         WHERE community_id = ? AND id = ?
         """,
         (hosted_character.id, default.id, notification.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE plotting_room_participants
+        SET character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_character.id, default.id, participant.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE plotting_room_messages
+        SET author_character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (other_default_character.id, default.id, message.id),
     )
     repo.connection.commit()
 
@@ -1313,9 +1571,88 @@ def test_tenant_pair_integrity_issues_detect_wrong_face_authorship(
     assert issue_map[("posts", post.id)] == (
         "post author character does not match community and membership"
     )
+    participant_issue = next(
+        issue
+        for issue in issues
+        if issue.table_name == "thread_participants" and issue.community_id == default.id
+    )
+    assert participant_issue.reason == "thread participant character belongs to another community"
     assert issue_map[("notifications", notification.id)] == (
         "notification actor character does not match community and membership"
     )
+    assert issue_map[("plotting_room_participants", participant.id)] == (
+        "plotting room participant character does not match community and membership"
+    )
+    assert issue_map[("plotting_room_messages", message.id)] == (
+        "plotting room message author character does not match community and membership"
+    )
+
+
+def test_notification_read_writes_are_membership_scoped(repo: ForumRepository) -> None:
+    default = repo.get_community(1)
+    role = repo.create_role(default.id, "member", "Member")
+    first_membership = repo.create_membership(
+        default.id,
+        repo.create_user("first-notify-read@example.com", "hash").id,
+        role.id,
+        "first-notify-read",
+        "First Notify Read",
+    )
+    second_membership = repo.create_membership(
+        default.id,
+        repo.create_user("second-notify-read@example.com", "hash").id,
+        role.id,
+        "second-notify-read",
+        "Second Notify Read",
+    )
+    first_character = repo.create_character(
+        default.id,
+        first_membership.id,
+        "first-notify-read",
+        "First Notify Read",
+    )
+    second_character = repo.create_character(
+        default.id,
+        second_membership.id,
+        "second-notify-read",
+        "Second Notify Read",
+    )
+    first_notification = repo.create_notification(
+        default.id,
+        first_membership.id,
+        kind="character",
+        character_id=first_character.id,
+        actor_membership_id=first_membership.id,
+        actor_character_id=first_character.id,
+    )
+    second_notification = repo.create_notification(
+        default.id,
+        second_membership.id,
+        kind="character",
+        character_id=second_character.id,
+        actor_membership_id=second_membership.id,
+        actor_character_id=second_character.id,
+    )
+
+    repo.mark_notifications_read(
+        default.id,
+        first_membership.id,
+        [first_notification.id, second_notification.id],
+    )
+
+    assert repo.get_notification(default.id, first_notification.id).read_at is not None
+    assert repo.get_notification(default.id, second_notification.id).read_at is None
+    with pytest.raises(LookupError, match="notification not found for membership"):
+        repo.mark_notification_read(
+            default.id,
+            first_membership.id,
+            second_notification.id,
+        )
+    assert repo.get_notification(default.id, second_notification.id).read_at is None
+
+    repo.mark_notification_read(default.id, second_membership.id, second_notification.id)
+
+    assert repo.get_notification(default.id, second_notification.id).read_at is not None
 
 
 def test_schema_migrates_existing_boards_for_place_navigation() -> None:
@@ -1501,6 +1838,12 @@ def test_realm_interactions_are_scoped_and_accept_one_membership_response(
         "poll-face",
         "Poll Face",
     )
+    hosted_character = repo.create_character(
+        hosted.id,
+        hosted_membership.id,
+        "hosted-poll-face",
+        "Hosted Poll Face",
+    )
     interaction = repo.create_realm_interaction(
         default.id,
         "sorting",
@@ -1518,11 +1861,22 @@ def test_realm_interactions_are_scoped_and_accept_one_membership_response(
         "library",
         "The library",
     )
-    repo.create_realm_interaction(
+    hosted_interaction = repo.create_realm_interaction(
         hosted.id,
         "sorting",
         "Hosted Sorting",
         placement="application",
+    )
+    hosted_question = repo.create_realm_interaction_question(
+        hosted.id,
+        hosted_interaction.id,
+        "Where do you belong elsewhere?",
+    )
+    hosted_option = repo.create_realm_interaction_option(
+        hosted.id,
+        hosted_question.id,
+        "hosted-library",
+        "The hosted library",
     )
 
     response = repo.submit_realm_interaction_response(
@@ -1553,6 +1907,74 @@ def test_realm_interactions_are_scoped_and_accept_one_membership_response(
             hosted_membership.id,
             selected_option_ids={question.id: option.id},
         )
+    with pytest.raises(LookupError, match="character not found"):
+        repo.submit_realm_interaction_response(
+            default.id,
+            interaction.id,
+            default_membership.id,
+            character_id=hosted_character.id,
+            selected_option_ids={question.id: option.id},
+        )
+    other_user = repo.create_user("other-poll@example.com", "hash")
+    other_membership = repo.create_membership(
+        default.id,
+        other_user.id,
+        default_role.id,
+        "other-poll",
+        "Other Poll",
+    )
+    other_character = repo.create_character(
+        default.id,
+        other_membership.id,
+        "other-poll-face",
+        "Other Poll Face",
+    )
+    with pytest.raises(TenantBoundaryError, match="responding membership"):
+        repo.submit_realm_interaction_response(
+            default.id,
+            interaction.id,
+            default_membership.id,
+            character_id=other_character.id,
+            selected_option_ids={question.id: option.id},
+        )
+
+    answer_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM realm_interaction_answers
+        WHERE community_id = ? AND response_id = ?
+        """,
+        (default.id, response.id),
+    ).fetchone()["id"]
+    repo.connection.execute(
+        """
+        UPDATE realm_interaction_responses
+        SET character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_character.id, default.id, response.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE realm_interaction_answers
+        SET option_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_option.id, default.id, answer_id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("realm_interaction_responses", response.id)] == (
+        "realm interaction response character does not match community and membership"
+    )
+    assert issue_map[("realm_interaction_answers", answer_id)] == (
+        "realm interaction answer option does not match question"
+    )
 
 
 def test_claim_types_template_fields_and_character_claims_are_scoped(
@@ -1625,15 +2047,36 @@ def test_claim_types_template_fields_and_character_claims_are_scoped(
         maps_to_claim_type_id=default_face.id,
         is_required=True,
     )
+    faction_field = repo.create_application_template_field(
+        default.id,
+        "faction_claim",
+        "Faction claim",
+        field_type="text",
+        maps_to_claim_type_id=default_faction.id,
+    )
+    hosted_field = repo.create_application_template_field(
+        hosted.id,
+        "face_claim",
+        "Hosted face claim",
+        field_type="text",
+        maps_to_claim_type_id=hosted_face.id,
+    )
     application = repo.ensure_character_application(default.id, default_character.id)
+    hosted_application = repo.ensure_character_application(hosted.id, hosted_character.id)
     field_value = repo.set_application_field_value(
         default.id,
         application.id,
         field.id,
         "Sample Face",
     )
+    faction_field_value = repo.set_application_field_value(
+        default.id,
+        application.id,
+        faction_field.id,
+        "X-Men",
+    )
 
-    repo.create_character_claim(
+    face_claim = repo.create_character_claim(
         default.id,
         default_face.id,
         "sample-face",
@@ -1670,7 +2113,7 @@ def test_claim_types_template_fields_and_character_claims_are_scoped(
     )
     assert [
         value.value for value in repo.list_application_field_values(default.id, application.id)
-    ] == ["Sample Face"]
+    ] == ["Sample Face", "X-Men"]
     assert len(repo.list_character_claims(default.id, claim_type_id=default_faction.id)) == 2
     assert len(repo.list_character_claims(hosted.id, claim_type_id=hosted_face.id)) == 1
 
@@ -1693,6 +2136,58 @@ def test_claim_types_template_fields_and_character_claims_are_scoped(
         )
     with pytest.raises(LookupError, match="application not found"):
         repo.set_application_field_value(hosted.id, application.id, field.id, "Leak")
+
+    repo.connection.execute(
+        """
+        UPDATE application_template_fields
+        SET maps_to_claim_type_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_face.id, default.id, field.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE application_field_values
+        SET field_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_field.id, default.id, field_value.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE application_field_values
+        SET application_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_application.id, default.id, faction_field_value.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE character_claims
+        SET character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_character.id, default.id, face_claim.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("character_claims", face_claim.id)] == (
+        "character claim character belongs to another community"
+    )
+    assert issue_map[("application_template_fields", field.id)] == (
+        "application template field mapped claim type belongs to another community"
+    )
+    assert issue_map[("application_field_values", field_value.id)] == (
+        "application field value field belongs to another community"
+    )
+    assert issue_map[("application_field_values", faction_field_value.id)] == (
+        "application field value application belongs to another community"
+    )
 
 
 def test_schema_migrates_plot_hook_and_prospective_interest_columns() -> None:
@@ -1879,6 +2374,25 @@ def test_community_identity_accent_group_is_tenant_scoped(repo: ForumRepository)
     with pytest.raises(LookupError):
         repo.update_community_identity_accent_group(default.id, hosted_group.id)
 
+    repo.connection.execute(
+        """
+        UPDATE communities
+        SET identity_accent_facet_group_id = ?
+        WHERE id = ?
+        """,
+        (hosted_group.id, default.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("communities", default.id)] == (
+        "community identity accent facet group belongs to another community"
+    )
+
 
 def test_community_post_style_policy_is_tenant_scoped(repo: ForumRepository) -> None:
     default = repo.get_community(1)
@@ -1951,6 +2465,23 @@ def test_board_hierarchy_is_tenant_scoped(repo: ForumRepository) -> None:
             parent_board_id=hosted_parent.id,
         )
 
+    repo.connection.execute(
+        """
+        UPDATE boards
+        SET parent_board_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_parent.id, default.id, child.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("boards", child.id)] == "board parent belongs to another community"
+
 
 def test_board_cannot_parent_itself(repo: ForumRepository) -> None:
     community = repo.get_community(1)
@@ -1970,6 +2501,23 @@ def test_board_cannot_parent_itself(repo: ForumRepository) -> None:
             image_alt=board.image_alt,
             is_private=board.is_private,
         )
+
+    repo.connection.execute(
+        """
+        UPDATE boards
+        SET parent_board_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (board.id, community.id, board.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("boards", board.id)] == "board cannot be its own parent"
 
 
 def test_public_identity_is_membership_scoped(repo: ForumRepository) -> None:
@@ -2095,6 +2643,37 @@ def test_application_review_rooms_are_tenant_scoped(repo: ForumRepository) -> No
             actor_character_id=jean.id,
         )
     assert repo.get_role(default.id, default_membership.role_id).is_admin is False
+
+    event_id = events[0].id
+    repo.connection.execute(
+        """
+        UPDATE applications
+        SET membership_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_membership.id, default.id, submitted.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE application_events
+        SET actor_character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (jean.id, default.id, event_id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("applications", submitted.id)] == (
+        "application membership belongs to another community"
+    )
+    assert issue_map[("application_events", event_id)] == (
+        "application event actor character does not match community and membership"
+    )
 
 
 def test_characters_are_membership_owned_posting_identities(repo: ForumRepository) -> None:
@@ -2273,11 +2852,28 @@ def test_character_updates_are_scoped_by_community(repo: ForumRepository) -> Non
 
 def test_world_facets_scope_characters_boards_and_threads(repo: ForumRepository) -> None:
     community = repo.get_community(1)
+    hosted = repo.create_community("hosted-world-facets", "Hosted World Facets")
     role = repo.create_role(community.id, "member", "Member")
+    hosted_role = repo.create_role(hosted.id, "member", "Member")
     user = repo.create_user("writer@example.com", "hash")
+    hosted_user = repo.create_user("hosted-writer@example.com", "hash")
     membership = repo.create_membership(community.id, user.id, role.id, "writer", "Writer")
+    hosted_membership = repo.create_membership(
+        hosted.id,
+        hosted_user.id,
+        hosted_role.id,
+        "hosted-writer",
+        "Hosted Writer",
+    )
     rogue = repo.create_character(community.id, membership.id, "rogue", "Rogue")
+    hosted_character = repo.create_character(
+        hosted.id,
+        hosted_membership.id,
+        "hosted-rogue",
+        "Hosted Rogue",
+    )
     board = repo.create_board(community.id, "danger-room", "Danger Room")
+    hosted_board = repo.create_board(hosted.id, "danger-room", "Hosted Danger Room")
     thread = repo.create_thread(
         community.id, board.id, rogue.id, "sentinel-drill", "Sentinel Drill"
     )
@@ -2288,6 +2884,13 @@ def test_world_facets_scope_characters_boards_and_threads(repo: ForumRepository)
         "blackbird-briefing",
         "Blackbird Briefing",
     )
+    hosted_thread = repo.create_thread(
+        hosted.id,
+        hosted_board.id,
+        hosted_character.id,
+        "hosted-drill",
+        "Hosted Drill",
+    )
 
     species = repo.create_facet_group(community.id, "species", "Species", sort_order=10)
     affiliation = repo.create_facet_group(
@@ -2296,8 +2899,10 @@ def test_world_facets_scope_characters_boards_and_threads(repo: ForumRepository)
         "Affiliation",
         sort_order=20,
     )
+    hosted_group = repo.create_facet_group(hosted.id, "species", "Hosted Species")
     mutant = repo.create_facet(community.id, species.id, "mutant", "Mutant")
     x_men = repo.create_facet(community.id, affiliation.id, "x-men", "X-Men")
+    hosted_facet = repo.create_facet(hosted.id, hosted_group.id, "mutant", "Hosted Mutant")
 
     repo.assign_character_facet(community.id, rogue.id, mutant.id)
     repo.assign_character_facet(community.id, rogue.id, x_men.id)
@@ -2345,6 +2950,71 @@ def test_world_facets_scope_characters_boards_and_threads(repo: ForumRepository)
         thread.id,
         second_thread.id,
     }
+
+    character_assignment_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM character_facets
+        WHERE community_id = ? AND character_id = ? AND facet_id = ?
+        """,
+        (community.id, rogue.id, mutant.id),
+    ).fetchone()["id"]
+    board_assignment_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM board_facets
+        WHERE community_id = ? AND board_id = ? AND facet_id = ?
+        """,
+        (community.id, board.id, x_men.id),
+    ).fetchone()["id"]
+    thread_assignment_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM thread_facets
+        WHERE community_id = ? AND thread_id = ? AND facet_id = ?
+        """,
+        (community.id, thread.id, x_men.id),
+    ).fetchone()["id"]
+    repo.connection.execute(
+        """
+        UPDATE character_facets
+        SET character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_character.id, community.id, character_assignment_id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE board_facets
+        SET facet_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_facet.id, community.id, board_assignment_id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE thread_facets
+        SET thread_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_thread.id, community.id, thread_assignment_id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("character_facets", character_assignment_id)] == (
+        "character facet character belongs to another community"
+    )
+    assert issue_map[("board_facets", board_assignment_id)] == (
+        "board facet facet belongs to another community"
+    )
+    assert issue_map[("thread_facets", thread_assignment_id)] == (
+        "thread facet thread belongs to another community"
+    )
 
 
 def test_board_rollup_batch_reads_are_tenant_scoped(repo: ForumRepository) -> None:
@@ -2426,6 +3096,12 @@ def test_network_catalog_batch_reads_are_tenant_scoped(repo: ForumRepository) ->
         name="Catalog Theme",
         tokens_json="{}",
     )
+    other_theme = repo.upsert_default_theme(
+        other.id,
+        slug="catalog-theme",
+        name="Other Catalog Theme",
+        tokens_json="{}",
+    )
 
     assert repo.public_scene_hub_community_ids([community.id]) == {community.id}
     assert repo.list_materials_for_communities([community.id]) == {
@@ -2438,6 +3114,28 @@ def test_network_catalog_batch_reads_are_tenant_scoped(repo: ForumRepository) ->
     assert repo.list_facet_groups_for_communities([community.id]) == {community.id: [group]}
     assert repo.default_themes_for_communities([community.id]) == {community.id: theme}
     assert scene_hub.community_id == community.id
+
+    with pytest.raises(LookupError, match="theme not found"):
+        repo.set_default_theme(community.id, other_theme.id)
+
+    repo.connection.execute(
+        """
+        UPDATE communities
+        SET default_theme_id = ?
+        WHERE id = ?
+        """,
+        (other_theme.id, community.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("communities", community.id)] == (
+        "community default theme belongs to another community"
+    )
 
 
 def test_network_membership_counts_batch_application_state(repo: ForumRepository) -> None:
@@ -2495,7 +3193,7 @@ def test_world_materials_are_tenant_scoped_and_facet_tagged(repo: ForumRepositor
     default_group = repo.create_facet_group(default.id, "affiliation", "Affiliation")
     hosted_group = repo.create_facet_group(hosted.id, "affiliation", "Affiliation")
     x_men = repo.create_facet(default.id, default_group.id, "x-men", "X-Men")
-    repo.create_facet(hosted.id, hosted_group.id, "x-men", "X-Men Elsewhere")
+    hosted_x_men = repo.create_facet(hosted.id, hosted_group.id, "x-men", "X-Men Elsewhere")
 
     premise = repo.create_material(
         default.id,
@@ -2537,6 +3235,33 @@ def test_world_materials_are_tenant_scoped_and_facet_tagged(repo: ForumRepositor
     with pytest.raises(LookupError):
         repo.assign_material_facet(hosted.id, premise.id, x_men.id)
 
+    material_assignment_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM material_facets
+        WHERE community_id = ? AND material_id = ? AND facet_id = ?
+        """,
+        (default.id, premise.id, x_men.id),
+    ).fetchone()["id"]
+    repo.connection.execute(
+        """
+        UPDATE material_facets
+        SET facet_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_x_men.id, default.id, material_assignment_id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("material_facets", material_assignment_id)] == (
+        "material facet facet belongs to another community"
+    )
+
 
 def test_wanted_ads_are_tenant_scoped_and_facet_tagged(repo: ForumRepository) -> None:
     default = repo.get_community(1)
@@ -2568,7 +3293,9 @@ def test_wanted_ads_are_tenant_scoped_and_facet_tagged(repo: ForumRepository) ->
         "Rogue Elsewhere",
     )
     group = repo.create_facet_group(default.id, "affiliation", "Affiliation")
+    hosted_group = repo.create_facet_group(hosted.id, "affiliation", "Hosted Affiliation")
     x_men = repo.create_facet(default.id, group.id, "x-men", "X-Men")
+    hosted_x_men = repo.create_facet(hosted.id, hosted_group.id, "x-men", "Hosted X-Men")
 
     wanted = repo.create_wanted_ad(
         default.id,
@@ -2602,9 +3329,10 @@ def test_wanted_ads_are_tenant_scoped_and_facet_tagged(repo: ForumRepository) ->
         actor_membership_id=default_membership.id,
         actor_character_id=magneto.id,
     )
+    hosted_wanted = repo.get_wanted_ad_by_slug(hosted.id, "rogue-rival")
 
     assert repo.get_wanted_ad_by_slug(default.id, "rogue-rival").title == "Rogue rival"
-    assert repo.get_wanted_ad_by_slug(hosted.id, "rogue-rival").title == "Hosted rival"
+    assert hosted_wanted.title == "Hosted rival"
     assert [item.title for item in repo.list_wanted_ads(default.id)] == ["Rogue rival"]
     assert [facet.slug for facet in repo.list_wanted_ad_facets(default.id, wanted.id)] == ["x-men"]
     assert repo.list_wanted_ad_facets_for_wanted_ads(default.id, [wanted.id]) == {
@@ -2650,6 +3378,93 @@ def test_wanted_ads_are_tenant_scoped_and_facet_tagged(repo: ForumRepository) ->
             wanted_ad_id=wanted.id,
         )
 
+    wanted_facet_assignment_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM wanted_ad_facets
+        WHERE community_id = ? AND wanted_ad_id = ? AND facet_id = ?
+        """,
+        (default.id, wanted.id, x_men.id),
+    ).fetchone()["id"]
+    related_character_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM wanted_ad_related_characters
+        WHERE community_id = ? AND wanted_ad_id = ? AND character_id = ?
+        """,
+        (default.id, wanted.id, magneto.id),
+    ).fetchone()["id"]
+    repo.connection.execute(
+        """
+        UPDATE wanted_ad_facets
+        SET facet_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_x_men.id, default.id, wanted_facet_assignment_id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE wanted_ad_related_characters
+        SET character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_character.id, default.id, related_character_id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE character_reserves
+        SET membership_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_membership.id, default.id, reserve.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("character_reserves", reserve.id)] == (
+        "character reserve membership belongs to another community"
+    )
+    assert issue_map[("wanted_ad_facets", wanted_facet_assignment_id)] == (
+        "wanted hook facet facet belongs to another community"
+    )
+    assert issue_map[("wanted_ad_related_characters", related_character_id)] == (
+        "wanted related face character belongs to another community"
+    )
+
+    repo.connection.execute(
+        """
+        UPDATE wanted_ads
+        SET creator_character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_character.id, default.id, wanted.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE wanted_ad_interests
+        SET wanted_ad_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_wanted.id, default.id, interest.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("wanted_ads", wanted.id)] == (
+        "wanted hook creator character does not match community and membership"
+    )
+    assert issue_map[("wanted_ad_interests", interest.id)] == (
+        "wanted interest wanted hook belongs to another community"
+    )
+
 
 def test_plot_hooks_and_prospective_wanted_interest_are_tenant_scoped(
     repo: ForumRepository,
@@ -2680,7 +3495,9 @@ def test_plot_hooks_and_prospective_wanted_interest_are_tenant_scoped(
     gambit = repo.create_character(default.id, prospect.id, "gambit", "Gambit")
     hosted_character = repo.create_character(hosted.id, hosted_membership.id, "rogue", "Rogue")
     group = repo.create_facet_group(default.id, "affiliation", "Affiliation")
+    hosted_group = repo.create_facet_group(hosted.id, "affiliation", "Hosted Affiliation")
     x_men = repo.create_facet(default.id, group.id, "x-men", "X-Men")
+    hosted_x_men = repo.create_facet(hosted.id, hosted_group.id, "x-men", "Hosted X-Men")
 
     hook = repo.create_character_plot_hook(
         default.id,
@@ -2691,7 +3508,7 @@ def test_plot_hooks_and_prospective_wanted_interest_are_tenant_scoped(
         hook_type="relationship",
         summary="A pressure point.",
     )
-    repo.create_character_plot_hook(
+    hosted_hook = repo.create_character_plot_hook(
         hosted.id,
         hosted_membership.id,
         hosted_character.id,
@@ -2855,6 +3672,27 @@ def test_plot_hooks_and_prospective_wanted_interest_are_tenant_scoped(
             hosted_membership.id,
             "Wrong room.",
         )
+    with pytest.raises(LookupError):
+        repo.create_plotting_room_participant(
+            hosted.id,
+            room.id,
+            hosted_membership.id,
+            character_id=hosted_character.id,
+        )
+    with pytest.raises(LookupError):
+        repo.create_plotting_room_participant(
+            default.id,
+            room.id,
+            hosted_membership.id,
+            character_id=hosted_character.id,
+        )
+    with pytest.raises(TenantBoundaryError):
+        repo.create_plotting_room_participant(
+            default.id,
+            room.id,
+            owner.id,
+            character_id=gambit.id,
+        )
     with pytest.raises(TenantBoundaryError):
         repo.create_plotting_room_message(
             default.id,
@@ -2863,6 +3701,55 @@ def test_plot_hooks_and_prospective_wanted_interest_are_tenant_scoped(
             "Wrong face.",
             author_character_id=gambit.id,
         )
+
+    hook_facet_assignment_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM character_plot_hook_facets
+        WHERE community_id = ? AND plot_hook_id = ? AND facet_id = ?
+        """,
+        (default.id, hook.id, x_men.id),
+    ).fetchone()["id"]
+    repo.connection.execute(
+        """
+        UPDATE character_plot_hook_facets
+        SET facet_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_x_men.id, default.id, hook_facet_assignment_id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE character_plot_hooks
+        SET character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_character.id, default.id, hook.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE character_plot_hook_interests
+        SET plot_hook_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_hook.id, default.id, interest.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("character_plot_hooks", hook.id)] == (
+        "plot hook character does not match community and membership"
+    )
+    assert issue_map[("character_plot_hook_interests", interest.id)] == (
+        "plot hook interest hook belongs to another community"
+    )
+    assert issue_map[("character_plot_hook_facets", hook_facet_assignment_id)] == (
+        "plot hook facet facet belongs to another community"
+    )
 
 
 def test_plotting_room_participants_are_unique_for_nullable_identity(
@@ -3214,6 +4101,121 @@ def test_thread_reads_are_membership_scoped(repo: ForumRepository) -> None:
     assert repo.get_thread_read_at(default.id, thread.id, other_membership.id) is None
 
 
+def test_thread_read_and_watch_boundaries_are_tenant_scoped(repo: ForumRepository) -> None:
+    default = repo.get_community(1)
+    hosted = repo.create_community("hosted-thread-state", "Hosted Thread State")
+    default_role = repo.create_role(default.id, "member", "Member")
+    hosted_role = repo.create_role(hosted.id, "member", "Member")
+    default_membership = repo.create_membership(
+        default.id,
+        repo.create_user("thread-state@example.com", "hash").id,
+        default_role.id,
+        "thread-state",
+        "Thread State",
+    )
+    hosted_membership = repo.create_membership(
+        hosted.id,
+        repo.create_user("hosted-thread-state@example.com", "hash").id,
+        hosted_role.id,
+        "hosted-thread-state",
+        "Hosted Thread State",
+    )
+    default_character = repo.create_character(
+        default.id,
+        default_membership.id,
+        "thread-state",
+        "Thread State",
+    )
+    hosted_character = repo.create_character(
+        hosted.id,
+        hosted_membership.id,
+        "hosted-thread-state",
+        "Hosted Thread State",
+    )
+    default_board = repo.create_board(default.id, "thread-state", "Thread State")
+    hosted_board = repo.create_board(hosted.id, "thread-state", "Hosted Thread State")
+    default_thread = repo.create_thread(
+        default.id,
+        default_board.id,
+        default_character.id,
+        "thread-state",
+        "Thread State",
+    )
+    second_default_thread = repo.create_thread(
+        default.id,
+        default_board.id,
+        default_character.id,
+        "thread-state-two",
+        "Thread State Two",
+    )
+    hosted_thread = repo.create_thread(
+        hosted.id,
+        hosted_board.id,
+        hosted_character.id,
+        "hosted-thread-state",
+        "Hosted Thread State",
+    )
+
+    repo.mark_thread_read(default.id, default_thread.id, default_membership.id)
+    repo.mark_thread_read(default.id, second_default_thread.id, default_membership.id)
+    repo.watch_thread(default.id, default_thread.id, default_membership.id)
+    repo.watch_thread(default.id, second_default_thread.id, default_membership.id)
+
+    with pytest.raises(LookupError, match="thread not found"):
+        repo.unwatch_thread(default.id, hosted_thread.id, default_membership.id)
+    with pytest.raises(LookupError, match="membership not found"):
+        repo.unwatch_thread(default.id, default_thread.id, hosted_membership.id)
+    repo.unwatch_thread(default.id, default_thread.id, default_membership.id)
+    with pytest.raises(LookupError, match="thread watch not found"):
+        repo.get_thread_watch(default.id, default_thread.id, default_membership.id)
+
+    read_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM thread_reads
+        WHERE community_id = ? AND thread_id = ? AND membership_id = ?
+        """,
+        (default.id, second_default_thread.id, default_membership.id),
+    ).fetchone()["id"]
+    watch_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM thread_watches
+        WHERE community_id = ? AND thread_id = ? AND membership_id = ?
+        """,
+        (default.id, second_default_thread.id, default_membership.id),
+    ).fetchone()["id"]
+    repo.connection.execute(
+        """
+        UPDATE thread_reads
+        SET thread_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_thread.id, default.id, read_id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE thread_watches
+        SET membership_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_membership.id, default.id, watch_id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("thread_reads", read_id)] == (
+        "thread read thread belongs to another community"
+    )
+    assert issue_map[("thread_watches", watch_id)] == (
+        "thread watch membership belongs to another community"
+    )
+
+
 def test_post_revisions_are_scoped_by_community(repo: ForumRepository) -> None:
     default = repo.get_community(1)
     hosted = repo.create_community("hosted", "Hosted Test")
@@ -3268,6 +4270,13 @@ def test_post_revisions_are_scoped_by_community(repo: ForumRepository) -> None:
     ] == ["Elsewhere."]
     assert default_revision.community_id == default.id
     assert hosted_revision.community_id == hosted.id
+    editor_revision = repo.create_post_revision(
+        default.id,
+        default_post.id,
+        default_membership.id,
+        "After.",
+        "After with a typo fix.",
+    )
 
     with pytest.raises(LookupError):
         repo.create_post_revision(
@@ -3277,3 +4286,41 @@ def test_post_revisions_are_scoped_by_community(repo: ForumRepository) -> None:
             "Wrong.",
             "Wrong.",
         )
+    with pytest.raises(LookupError):
+        repo.create_post_revision(
+            default.id,
+            default_post.id,
+            hosted_membership.id,
+            "Wrong.",
+            "Wrong.",
+        )
+
+    repo.connection.execute(
+        """
+        UPDATE post_revisions
+        SET post_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_post.id, default.id, default_revision.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE post_revisions
+        SET editor_membership_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_membership.id, default.id, editor_revision.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("post_revisions", default_revision.id)] == (
+        "post revision post belongs to another community"
+    )
+    assert issue_map[("post_revisions", editor_revision.id)] == (
+        "post revision editor membership belongs to another community"
+    )


### PR DESCRIPTION
## Summary

This PR hardens Elbysodic's backend trust spine across storage, service orchestration, and regression proof.

- expands tenant-pair integrity diagnostics across board navigation, applications, claims/reserves/wanted hooks, posts/revisions, reads/watches, notifications, plotting rooms, facets, gateway slots, and related PBP primitives
- hardens repository transaction cleanup and request-scoped service cleanup on identity-resolution and commit failures
- moves more membership/role policy decisions into service/read-model boundaries instead of page handlers
- tightens notification read/mark-all behavior around membership visibility and plot-hook privacy
- constrains new thread participant tagging to taggable community roster characters plus the selected posting face
- adds backend contract regression tests for lifecycle cleanup, raw SQL/policy placement, and repository transaction recovery

## Why

The north star work surfaced a common backend risk: Elbysodic's product safety depends less on any one route and more on consistently preserving community, membership, character, staff, and privacy boundaries across every stored PBP primitive. This change makes those boundaries more explicit, easier to test, and harder to bypass from web handlers or corrupted stored state.

## Impact

Directors and staff get safer Realm Studio behavior around navigation, claims, notifications, and surfaced state. Writers get stronger protection against wrong-face participants, cross-community leakage, and private/staff notification visibility. Future Continuity Graph work gets a broader storage integrity scanner to build on before source-linked memory becomes more central.

## Validation

- `uv run pytest -q --tb=short`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`

## Steward Notes

- Consulted root constitution, Storage and Migration Steward, Test Steward, and Package and Tooling Steward.
- Accepted: repository diagnostics should cover cross-community and self-referential corruption for stored PBP primitives; proof lives in tenant repository tests.
- Accepted: request/transaction lifecycle cleanup should be executable contract proof; proof lives in `tests/test_backend_contracts.py`.
- Accepted: page handlers should not own policy decisions or raw SQL; proof lives in static backend contract tests.
- Collateral: no docs/changelog fragment because this is internal backend trust hardening with no public API, route, schema, migration, dependency, or user-facing copy change.
