### PR TITLE
Expand tenant integrity diagnostics

### DIFF
--- a/docs/architecture/data-integrity.md
+++ b/docs/architecture/data-integrity.md
@@ -15,6 +15,7 @@ High-risk tenant-paired rows include:
 - memberships and roles
 - characters and memberships
 - boards, threads, posts, and public authorship
+- command submissions and the membership that reserved the command
 - applications and review events
 - wanted hooks, interests, reserves, and claims
 - plotting rooms, participants, and messages
@@ -32,6 +33,10 @@ Use all three layers:
 
 Diagnostics are not a substitute for constraints. They are the repair and
 operations surface for old data, migrations, imports, and local demo databases.
+`ForumRepository.list_tenant_pair_integrity_issues()` is the shared repository
+diagnostic for tenant-paired creative and workflow rows, including membership
+roles, default faces, character ownership, command submissions, authorship,
+claims, plotting, thread state, and notifications.
 
 ## Session Selection
 

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -1630,6 +1630,70 @@ class IdentityRepositoryMixin(RepositoryBase):
                 UNION ALL
 
                 SELECT
+                    'community_memberships' AS table_name,
+                    membership.id AS row_id,
+                    membership.community_id,
+                    CASE
+                        WHEN role.id IS NULL THEN 'membership role belongs to another community'
+                        WHEN default_character.id IS NULL
+                            AND membership.default_character_id IS NOT NULL
+                            THEN 'membership default face belongs to another community'
+                        WHEN default_character.membership_id != membership.id
+                            THEN 'membership default face does not belong to membership'
+                        ELSE 'membership tenant pair is invalid'
+                    END AS reason
+                FROM community_memberships AS membership
+                LEFT JOIN roles AS role
+                    ON role.id = membership.role_id
+                    AND role.community_id = membership.community_id
+                LEFT JOIN characters AS default_character
+                    ON default_character.id = membership.default_character_id
+                    AND default_character.community_id = membership.community_id
+                WHERE role.id IS NULL
+                    OR (
+                        membership.default_character_id IS NOT NULL
+                        AND (
+                            default_character.id IS NULL
+                            OR default_character.membership_id != membership.id
+                        )
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'characters' AS table_name,
+                    character.id AS row_id,
+                    character.community_id,
+                    CASE
+                        WHEN membership.id IS NULL THEN 'character membership belongs to another community'
+                        ELSE 'character tenant pair is invalid'
+                    END AS reason
+                FROM characters AS character
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = character.membership_id
+                    AND membership.community_id = character.community_id
+                WHERE membership.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'command_submissions' AS table_name,
+                    command_submission.id AS row_id,
+                    command_submission.community_id,
+                    CASE
+                        WHEN membership.id IS NULL
+                            THEN 'command submission membership belongs to another community'
+                        ELSE 'command submission tenant pair is invalid'
+                    END AS reason
+                FROM command_submissions AS command_submission
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = command_submission.membership_id
+                    AND membership.community_id = command_submission.community_id
+                WHERE membership.id IS NULL
+
+                UNION ALL
+
+                SELECT
                     'threads' AS table_name,
                     thread.id AS row_id,
                     thread.community_id,

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -1346,6 +1346,157 @@ def test_membership_role_integrity_issues_detect_cross_community_roles(
     assert issues[0].membership_id == membership.id
     assert issues[0].role_id == default_role.id
 
+    tenant_issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert tenant_issue_map[("community_memberships", membership.id)] == (
+        "membership role belongs to another community"
+    )
+
+
+def test_identity_root_tenant_pair_integrity_detects_face_and_owner_drift(
+    repo: ForumRepository,
+) -> None:
+    default = repo.get_community(1)
+    hosted = repo.create_community("hosted-identity-roots", "Hosted Identity Roots")
+    default_role = repo.create_role(default.id, "member", "Member")
+    hosted_role = repo.create_role(hosted.id, "member", "Member")
+    default_user = repo.create_user("identity-roots@example.com", "hash")
+    other_default_user = repo.create_user("identity-roots-other@example.com", "hash")
+    hosted_user = repo.create_user("hosted-identity-roots@example.com", "hash")
+    default_membership = repo.create_membership(
+        default.id,
+        default_user.id,
+        default_role.id,
+        "identity-roots",
+        "Identity Roots",
+    )
+    other_default_membership = repo.create_membership(
+        default.id,
+        other_default_user.id,
+        default_role.id,
+        "identity-roots-other",
+        "Identity Roots Other",
+    )
+    hosted_membership = repo.create_membership(
+        hosted.id,
+        hosted_user.id,
+        hosted_role.id,
+        "hosted-identity-roots",
+        "Hosted Identity Roots",
+    )
+    default_character = repo.create_character(
+        default.id,
+        default_membership.id,
+        "identity-roots",
+        "Identity Roots",
+    )
+    hosted_character = repo.create_character(
+        hosted.id,
+        hosted_membership.id,
+        "hosted-identity-roots",
+        "Hosted Identity Roots",
+    )
+
+    repo.connection.execute(
+        """
+        UPDATE community_memberships
+        SET default_character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_character.id, default.id, default_membership.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE community_memberships
+        SET default_character_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (default_character.id, default.id, other_default_membership.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE characters
+        SET membership_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (default_membership.id, hosted.id, hosted_character.id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("community_memberships", default_membership.id)] == (
+        "membership default face belongs to another community"
+    )
+    assert issue_map[("community_memberships", other_default_membership.id)] == (
+        "membership default face does not belong to membership"
+    )
+    assert issue_map[("characters", hosted_character.id)] == (
+        "character membership belongs to another community"
+    )
+
+
+def test_command_submissions_are_reported_by_tenant_pair_integrity(
+    repo: ForumRepository,
+) -> None:
+    default = repo.get_community(1)
+    hosted = repo.create_community("hosted-command-integrity", "Hosted Command Integrity")
+    default_role = repo.create_role(default.id, "member", "Member")
+    hosted_role = repo.create_role(hosted.id, "member", "Member")
+    default_membership = repo.create_membership(
+        default.id,
+        repo.create_user("command-integrity@example.com", "hash").id,
+        default_role.id,
+        "command-integrity",
+        "Command Integrity",
+    )
+    hosted_membership = repo.create_membership(
+        hosted.id,
+        repo.create_user("hosted-command-integrity@example.com", "hash").id,
+        hosted_role.id,
+        "hosted-command-integrity",
+        "Hosted Command Integrity",
+    )
+    assert repo.reserve_command_submission(
+        default.id,
+        default_membership.id,
+        command_key="thread:reply",
+        token=token_hex(16),
+    )
+    command_submission_id = repo.connection.execute(
+        """
+        SELECT id
+        FROM command_submissions
+        WHERE community_id = ? AND membership_id = ?
+        """,
+        (default.id, default_membership.id),
+    ).fetchone()["id"]
+
+    repo.connection.execute(
+        """
+        UPDATE command_submissions
+        SET membership_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_membership.id, default.id, command_submission_id),
+    )
+    repo.connection.commit()
+
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("command_submissions", command_submission_id)] == (
+        "command submission membership belongs to another community"
+    )
+
 
 def test_session_identity_integrity_issues_detect_cross_community_selection(
     repo: ForumRepository,


### PR DESCRIPTION
## Summary
- extend the shared tenant-pair integrity diagnostic to report membership role/default-face drift, character ownership drift, and command-submission membership drift
- add regression tests that corrupt those pairs directly and prove the diagnostic reports the right table, row, community, and reason
- update the data-integrity architecture note to name command submissions and the shared diagnostic contract

## Steward Notes
- Steward: Storage, services, tests, docs, and Surface Contract Steward context from the tenant/data-integrity backlog.
- Accepted: keep this first #55 PR schema-neutral and diagnostic-focused so it does not cross the migration/data-model stop-and-ask line.
- Deferred: composite constraints/triggers and repair migrations for these pairs remain future #55 work and should be approved before implementation.
- Proof: focused tenant repository tests plus full local gates passed.

## Validation
- uv run pytest tests/test_tenant_repository.py -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
- uv run pytest -q --tb=short

Refs #55