### PR TITLE
Clear selected session identity on logout

### DIFF
--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -73,6 +73,8 @@ Production request identity is session-backed:
 - dev identity headers are ignored
 - unsigned `elbysodic_dev_identity` cookies are ignored and are not issued
 - `/dev/personas` is unavailable even when `ELBYSODIC_DEV_TOOLS` is set
+- logout revokes the stored session and clears its selected community and
+  membership so stale cookies cannot carry forward active realm identity state
 
 The logged-out `/` and `/network` surfaces use public catalog read models.
 They can show realm names, public premise or current-event summaries, public

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -861,7 +861,9 @@ class IdentityRepositoryMixin(RepositoryBase):
         self.connection.execute(
             """
             UPDATE user_sessions
-            SET revoked_at = COALESCE(revoked_at, ?)
+            SET revoked_at = COALESCE(revoked_at, ?),
+                selected_community_id = NULL,
+                selected_membership_id = NULL
             WHERE token_hash = ?
             """,
             (_utc_now(), token_hash),

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -1296,10 +1296,24 @@ def test_thread_counts_are_scoped_to_board_and_community() -> None:
 
 def test_user_sessions_can_be_created_touched_and_revoked(repo: ForumRepository) -> None:
     user = repo.create_user("session@example.com", "hash")
+    community = repo.get_community(1)
+    role = repo.create_role(community.id, "session-member", "Session Member")
+    membership = repo.create_membership(
+        community.id,
+        user.id,
+        role.id,
+        "session-member",
+        "Session Member",
+    )
     session = repo.create_user_session(
         user.id,
         "abc123",
         expires_at="2026-06-01T00:00:00+00:00",
+    )
+    repo.update_user_session_identity(
+        session.id,
+        community_id=community.id,
+        membership_id=membership.id,
     )
 
     stored = repo.get_user_session_by_token_hash("abc123")
@@ -1309,8 +1323,12 @@ def test_user_sessions_can_be_created_touched_and_revoked(repo: ForumRepository)
 
     assert stored.user_id == user.id
     assert stored.expires_at == "2026-06-01T00:00:00+00:00"
+    assert stored.selected_community_id == community.id
+    assert stored.selected_membership_id == membership.id
     assert touched.last_seen_at >= session.last_seen_at
     assert revoked.revoked_at is not None
+    assert revoked.selected_community_id is None
+    assert revoked.selected_membership_id is None
 
 
 def test_membership_role_integrity_issues_detect_cross_community_roles(

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -10,6 +10,7 @@ from chirp.testing import TestClient
 
 from elbysodic.db.repositories.discovery import DiscoveryTagInput
 from elbysodic.services import create_services
+from elbysodic.services.auth import session_token_hash
 from elbysodic.services.network import search_studio_network
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
@@ -1037,6 +1038,9 @@ def test_production_release_smoke_core_user_flow(monkeypatch) -> None:
                 "/studio",
                 headers={"Cookie": f"elbysodic_session={original_session}"},
             )
+            revoked_session = services.repo.get_user_session_by_token_hash(
+                session_token_hash(original_session)
+            )
 
         assert health.status == 200
         assert public_root.status == 200
@@ -1084,6 +1088,9 @@ def test_production_release_smoke_core_user_flow(monkeypatch) -> None:
         assert dict(studio_after_logout.headers)["location"] == "/login?next=/studio"
         assert studio_with_stale_session.status == 302
         assert dict(studio_with_stale_session.headers)["location"] == "/login?next=/studio"
+        assert revoked_session.revoked_at is not None
+        assert revoked_session.selected_community_id is None
+        assert revoked_session.selected_membership_id is None
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- clear selected community and membership ids when a user session is revoked on logout
- prove repository revocation removes selected identity state after a session had an active realm membership
- extend the production release smoke test to assert stale-session replay redirects and the stored session no longer carries selected identity
- document the logout/session revocation contract in the security boundary guide

## Steward Notes
- Steward: Auth/security, storage, services, tests, docs.
- Accepted: this PR keeps the #54 slice narrow around logout revocation and selected identity cleanup.
- Deferred: session renewal, operational auth diagnostics, broader CSRF matrix expansion, and Railway live smoke remain future #54 work.
- Proof: repository session test, rendered production smoke, full local gates.

## Validation
- uv run pytest tests/test_tenant_repository.py::test_user_sessions_can_be_created_touched_and_revoked -q --tb=short
- uv run pytest tests/test_web_security.py::test_production_release_smoke_core_user_flow -q --tb=short
- uv run pytest tests/test_tenant_repository.py tests/test_web_security.py -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
- uv run pytest -q --tb=short

Refs #54