### PR TITLE
Discard failed command reservations

### DIFF
--- a/docs/architecture/request-identity-and-command-protocol.md
+++ b/docs/architecture/request-identity-and-command-protocol.md
@@ -58,6 +58,12 @@ Commands that create posts, scenes, rooms, reserves, claims, applications,
 notifications, or identity transitions need either idempotency or a deliberate
 duplicate policy.
 
+When a command-token form reserves a server idempotency key and then fails
+before producing the canonical result path, the incomplete reservation must be
+discarded. Validation errors, stale actor failures, and rolled-back service
+exceptions should let the same rendered key retry the corrected command instead
+of becoming a permanent no-result duplicate.
+
 Chirp `_actions.py` dispatch may be used as transport plumbing for command
 routing only after the action path preserves request-scoped services. Elbysodic
 commands must still resolve tenant, membership, active face, and staff power

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -2660,6 +2660,29 @@ class IdentityRepositoryMixin(RepositoryBase):
         )
         self._commit()
 
+    def discard_command_submission(
+        self,
+        community_id: int,
+        membership_id: int,
+        *,
+        command_key: str,
+        token: str,
+    ) -> bool:
+        self.get_membership(community_id, membership_id)
+        cursor = self.connection.execute(
+            """
+            DELETE FROM command_submissions
+            WHERE community_id = ?
+                AND membership_id = ?
+                AND command_key = ?
+                AND token_hash = ?
+                AND result_path IS NULL
+            """,
+            (community_id, membership_id, command_key, _command_token_hash(token)),
+        )
+        self._commit()
+        return cursor.rowcount > 0
+
     def search_memberships(
         self,
         community_id: int,

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -820,6 +820,17 @@ class AppServices:
             result_path=result_path,
         )
 
+    def discard_command(self, command_key: str, token: str) -> None:
+        if not token:
+            return
+        viewer = self.viewer()
+        self.repo.discard_command_submission(
+            viewer.community.id,
+            viewer.membership.id,
+            command_key=command_key,
+            token=token,
+        )
+
     def recovery_view(self, *, kind: RecoveryKind, slug: str) -> RecoveryView:
         return _recovery_view(self.repo, self.viewer(), kind=kind, slug=slug)
 

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py
@@ -54,6 +54,7 @@ async def post(request: Request, board_slug: str) -> Page | Redirect:
             participant_ids=participant_ids,
         )
     except (LookupError, PermissionError, ValueError) as exc:
+        services.discard_command(command_key, key)
         return _render_form(
             request,
             board_slug,
@@ -68,6 +69,9 @@ async def post(request: Request, board_slug: str) -> Page | Redirect:
             posting_mode=posting_mode,
             body=body,
         )
+    except Exception:
+        services.discard_command(command_key, key)
+        raise
 
     result_path = (
         f"/boards/{board_slug}/threads/{created.thread.slug}#post-{created.post.post_number}"

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py
@@ -118,6 +118,7 @@ async def post(request: Request, board_slug: str, thread_slug: str) -> Page | Re
     try:
         post = services.reply_to_thread(board_slug, thread_slug, character_id, body)
     except (LookupError, PermissionError, ValueError) as exc:
+        services.discard_command(command_key, key)
         return _render_thread(
             request,
             board_slug,
@@ -126,6 +127,9 @@ async def post(request: Request, board_slug: str, thread_slug: str) -> Page | Re
             body=body,
             selected_character_id=character_id,
         )
+    except Exception:
+        services.discard_command(command_key, key)
+        raise
 
     result_path = f"{request.path}#post-{post.post_number}"
     services.complete_command(command_key, key, result_path)

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -11692,6 +11692,59 @@ def test_start_thread_creates_opening_post_as_selected_character() -> None:
     asyncio.run(run())
 
 
+def test_start_thread_validation_error_discards_idempotency_reservation() -> None:
+    async def run() -> None:
+        app = _app()
+        services = get_services()
+        character = services.viewer().current_character
+        assert character is not None
+
+        async with TestClient(app) as client:
+            form = await client.get("/boards/danger-room/threads/new")
+            key = _input_value(form.text, "idempotency_key")
+            invalid = await client.post(
+                "/boards/danger-room/threads/new",
+                body=urlencode(
+                    {
+                        "character_id": character.id,
+                        "title": "",
+                        "body": "This body should not reserve the command forever.",
+                        "idempotency_key": key,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            corrected = await client.post(
+                "/boards/danger-room/threads/new",
+                body=urlencode(
+                    {
+                        "character_id": character.id,
+                        "title": "Retryable Scene Command",
+                        "body": "The corrected scene can reuse the rendered key.",
+                        "idempotency_key": key,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+
+        assert invalid.status == 200
+        assert "thread title is required" in invalid.text
+        assert corrected.status == 302
+        assert dict(corrected.headers)["location"].startswith(
+            "/boards/danger-room/threads/retryable-scene-command#post-"
+        )
+        board = services.repo.get_board_by_slug(services.seed.community.id, "danger-room")
+        thread = services.repo.get_thread_by_slug(
+            services.seed.community.id,
+            board.id,
+            "retryable-scene-command",
+        )
+        posts = services.repo.list_posts(services.seed.community.id, thread.id)
+        assert [post.body for post in posts] == ["The corrected scene can reuse the rendered key."]
+
+    asyncio.run(run())
+
+
 def test_reply_idempotency_key_prevents_duplicate_posts() -> None:
     async def run() -> None:
         app = _app()
@@ -11740,6 +11793,55 @@ def test_reply_idempotency_key_prevents_duplicate_posts() -> None:
         posts = repo.list_posts(community.id, thread.id)
         assert len(posts) == before_count + 1
         assert posts[-1].body == "Rogue checks the duplicate-submit guard."
+
+    asyncio.run(run())
+
+
+def test_reply_validation_error_discards_idempotency_reservation() -> None:
+    async def run() -> None:
+        app = _app()
+        services = get_services()
+        repo = services.repo
+        community = services.seed.community
+        board = repo.get_board_by_slug(community.id, "danger-room")
+        thread = repo.get_thread_by_slug(community.id, board.id, "sentinel-drill")
+        character = services.viewer().current_character
+        assert character is not None
+        before_count = len(repo.list_posts(community.id, thread.id))
+
+        async with TestClient(app) as client:
+            page = await client.get("/boards/danger-room/threads/sentinel-drill")
+            key = _input_value(page.text, "idempotency_key")
+            invalid = await client.post(
+                "/boards/danger-room/threads/sentinel-drill",
+                body=urlencode(
+                    {
+                        "character_id": str(character.id),
+                        "body": "",
+                        "idempotency_key": key,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            corrected = await client.post(
+                "/boards/danger-room/threads/sentinel-drill",
+                body=urlencode(
+                    {
+                        "character_id": str(character.id),
+                        "body": "Rogue retries after a validation miss.",
+                        "idempotency_key": key,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+
+        assert invalid.status == 200
+        assert "reply body is required" in invalid.text
+        assert corrected.status == 302
+        assert dict(corrected.headers)["location"].endswith(f"#post-{before_count + 1}")
+        posts = repo.list_posts(community.id, thread.id)
+        assert len(posts) == before_count + 1
+        assert posts[-1].body == "Rogue retries after a validation miss."
 
     asyncio.run(run())
 

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -1313,6 +1313,78 @@ def test_user_sessions_can_be_created_touched_and_revoked(repo: ForumRepository)
     assert revoked.revoked_at is not None
 
 
+def test_incomplete_command_submissions_can_be_discarded_for_retry(
+    repo: ForumRepository,
+) -> None:
+    community = repo.get_community(1)
+    role = repo.create_role(community.id, "command-member", "Command Member")
+    membership = repo.create_membership(
+        community.id,
+        repo.create_user("command-retry@example.com", "hash").id,
+        role.id,
+        "command-member",
+        "Command Member",
+    )
+    token = token_hex(16)
+
+    assert repo.reserve_command_submission(
+        community.id,
+        membership.id,
+        command_key="reply:danger-room:sentinel-drill",
+        token=token,
+    )
+    assert not repo.reserve_command_submission(
+        community.id,
+        membership.id,
+        command_key="reply:danger-room:sentinel-drill",
+        token=token,
+    )
+    assert repo.discard_command_submission(
+        community.id,
+        membership.id,
+        command_key="reply:danger-room:sentinel-drill",
+        token=token,
+    )
+    assert (
+        repo.get_command_submission(
+            community.id,
+            membership.id,
+            command_key="reply:danger-room:sentinel-drill",
+            token=token,
+        )
+        is None
+    )
+    assert repo.reserve_command_submission(
+        community.id,
+        membership.id,
+        command_key="reply:danger-room:sentinel-drill",
+        token=token,
+    )
+    repo.complete_command_submission(
+        community.id,
+        membership.id,
+        command_key="reply:danger-room:sentinel-drill",
+        token=token,
+        result_path="/boards/danger-room/threads/sentinel-drill#post-4",
+    )
+
+    assert not repo.discard_command_submission(
+        community.id,
+        membership.id,
+        command_key="reply:danger-room:sentinel-drill",
+        token=token,
+    )
+    completed = repo.get_command_submission(
+        community.id,
+        membership.id,
+        command_key="reply:danger-room:sentinel-drill",
+        token=token,
+    )
+
+    assert completed is not None
+    assert completed.result_path == "/boards/danger-room/threads/sentinel-drill#post-4"
+
+
 def test_membership_role_integrity_issues_detect_cross_community_roles(
     repo: ForumRepository,
 ) -> None:


### PR DESCRIPTION
## Summary
- add repository/service support for discarding incomplete command submissions while preserving completed idempotency results
- discard reserved command tokens when start-thread or reply validation/stale-command handling fails before a result path is produced
- add repository and rendered regression tests proving corrected retries can reuse the same rendered idempotency key
- document the retry rule in the request identity and command protocol

## Steward Notes
- Steward: Service, storage, tests, docs, and command/surface contract concerns.
- Accepted: this PR targets the no-result reservation dead-end for rendered command-token forms.
- Deferred: broader rollback work for wanted-to-plotting, plotting-to-scene, application acceptance, and live stale command matrices remains future #56 work.
- Proof: repository command lifecycle test, rendered start-thread/reply retry tests, existing duplicate-submit tests, full local gates.

## Validation
- uv run pytest tests/test_tenant_repository.py::test_incomplete_command_submissions_can_be_discarded_for_retry -q --tb=short
- uv run pytest tests/test_forum_slice.py::test_start_thread_validation_error_discards_idempotency_reservation tests/test_forum_slice.py::test_reply_validation_error_discards_idempotency_reservation tests/test_forum_slice.py::test_start_thread_creates_opening_post_as_selected_character tests/test_forum_slice.py::test_reply_idempotency_key_prevents_duplicate_posts -q --tb=short
- uv run pytest tests/test_tenant_repository.py tests/test_forum_slice.py -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
- uv run pytest -q --tb=short

Refs #56