### PR TITLE
Link duplicate access requests to accounts

### DIFF
--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -107,6 +107,12 @@ active-face state. Public realm previews may submit a request and show
 account-vs-anonymous posture, but only director-capable memberships in the same
 community can list or inspect request details.
 
+Duplicate open access requests are deduplicated by email inside one community.
+If a later duplicate arrives from a signed-in account for the same email, the
+existing anonymous request may link `account_user_id`; it must not create a
+second request or grant membership, role, face, invite, reserve, claim, session,
+or active-face state.
+
 The access-request lifecycle is `pending -> reviewed -> invited` or
 `pending/reviewed -> declined`. An invited request may link to the invitation
 row that was created from it, but the raw invite token is still shown only at

--- a/docs/operations/invite-only-alpha.md
+++ b/docs/operations/invite-only-alpha.md
@@ -35,6 +35,9 @@ replica, and explicit smoke evidence before writers are invited.
   pending, use `Reissue invitation` to revoke it and create a fresh invitation
   for the same email.
 - Confirm expired, revoked, and accepted links do not grant access.
+- If a prospect submitted request-access before logging in, a later signed-in
+  duplicate for the same email should link that account to the existing open
+  request instead of creating a second queue item or granting membership.
 
 ### Invitation Delivery Policy
 

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -1132,6 +1132,30 @@ class IdentityRepositoryMixin(RepositoryBase):
         )
         return None if row is None else _community_access_request_from_row(row)
 
+    def link_community_access_request_account_user(
+        self,
+        community_id: int,
+        request_id: int,
+        account_user_id: int,
+    ) -> CommunityAccessRequest:
+        access_request = self.get_community_access_request(community_id, request_id)
+        self.get_user(account_user_id)
+        if access_request.account_user_id is not None:
+            if access_request.account_user_id != account_user_id:
+                raise PermissionError("access request is already linked to another account")
+            return access_request
+        self.connection.execute(
+            """
+            UPDATE community_access_requests
+            SET account_user_id = ?,
+                updated_at = ?
+            WHERE community_id = ? AND id = ?
+            """,
+            (account_user_id, _utc_now(), community_id, request_id),
+        )
+        self._commit()
+        return self.get_community_access_request(community_id, request_id)
+
     def update_community_access_request_status(
         self,
         community_id: int,

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -1039,6 +1039,12 @@ class AppServices:
             email=clean_email[:240],
         )
         if existing is not None:
+            if account_user_id is not None and existing.account_user_id is None:
+                return self.repo.link_community_access_request_account_user(
+                    community.id,
+                    existing.id,
+                    account_user_id,
+                )
             return existing
         return self.repo.create_community_access_request(
             community.id,

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -4050,6 +4050,7 @@ def test_studio_launch_moderates_access_requests() -> None:
 
 def test_access_request_submission_reuses_open_request_for_email() -> None:
     services = create_services(path=":memory:")
+    account = services.repo.create_user("prospect@example.com", "hash")
 
     first = services.create_access_request(
         "afterlight-accord",
@@ -4066,13 +4067,17 @@ def test_access_request_submission_reuses_open_request_for_email() -> None:
         face_concept="Forbidden envoy",
         wanted_hook="Transit gate",
         notes="Second note.",
+        account_user_id=account.id,
     )
     community = services.repo.get_community_by_slug("afterlight-accord")
 
-    assert second == first
-    assert services.repo.list_community_access_requests(community.id) == [first]
-    assert first.email == "prospect@example.com"
-    assert first.display_name == "Prospect One"
+    assert second.id == first.id
+    assert second.account_user_id == account.id
+    assert services.repo.list_community_access_requests(community.id) == [second]
+    assert second.email == "prospect@example.com"
+    assert second.display_name == "Prospect One"
+    with pytest.raises(LookupError):
+        services.repo.get_membership_for_user(community.id, account.id)
 
 
 def test_director_reads_access_request_detail() -> None:

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -750,6 +750,47 @@ def test_community_access_request_status_transitions(repo: ForumRepository) -> N
         )
 
 
+def test_access_request_account_linking_preserves_existing_open_request(
+    repo: ForumRepository,
+) -> None:
+    default = repo.get_community(1)
+    user = repo.create_user("linked-request@example.com", "hash")
+    access_request = repo.create_community_access_request(
+        default.id,
+        email="linked-request@example.com",
+        display_name="Anonymous Prospect",
+        face_concept="Archive thief",
+        wanted_hook="Sealed branch",
+        notes="Submitted before logging in.",
+    )
+
+    linked = repo.link_community_access_request_account_user(
+        default.id,
+        access_request.id,
+        user.id,
+    )
+    linked_again = repo.link_community_access_request_account_user(
+        default.id,
+        access_request.id,
+        user.id,
+    )
+
+    assert linked.id == access_request.id
+    assert linked.account_user_id == user.id
+    assert linked_again == linked
+    assert repo.list_community_access_requests(default.id) == [linked]
+    assert (
+        repo.find_open_community_access_request(default.id, email="linked-request@example.com")
+        == linked
+    )
+    with pytest.raises(PermissionError, match="already linked"):
+        repo.link_community_access_request_account_user(
+            default.id,
+            access_request.id,
+            repo.create_user("other-linked-request@example.com", "hash").id,
+        )
+
+
 def test_discovery_profiles_and_tags_are_tenant_scoped(repo: ForumRepository) -> None:
     default = repo.get_community(1)
     hosted = repo.create_community("discovery-hosted", "Discovery Hosted")

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -397,6 +397,64 @@ def test_production_signed_in_non_member_sees_account_posture_on_public_realm(
     asyncio.run(run())
 
 
+def test_production_signed_in_duplicate_access_request_links_existing_record(
+    monkeypatch,
+) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        services = create_services(path=":memory:")
+        community = services.repo.get_community_by_slug("afterlight-accord")
+        existing = services.repo.create_community_access_request(
+            community.id,
+            email="moira@example.com",
+            display_name="Anonymous Moira",
+            face_concept="Archivist with a sealed branch",
+            wanted_hook="Archive thief",
+            notes="Submitted before logging in.",
+        )
+        app = create_app(debug=False, services=services)
+
+        async with TestClient(app) as client:
+            _login, cookies = await _production_login(client, email="moira@example.com")
+            request_access = await client.get(
+                "/c/afterlight-accord/request-access",
+                headers={"Cookie": _cookie_header(cookies)},
+            )
+            request_cookies = {**cookies, **_cookie_values(request_access)}
+            response = await client.post(
+                "/request-access",
+                body=urlencode(
+                    {
+                        "community_slug": "afterlight-accord",
+                        "display_name": "Moira",
+                        "face_concept": "Archivist with a sealed branch",
+                        "wanted_hook": "Archive thief",
+                        "notes": "Link this request to my account.",
+                        "_csrf_token": _csrf_token(request_access.text),
+                    }
+                ).encode(),
+                headers={**_FORM, "Cookie": _cookie_header(request_cookies)},
+            )
+
+        requests = [
+            item
+            for item in services.repo.list_community_access_requests(community.id)
+            if item.email == "moira@example.com"
+        ]
+        moira = services.repo.get_user_by_email("moira@example.com")
+
+        assert response.status == 200
+        assert "Access request received for your Elbysodic account" in response.text
+        assert len(requests) == 1
+        assert requests[0].id == existing.id
+        assert requests[0].account_user_id == moira.id
+        assert requests[0].display_name == "Anonymous Moira"
+        with pytest.raises(LookupError):
+            services.repo.get_membership_for_user(community.id, moira.id)
+
+    asyncio.run(run())
+
+
 def test_production_signed_out_public_realm_keeps_anonymous_posture(monkeypatch) -> None:
     async def run() -> None:
         _set_production_env(monkeypatch)


### PR DESCRIPTION
## Summary
- link an existing open anonymous access request to a signed-in account when a duplicate request arrives for the same email
- keep duplicate handling tenant/email scoped without creating membership, role, face, invite, reserve, claim, session, or active-face state
- add repository, service, and rendered production tests for the account-linking duplicate path
- update security and invite-only runbook docs with the duplicate request rule

## Steward Notes
- Steward: Onboarding/product, security, storage, service, tests, docs.
- Accepted: this PR hardens duplicate request-access behavior and preserves the invitation-only boundary.
- Deferred: re-open/reissue policy details, first-application linkage, sender/email policy, and broader first-face activation state remain future #57 work.
- Proof: repository link test, service duplicate test, rendered production signed-in duplicate test, full local gates.

## Validation
- uv run pytest tests/test_tenant_repository.py::test_access_request_account_linking_preserves_existing_open_request -q --tb=short
- uv run pytest tests/test_forum_slice.py::test_access_request_submission_reuses_open_request_for_email -q --tb=short
- uv run pytest tests/test_web_security.py::test_production_signed_in_duplicate_access_request_links_existing_record -q --tb=short
- uv run pytest tests/test_tenant_repository.py tests/test_forum_slice.py tests/test_web_security.py -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
- uv run pytest -q --tb=short

Refs #57