### PR TITLE
Derive Blueprint apply readiness from preflight diffs

### DIFF
--- a/docs/product/program-blueprints.md
+++ b/docs/product/program-blueprints.md
@@ -304,7 +304,10 @@ for Studio intake, plus the privileged seed-data source used by development
 fixtures.
 Studio may accept an apply-shaped POST only as a guarded no-op: it must re-run
 preview, reject stale fingerprints, enter the transaction boundary, and return
-that apply is still gated without writing rows.
+that apply is still gated without writing rows. The readiness review shown with
+that gate is diff-aware: it summarizes create, update, skip, blocked, and
+warning counts, and it names skipped live face or wanted-hook collisions that
+need explicit update semantics before real apply can be enabled.
 
 ## Hydration Gate
 
@@ -316,6 +319,8 @@ Keep apply disabled until the hydrator has an explicit service-layer plan for:
 - rollback behavior when a later object fails after earlier objects validate
 - tenant tests that prove every created object stays in the selected community
 - a dry-run diff that names create, update, and skipped objects before mutation
+- an apply readiness review that derives from the accepted diff instead of a
+  generic checklist
 
 Until those pieces exist, Studio intake should keep saying that preview is a
 hydration gate, not a launch button.

--- a/src/elbysodic/services/blueprints.py
+++ b/src/elbysodic/services/blueprints.py
@@ -66,16 +66,28 @@ def preview_program_blueprint(
 def program_blueprint_apply_readiness(
     preview: ProgramBlueprintPreview | None,
 ) -> BlueprintApplyReadiness:
+    if preview is None:
+        return BlueprintApplyReadiness(
+            can_check_gate=False,
+            items=("Preview a valid Program Blueprint before checking the apply gate.",),
+        )
+    if not preview.is_valid:
+        return BlueprintApplyReadiness(
+            can_check_gate=False,
+            items=("Resolve validation notes before checking the apply gate.",),
+        )
+    action_counts = _diff_action_counts(preview.diff_rows)
+    items = [
+        _diff_action_readiness_summary(action_counts),
+        _collision_readiness_summary(preview.diff_rows),
+        "Duplicate handling must stay tenant-scoped.",
+        "Starter faces need explicit ownership defaults.",
+        "Hydration must run inside one rollback-tested transaction.",
+        "Unsupported keys must remain visible before apply.",
+    ]
     return BlueprintApplyReadiness(
-        can_check_gate=bool(
-            preview is not None and preview.is_valid and preview.preview_fingerprint
-        ),
-        items=(
-            "Duplicate handling must stay tenant-scoped.",
-            "Starter faces need explicit ownership defaults.",
-            "Hydration must run inside one rollback-tested transaction.",
-            "Unsupported keys must remain visible before apply.",
-        ),
+        can_check_gate=bool(preview.preview_fingerprint),
+        items=tuple(items),
     )
 
 
@@ -302,3 +314,34 @@ def _preview_fingerprint(source: str, rows: tuple[BlueprintDiffRow, ...]) -> str
         digest.update(b"\0")
         digest.update(row.detail.encode("utf-8"))
     return digest.hexdigest()[:16]
+
+
+def _diff_action_counts(rows: tuple[BlueprintDiffRow, ...]) -> dict[str, int]:
+    return {
+        action: sum(1 for row in rows if row.action == action)
+        for action in ("create", "update", "skip", "blocked", "warning")
+    }
+
+
+def _diff_action_readiness_summary(action_counts: dict[str, int]) -> str:
+    return (
+        "Preflight resolved "
+        f"{action_counts['create']} create, "
+        f"{action_counts['update']} update, "
+        f"{action_counts['skip']} skip, "
+        f"{action_counts['blocked']} blocked, and "
+        f"{action_counts['warning']} warning actions."
+    )
+
+
+def _collision_readiness_summary(rows: tuple[BlueprintDiffRow, ...]) -> str:
+    skipped_collisions = [
+        row for row in rows if row.action == "skip" and row.section in {"face", "wanted hook"}
+    ]
+    if not skipped_collisions:
+        return "No live face or wanted-hook collisions need explicit update mode."
+    labels = ", ".join(f"{row.section}: {row.label}" for row in skipped_collisions[:3])
+    overflow = len(skipped_collisions) - 3
+    if overflow > 0:
+        labels = f"{labels}, and {overflow} more"
+    return f"Skipped live collisions need explicit update mode before apply: {labels}."

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -5187,6 +5187,11 @@ appearance:
         assert "Hydration gate: nothing has been applied." in response.text
         assert "duplicate handling, ownership defaults, rollback behavior" in response.text
         assert "Apply readiness review" in response.text
+        assert (
+            "Preflight resolved 7 create, 0 update, 0 skip, 0 blocked, and 0 warning actions."
+            in (response.text)
+        )
+        assert "No live face or wanted-hook collisions need explicit update mode." in response.text
         assert "Duplicate handling must stay tenant-scoped." in response.text
         assert "Hydration must run inside one rollback-tested transaction." in response.text
         assert "Check apply gate" in response.text

--- a/tests/test_program_blueprints.py
+++ b/tests/test_program_blueprints.py
@@ -953,6 +953,7 @@ wanted:
 """
 
     preview = admin_services.preview_program_blueprint(source)
+    readiness = admin_services.program_blueprint_apply_readiness(preview)
     rows = {(row.section, row.slug): row for row in preview.diff_rows}
 
     assert preview.is_valid
@@ -963,6 +964,11 @@ wanted:
     assert rows[("material", "premise")].action == "update"
     assert rows[("wanted hook", "iceman-winter-rescue-specialist")].action == "skip"
     assert preview.diff_action_summary == "Preflight: 4 update actions, 2 skip actions."
+    assert readiness.can_check_gate
+    assert (
+        "Skipped live collisions need explicit update mode before apply: "
+        "face: Rogue, wanted hook: Iceman winter rescue specialist."
+    ) in readiness.items
 
 
 def test_seed_hydrates_blueprint_board_media_fields(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- make Program Blueprint apply readiness derive from the actual preflight diff rows
- surface create/update/skip/blocked/warning counts and skipped live face/wanted collisions before the gated apply check
- add service and rendered intake proof while keeping apply as a guarded no-op
- update Program Blueprint docs for diff-aware readiness

## Verification
- uv run pytest -q tests/test_program_blueprints.py::test_program_blueprint_preview_scopes_existing_seed_collisions_by_section tests/test_forum_slice.py::test_studio_intake_previews_program_blueprint_yaml_without_hydration --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

## Steward Notes
- Consulted Blueprint, service, web, test, and docs guidance.
- Accepted: apply readiness should be tied to the accepted diff, not a generic checklist, while real hydration remains gated.
- Proof: rendered Studio intake readiness text for clean creates and service-level collision readiness for existing face/wanted skips.
- Collateral: Program Blueprint product docs updated.
- Remaining risk: no rows are applied in this slice; transaction-backed apply, rollback, and idempotent hydration remain future #61 work.

Closes #61