### PR TITLE
Move public access posture into network read models

### DIFF
--- a/docs/product/community-shapes.md
+++ b/docs/product/community-shapes.md
@@ -49,6 +49,9 @@ tone, genre, pressure, access, pace, and roster shape.
 
 These are public catalog fields. They should be owned by service read models
 and repository methods, not by templates or slug/name heuristics.
+Request-access hrefs are also read-model posture, not template string building:
+templates may suppress the action for the current member, but they should not
+infer public access paths from private membership state.
 
 | Field | User Question It Answers | Product State |
 | --- | --- | --- |

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -1885,6 +1885,12 @@ class StudioNetworkProgramView:
         return _program_href(self, "/applications/new")
 
     @property
+    def request_access_href(self) -> str:
+        if self.community.launch_status != "public-preview":
+            return ""
+        return _program_href(self, "/request-access")
+
+    @property
     def launch_status_label(self) -> str:
         return self.community.launch_status.replace("-", " ").title()
 
@@ -2161,6 +2167,12 @@ class PublicCatalogCard:
         if self.community.launch_status == "invite-only":
             return "Invite-only"
         return "Backstage"
+
+    @property
+    def request_access_href(self) -> str:
+        if self.community.launch_status != "public-preview":
+            return ""
+        return f"{self.entry_href}/request-access"
 
     @property
     def application_posture_label(self) -> str:

--- a/src/elbysodic/web/pages/_components/network_catalog.html
+++ b/src/elbysodic/web/pages/_components/network_catalog.html
@@ -102,8 +102,8 @@ A realm ready for scenes, casting, and writer movement.
     {% if program.open_wanted_count %}
     {{ compact_link_action(program.entry_href ~ "/wanted", "Open calls", "star") }}
     {% end %}
-    {% if program.community.launch_status == "public-preview" and not (viewer and viewer.community.id == program.community.id) %}
-    {{ compact_link_action(program.entry_href ~ "/request-access", "Request access", "envelope") }}
+    {% if program.request_access_href and not (viewer and viewer.community.id == program.community.id) %}
+    {{ compact_link_action(program.request_access_href, "Request access", "envelope") }}
     {% end %}
   </div>
 </article>

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -764,6 +764,7 @@ def test_network_read_models_split_public_cards_from_viewer_state() -> None:
         assert not hasattr(card, "unread_notification_count")
         assert not hasattr(card, "plotting_room_count")
         assert card.invite_posture_label == "Public preview"
+        assert card.request_access_href == f"/c/{card.community.slug}/request-access"
 
 
 def test_public_network_explore_keeps_filters_below_results() -> None:


### PR DESCRIPTION
## Summary
- add request-access hrefs to public catalog and Studio Network program read models
- update network card rendering to consume read-model access posture instead of reconstructing public access paths
- add public catalog read-model proof that cards expose safe request-access hrefs without member/role/face/unread state
- document request-access hrefs as service-owned public catalog posture

## Verification
- uv run pytest -q tests/test_web_security.py::test_network_read_models_split_public_cards_from_viewer_state tests/test_web_security.py::test_public_network_cards_link_to_request_access tests/test_web_security.py::test_signed_in_network_marks_current_realm_without_leaking_staff --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

## Steward Notes
- Consulted service, web, test, docs, and public discovery guidance.
- Accepted: public access posture belongs in read models; templates may suppress current-member actions but should not rebuild access URLs from private state.
- Proof: public card read-model test plus rendered public/current-member network tests.
- Collateral: community shapes/public discovery docs updated.
- Remaining risk: broader ranking/filter/query-budget work remains future #62 scope.

Closes #62