### PR TITLE
Expose SQLite health in Studio Operations

### DIFF
--- a/docs/architecture/sqlite-request-lifecycle.md
+++ b/docs/architecture/sqlite-request-lifecycle.md
@@ -19,6 +19,9 @@ and identity safety contract, not as incidental plumbing.
   new connection would create an empty database.
 - `connect()` owns SQLite pragmas: foreign keys, busy timeout, and WAL for
   filesystem databases.
+- Studio Operations reads journal mode and `PRAGMA integrity_check` through the
+  operations service read model so director/operator diagnostics do not drift
+  into page-local SQL or ordinary member surfaces.
 - Repository list/read methods must not perform incidental writes or commits.
   Defaults and reconciliation belong to schema creation, community creation,
   migrations, seed/bootstrap, or explicit maintenance workflows.

--- a/docs/operations/production-bootstrap.md
+++ b/docs/operations/production-bootstrap.md
@@ -13,8 +13,9 @@ production bootstrap creates the first real director identity and realm.
 - `ELBYSODIC_SECRET_KEY` is present and at least 32 characters.
 - Demo mode is off for production unless the session is explicitly a demo.
 - A fresh backup exists, or the database is confirmed empty.
-- Studio Operations shows the expected environment, database path, schema
-  version, migration ledger, realm count, and launch status.
+- Studio Operations shows the expected environment, database path, journal
+  mode, integrity check, schema version, migration ledger, realm count, and
+  launch status.
 - The first realm name, slug, director email, director username, and director
   display name have been reviewed for typos.
 
@@ -22,6 +23,8 @@ production bootstrap creates the first real director identity and realm.
 
 - The seed command or Studio Operations points at a non-volume path such as
   `var/elbysodic.sqlite3`.
+- Studio Operations reports a filesystem SQLite journal mode other than `wal`
+  or an integrity check other than `ok`.
 - More than one Railway replica is active while SQLite is the backing store.
 - The migration ledger is behind the app schema version.
 - The realm slug is uncertain or conflicts with planned host routing.
@@ -42,6 +45,8 @@ Production bootstrap:
 - App URL:
 - Volume path:
 - Database path:
+- Journal mode:
+- Integrity check:
 - Schema version:
 - Migration ledger:
 - Replica count:
@@ -66,6 +71,8 @@ Production bootstrap:
 - App URL: https://elbysodic-staging.up.railway.app
 - Volume path: /app/var
 - Database path: not inspected from app runtime in this run
+- Journal mode: not inspected from app runtime in this run
+- Integrity check: not inspected from app runtime in this run
 - Schema version: not inspected from app runtime in this run
 - Migration ledger: not inspected from app runtime in this run
 - Replica count: not inspected from app runtime in this run

--- a/docs/operations/railway-production-smoke-record.md
+++ b/docs/operations/railway-production-smoke-record.md
@@ -19,6 +19,8 @@ Railway staging smoke:
 - Railway project/service/environment: intuitive-friendship / elbysodic / staging
 - Volume path: /app/var, Railway status reported elbysodic-volume mounted
 - Database path: not inspected from app runtime in this run
+- Journal mode: not inspected from app runtime in this run
+- Integrity check: not inspected from app runtime in this run
 - Replica count: not inspected from app runtime in this run
 - Demo mode: not inspected from app runtime in this run
 - Public GETs: `/health` 200, `/` 200, `/network` 200
@@ -41,6 +43,8 @@ Railway production smoke:
 - Railway project/service/environment: unavailable locally
 - Volume path: not tested
 - Database path: not tested
+- Journal mode: not tested
+- Integrity check: not tested
 - Replica count: not tested
 - Demo mode: not tested
 - Account tested: not tested
@@ -68,6 +72,8 @@ Railway production smoke:
 - Railway project/service/environment:
 - Volume path:
 - Database path:
+- Journal mode:
+- Integrity check:
 - Replica count:
 - Demo mode:
 - Account tested:
@@ -95,7 +101,8 @@ Railway production smoke:
 - Logout revokes the session; replaying the stale session cannot open Studio.
 - Seed media under `/elbysodic-static/seed-media/...` returns `200`.
 - Studio Operations shows one replica, the expected volume-backed database
-  path, current schema version, migration ledger, and launch status.
+  path, WAL journal mode, `ok` integrity check, current schema version,
+  migration ledger, and launch status.
 
 ## First Run Notes
 

--- a/docs/operations/sqlite-production.md
+++ b/docs/operations/sqlite-production.md
@@ -44,6 +44,13 @@ free, then archive or remove the checkout.
 
 ## Persistence Checks
 
+Studio Operations exposes the runtime inspection only to members who can manage
+the realm. Use it to confirm the app is pointed at the expected database file,
+the SQLite journal mode, the integrity check result, schema/user version,
+migration ledger, realm count, and launch status. The journal mode should be
+`wal` for filesystem-backed Railway and local production-like databases, and
+the integrity check should report `ok`.
+
 Before sharing a URL, prove these survive restart or redeploy:
 
 - writer posts
@@ -89,6 +96,12 @@ elbysodic dev db backup --db-path /app/var/elbysodic.sqlite3 \
 file. `backup` uses SQLite's online backup API and verifies
 `PRAGMA integrity_check` on the copied database before reporting success. It
 will not overwrite an existing backup unless `--overwrite` is passed.
+
+After a restore, open the restored file with Elbysodic services or Studio
+Operations and verify service readback for the realm plus the same `wal` journal
+mode, `ok` integrity check, schema version, migration ledger, and realm count
+expected for the source environment. Do not paste secrets, session cookies,
+reset links, or raw credentials into the drill record.
 
 ## Backup/Restore Drill Record
 

--- a/src/elbysodic/services/operations.py
+++ b/src/elbysodic/services/operations.py
@@ -87,6 +87,8 @@ class OperationsInspection:
     environment: str
     secure_cookies: bool
     database_path: str
+    journal_mode: str
+    integrity_check: str
     sqlite_user_version: int
     current_schema_version: int
     latest_migration_version: int
@@ -364,6 +366,8 @@ def operations_inspection(
     migration_row = connection.execute(
         "SELECT MAX(version) AS version FROM schema_migrations"
     ).fetchone()
+    journal_mode = connection.execute("PRAGMA journal_mode").fetchone()[0]
+    integrity_check = connection.execute("PRAGMA integrity_check").fetchone()[0]
     user_version = connection.execute("PRAGMA user_version").fetchone()[0]
     community_count = connection.execute("SELECT COUNT(*) AS count FROM communities").fetchone()
     try:
@@ -375,6 +379,8 @@ def operations_inspection(
         environment=config.environment,
         secure_cookies=config.secure_cookies,
         database_path=str(database_row["file"] or ":memory:"),
+        journal_mode=str(journal_mode),
+        integrity_check=str(integrity_check),
         sqlite_user_version=int(user_version),
         current_schema_version=CURRENT_SCHEMA_VERSION,
         latest_migration_version=int(migration_row["version"] or 0),

--- a/src/elbysodic/web/pages/studio/operations/page.html
+++ b/src/elbysodic/web/pages/studio/operations/page.html
@@ -113,6 +113,14 @@
         <dd>{{ operations.inspection.database_path }}</dd>
       </div>
       <div>
+        <dt>Journal mode</dt>
+        <dd>{{ operations.inspection.journal_mode }}</dd>
+      </div>
+      <div>
+        <dt>Integrity check</dt>
+        <dd>{{ operations.inspection.integrity_check }}</dd>
+      </div>
+      <div>
         <dt>Schema</dt>
         <dd>{{ operations.inspection.sqlite_user_version }} / {{ operations.inspection.current_schema_version }}</dd>
       </div>

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -237,6 +237,14 @@ def test_service_raw_sql_stays_limited_to_lifecycle_and_operations_diagnostics()
         ),
         (
             "src/elbysodic/services/operations.py",
+            'journal_mode = connection.execute("PRAGMA journal_mode").fetchone()[0]',
+        ),
+        (
+            "src/elbysodic/services/operations.py",
+            'integrity_check = connection.execute("PRAGMA integrity_check").fetchone()[0]',
+        ),
+        (
+            "src/elbysodic/services/operations.py",
             'user_version = connection.execute("PRAGMA user_version").fetchone()[0]',
         ),
         (

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -27,6 +27,7 @@ from elbysodic.services.notifications import (
     mark_all_notifications_read,
     visible_unread_notification_counts,
 )
+from elbysodic.services.operations import OperationsInspectionConfig, operations_inspection
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_scoped_path, scope_response_urls
@@ -5057,12 +5058,17 @@ def test_studio_operations_hides_review_queue_from_non_staff_members() -> None:
         assert "0 ready apps" in member_operations.text
         assert "Live check" not in member_operations.text
         assert "Database path" not in member_operations.text
+        assert "Journal mode" not in member_operations.text
+        assert "Integrity check" not in member_operations.text
         assert staff_operations.status == 200
         assert "Privacy Queue Face - ready" in staff_operations.text
         assert "ready apps" in staff_operations.text
         assert "Live check" in staff_operations.text
         assert "Runtime and persistence" in staff_operations.text
         assert "Database path" in staff_operations.text
+        assert "Journal mode" in staff_operations.text
+        assert "Integrity check" in staff_operations.text
+        assert "ok" in staff_operations.text
         assert "Schema" in staff_operations.text
         assert "Opening" in staff_operations.text
 
@@ -12109,6 +12115,24 @@ def test_startup_seed_preserves_director_edited_boards_and_materials(tmp_path: P
     assert restored_material.title == "B-24 Winter Custom Briefing"
     assert restored_material.summary == "Director-edited event summary."
     assert restored_material.body == "Director-edited event body."
+
+
+def test_file_backed_operations_inspection_reports_wal_and_integrity(
+    tmp_path: Path,
+) -> None:
+    services = create_services(path=tmp_path / "elbysodic.sqlite3")
+
+    inspection = operations_inspection(
+        services.repo,
+        services.viewer(),
+        OperationsInspectionConfig(environment="test", secure_cookies=True),
+    )
+
+    assert inspection.database_path.endswith("elbysodic.sqlite3")
+    assert inspection.journal_mode.lower() == "wal"
+    assert inspection.integrity_check == "ok"
+    assert inspection.latest_migration_version == inspection.current_schema_version
+    assert inspection.community_count > 0
 
 
 def test_composer_pages_point_empty_roster_to_character_setup() -> None:


### PR DESCRIPTION
## Summary
- add SQLite journal mode and integrity check to the service-owned Studio Operations inspection read model
- render the diagnostics only inside the existing manager-only live inspection panel
- update production SQLite, bootstrap, smoke, and request-lifecycle docs with the new health evidence

## Steward Notes
- Steward: Storage And Migration Steward
- Accepted: operations diagnostics should prove WAL/integrity and keep startup seed/persistence checks visible without schema changes.
- Proof: file-backed operations inspection test asserts WAL, `ok` integrity, current migration ledger, and realm readback; existing restart tests cover writer posts and director-edited boards/materials.
- Collateral: SQLite production, production bootstrap, Railway smoke record, and SQLite request lifecycle docs updated.
- Remaining risk: replica count and live Railway volume inspection still require an operator-run smoke in the target environment.

## Verification
- `uv run pytest -q --tb=short tests/test_forum_slice.py -k "studio_operations or file_backed_operations_inspection_reports_wal_and_integrity or file_backed_services_persist_created_threads or startup_seed_preserves_director_edited_boards_and_materials"`
- `uv run pytest -q --tb=short tests/test_backend_contracts.py -k raw_sql`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run pytest -q --tb=short`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path='':memory:'').check()"`

Closes #63