### PR TITLE
Add capability denial diagnostics

### DIFF
--- a/docs/architecture/primitives.md
+++ b/docs/architecture/primitives.md
@@ -18,6 +18,12 @@ workflow policy, and rendered privacy proof.
 permissions, community-local username, roster preferences, and moderation power
 belong here.
 
+Staff power is expressed in services as named membership-scoped capabilities,
+not user-level authority. The current storage shorthand grants all V1 staff
+capabilities through an admin role, but the product contract remains
+capability-shaped so a future partial-staff role can be added without teaching
+pages to read storage flags directly.
+
 `Character` is the public posting identity. Characters are not global. A
 character belongs to exactly one membership in exactly one community.
 

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -51,6 +51,15 @@ When adding a staff workflow, add or reuse a named capability in
 `src/elbysodic/services/policies.py` and route service-layer checks through the
 helper. Avoid direct `role.is_admin` checks outside the policy module.
 
+Policy diagnostics use the same named capability contract. When a maintainer or
+future recovery surface needs to explain a denial, use the service-owned
+capability diagnostic helper rather than inspecting role fields in a page or
+template. Diagnostics may name the requested capability and a generic reason,
+such as inactive membership, missing role, cross-community role, mismatched
+role assignment, or role lacking staff power. They must not include private
+target details, staff notes, application body, access-request notes, raw
+tokens, or role/member display names.
+
 V1 keeps `roles.is_admin` as the storage shorthand for "has every current
 staff capability." Do not add role-capability rows until partial staff roles
 become product-visible. Even while storage is coarse, page handlers and

--- a/src/elbysodic/services/policies.py
+++ b/src/elbysodic/services/policies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal
 
 from elbysodic.domain.models import Board, Character, CommunityMembership, Post, Role, Thread
@@ -24,15 +25,86 @@ ADMIN_CAPABILITIES: frozenset[Capability] = frozenset(
     }
 )
 
+type CapabilityDenialReason = Literal[
+    "allowed",
+    "missing_role",
+    "inactive_membership",
+    "role_community_mismatch",
+    "role_not_assigned",
+    "role_lacks_staff_power",
+    "unknown_capability",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityDiagnostic:
+    capability: Capability
+    allowed: bool
+    reason: CapabilityDenialReason
+    message: str
+
 
 def has_capability(
     membership: CommunityMembership,
     role: Role | None,
     capability: Capability,
 ) -> bool:
-    if role is None or not _is_active_role(membership, role):
-        return False
-    return role.is_admin and capability in ADMIN_CAPABILITIES
+    return explain_capability(membership, role, capability).allowed
+
+
+def explain_capability(
+    membership: CommunityMembership,
+    role: Role | None,
+    capability: Capability,
+) -> CapabilityDiagnostic:
+    if capability not in ADMIN_CAPABILITIES:
+        return CapabilityDiagnostic(
+            capability=capability,
+            allowed=False,
+            reason="unknown_capability",
+            message="Capability is not registered for this deployment.",
+        )
+    if role is None:
+        return CapabilityDiagnostic(
+            capability=capability,
+            allowed=False,
+            reason="missing_role",
+            message="Membership has no resolved community role.",
+        )
+    if not membership.is_active:
+        return CapabilityDiagnostic(
+            capability=capability,
+            allowed=False,
+            reason="inactive_membership",
+            message="Membership is inactive in this community.",
+        )
+    if role.community_id != membership.community_id:
+        return CapabilityDiagnostic(
+            capability=capability,
+            allowed=False,
+            reason="role_community_mismatch",
+            message="Resolved role belongs to another community.",
+        )
+    if role.id != membership.role_id:
+        return CapabilityDiagnostic(
+            capability=capability,
+            allowed=False,
+            reason="role_not_assigned",
+            message="Resolved role is not assigned to this membership.",
+        )
+    if not role.is_admin:
+        return CapabilityDiagnostic(
+            capability=capability,
+            allowed=False,
+            reason="role_lacks_staff_power",
+            message="Role does not grant this staff capability.",
+        )
+    return CapabilityDiagnostic(
+        capability=capability,
+        allowed=True,
+        reason="allowed",
+        message="Membership grants this staff capability.",
+    )
 
 
 def can_manage_applications(membership: CommunityMembership, role: Role | None) -> bool:
@@ -119,12 +191,3 @@ def can_edit_post(
     if post.author_membership_id == membership.id:
         return True
     return can_manage_threads(membership, role)
-
-
-def _is_active_role(membership: CommunityMembership, role: Role | None) -> bool:
-    return (
-        role is not None
-        and membership.is_active
-        and role.community_id == membership.community_id
-        and role.id == membership.role_id
-    )

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -63,6 +63,17 @@ def test_admin_role_grants_named_capabilities(
     assert policies.can_manage_applications(membership, admin_role)
 
 
+@pytest.mark.parametrize("capability", sorted(policies.ADMIN_CAPABILITIES))
+def test_named_capability_helpers_stay_registered(
+    capability: policies.Capability,
+    membership: CommunityMembership,
+    admin_role: Role,
+) -> None:
+    helper = getattr(policies, f"can_{capability}")
+
+    assert helper(membership, admin_role) is True
+
+
 def test_page_handlers_and_services_do_not_check_admin_flag_directly() -> None:
     checked_paths = [
         *Path("src/elbysodic/web/pages").rglob("page.py"),
@@ -91,6 +102,65 @@ def test_capabilities_require_active_membership_and_matching_role(
     assert not policies.can_manage_world(inactive, admin_role)
     assert not policies.can_manage_world(membership, wrong_community_role)
     assert not policies.can_manage_world(membership, wrong_role_id)
+
+
+@pytest.mark.parametrize(
+    ("membership_updates", "role_updates", "expected_reason"),
+    [
+        ({}, None, "missing_role"),
+        ({"is_active": False}, {}, "inactive_membership"),
+        ({}, {"community_id": 2}, "role_community_mismatch"),
+        ({}, {"id": 99}, "role_not_assigned"),
+        ({}, {"is_admin": False}, "role_lacks_staff_power"),
+    ],
+)
+def test_capability_denial_diagnostics_are_safe_and_specific(
+    membership_updates: dict[str, object],
+    role_updates: dict[str, object] | None,
+    expected_reason: policies.CapabilityDenialReason,
+    membership: CommunityMembership,
+    admin_role: Role,
+) -> None:
+    scoped_membership = replace(membership, **membership_updates)
+    role = None if role_updates is None else replace(admin_role, **role_updates)
+
+    diagnostic = policies.explain_capability(scoped_membership, role, "manage_world")
+
+    assert diagnostic.allowed is False
+    assert diagnostic.capability == "manage_world"
+    assert diagnostic.reason == expected_reason
+    assert scoped_membership.username not in diagnostic.message
+    assert scoped_membership.display_name not in diagnostic.message
+    if role is not None:
+        assert role.name not in diagnostic.message
+        assert role.slug not in diagnostic.message
+
+
+def test_capability_diagnostics_report_allowed_without_target_details(
+    membership: CommunityMembership,
+    admin_role: Role,
+) -> None:
+    diagnostic = policies.explain_capability(membership, admin_role, "manage_casting")
+
+    assert diagnostic.allowed is True
+    assert diagnostic.capability == "manage_casting"
+    assert diagnostic.reason == "allowed"
+    assert membership.username not in diagnostic.message
+    assert admin_role.name not in diagnostic.message
+
+
+def test_same_global_user_can_have_different_capabilities_per_community(
+    membership: CommunityMembership,
+    admin_role: Role,
+) -> None:
+    staffed_membership = replace(membership, community_id=2, role_id=40)
+    staffed_role = replace(admin_role, id=40, community_id=2, slug="director", is_admin=True)
+    writer_membership = replace(membership, community_id=3, role_id=41)
+    writer_role = replace(admin_role, id=41, community_id=3, slug="member", is_admin=False)
+
+    assert staffed_membership.user_id == writer_membership.user_id
+    assert policies.can_manage_applications(staffed_membership, staffed_role)
+    assert not policies.can_manage_applications(writer_membership, writer_role)
 
 
 def test_private_board_and_locked_thread_use_named_capabilities(


### PR DESCRIPTION
## Summary
- add a service-owned `CapabilityDiagnostic` path for safe capability allow/deny explanations
- keep existing `can_manage_*` helpers as the workflow contract while pinning helper registration and same-user cross-community behavior in tests
- document capability-shaped staff power and safe diagnostic boundaries without adding role-capability or audit schema

## Steward Notes
- Steward: Service Layer Steward
- Accepted: policy helpers remain the public authorization contract, and denial explanation belongs in services rather than pages/templates.
- Steward: Domain Model Steward
- Accepted: staff power stays membership-scoped, not user-scoped; tests cover the same global user with different community-local capabilities.
- Steward: Storage And Migration Steward
- Deferred: role-capability rows and audit-event rows require stop-and-ask and product-visible partial-staff behavior, so this PR stays schema-neutral.
- Collateral: security boundaries and primitives docs updated.
- Remaining risk: sensitive staff action audit trails still need a future schema/migration PR once the audit primitive is approved.

## Verification
- `uv run pytest -q --tb=short tests/test_policies.py`
- `uv run pytest -q --tb=short tests/test_backend_contracts.py -k "policy or critical_rendered"`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run pytest -q --tb=short`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path='':memory:'').check()"`

Closes #64