### PR TITLE
Add rendered surface contract registry

### DIFF
--- a/docs/architecture/surface-contract-architecture.md
+++ b/docs/architecture/surface-contract-architecture.md
@@ -31,6 +31,14 @@ For each rendered surface, record or make obvious:
 - expected empty states, recovery states, and forbidden states
 - rendered tests and docs collateral
 
+The executable registry lives in
+`src/elbysodic/web/surface_contracts.py`. It is intentionally lightweight:
+each entry names the route family, handler path, route-facing service call,
+read model family, required viewer modes, parity dimensions, and the rendered
+privacy matrix label. Backend contract tests read the registry so critical
+page handlers keep calling named service methods and the privacy matrix stays
+connected to the code.
+
 ## Rules
 
 - Public pages render public read models. They can show published public realm
@@ -136,6 +144,11 @@ The lightest acceptable proof depends on risk:
 These repeated surfaces should stay tied to one route-facing service method.
 When a row changes, update the rendered route privacy matrix and add proof for
 both visible and absent state.
+
+The rows below are prose summaries of the executable registry. Add or update a
+registry entry when a route family gains shell counts, page lists, detail
+views, action availability, notification visibility, recovery behavior, or
+diagnostics that can expose scoped state.
 
 | Surface | Service Contract | Shell Count | Page List | Detail View | Action Availability | Notification Visibility | Current Proof |
 | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/elbysodic/web/surface_contracts.py
+++ b/src/elbysodic/web/surface_contracts.py
@@ -1,0 +1,170 @@
+"""Rendered surface contract registry.
+
+The registry is executable documentation for route families that must keep
+privacy, counts, and action availability owned by services before templates
+render them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+type ViewerMode = Literal[
+    "public",
+    "account_visitor",
+    "member",
+    "owner",
+    "staff",
+    "director",
+    "inactive",
+    "faceless",
+    "cross_tenant",
+]
+
+type SurfaceDimension = Literal[
+    "shell_count",
+    "page_list",
+    "detail_view",
+    "action_availability",
+    "notification_visibility",
+    "recovery",
+    "diagnostics",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceContract:
+    key: str
+    route_family: str
+    page_path: str
+    service_calls: tuple[str, ...]
+    read_models: tuple[str, ...]
+    viewer_modes: tuple[ViewerMode, ...]
+    dimensions: tuple[SurfaceDimension, ...]
+    privacy_matrix_label: str
+
+
+SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
+    SurfaceContract(
+        key="realm_home",
+        route_family="/ and /c/{community}/",
+        page_path="src/elbysodic/web/pages/page.py",
+        service_calls=("services.realm_home()",),
+        read_models=("RealmHome", "PublicRealmGateway", "NetworkHome"),
+        viewer_modes=("public", "account_visitor", "member", "staff", "cross_tenant"),
+        dimensions=("shell_count", "page_list", "action_availability", "recovery"),
+        privacy_matrix_label="/c/{community}/",
+    ),
+    SurfaceContract(
+        key="claims_directory",
+        route_family="/claims",
+        page_path="src/elbysodic/web/pages/claims/page.py",
+        service_calls=("services.claims_page(",),
+        read_models=("ClaimsDirectory",),
+        viewer_modes=("member", "staff", "director", "cross_tenant"),
+        dimensions=("page_list", "detail_view", "action_availability"),
+        privacy_matrix_label="/claims",
+    ),
+    SurfaceContract(
+        key="roster",
+        route_family="/characters and /characters/{character}",
+        page_path="src/elbysodic/web/pages/characters/page.py",
+        service_calls=("services.character_roster_page(",),
+        read_models=("CharacterRosterDashboard", "CharacterProfile"),
+        viewer_modes=("member", "owner", "staff", "inactive", "cross_tenant"),
+        dimensions=("page_list", "detail_view", "action_availability", "recovery"),
+        privacy_matrix_label="/members",
+    ),
+    SurfaceContract(
+        key="thread_and_posting",
+        route_family="/boards/{board} and /boards/{board}/threads/{thread}",
+        page_path="src/elbysodic/web/pages/boards/{board_slug}/page.py",
+        service_calls=("services.board_page(",),
+        read_models=("BoardPage", "ThreadView", "PostView"),
+        viewer_modes=("member", "owner", "staff", "faceless", "cross_tenant"),
+        dimensions=(
+            "shell_count",
+            "page_list",
+            "detail_view",
+            "action_availability",
+            "notification_visibility",
+            "recovery",
+        ),
+        privacy_matrix_label="/boards/{board}",
+    ),
+    SurfaceContract(
+        key="wanted",
+        route_family="/wanted and /c/{community}/wanted",
+        page_path="src/elbysodic/web/pages/wanted/page.py",
+        service_calls=("services.wanted_ads()",),
+        read_models=("WantedBoard", "WantedAdDetail"),
+        viewer_modes=("public", "account_visitor", "member", "owner", "staff", "cross_tenant"),
+        dimensions=("page_list", "detail_view", "action_availability", "notification_visibility"),
+        privacy_matrix_label="/c/{community}/wanted",
+    ),
+    SurfaceContract(
+        key="plotting",
+        route_family="/plotting and /plotting/{room}",
+        page_path="src/elbysodic/web/pages/plotting/page.py",
+        service_calls=("services.plotting_desk()",),
+        read_models=("PlottingDesk", "PlottingRoomView"),
+        viewer_modes=("member", "owner", "staff", "inactive", "cross_tenant"),
+        dimensions=("page_list", "detail_view", "action_availability", "notification_visibility"),
+        privacy_matrix_label="/plotting",
+    ),
+    SurfaceContract(
+        key="applications",
+        route_family="/applications and /applications/{character}",
+        page_path="src/elbysodic/web/pages/applications/page.py",
+        service_calls=("services.applications_desk()",),
+        read_models=("ApplicationsDesk", "ApplicationReviewRoom"),
+        viewer_modes=("member", "owner", "staff", "faceless", "cross_tenant"),
+        dimensions=("page_list", "detail_view", "action_availability", "recovery"),
+        privacy_matrix_label="/applications",
+    ),
+    SurfaceContract(
+        key="notifications",
+        route_family="/notifications and shell/sidebar counts",
+        page_path="src/elbysodic/web/pages/notifications/page.py",
+        service_calls=("services.notification_center()",),
+        read_models=("NotificationCenter", "NotificationInboxItem"),
+        viewer_modes=("member", "owner", "staff", "inactive", "faceless", "cross_tenant"),
+        dimensions=("shell_count", "page_list", "detail_view", "notification_visibility"),
+        privacy_matrix_label="/notifications",
+    ),
+    SurfaceContract(
+        key="network_catalog",
+        route_family="/network",
+        page_path="src/elbysodic/web/pages/network/page.py",
+        service_calls=("services.network_explore(",),
+        read_models=("NetworkExplore", "PublicCatalogCard", "StudioNetworkProgramView"),
+        viewer_modes=("public", "account_visitor", "member", "staff", "cross_tenant"),
+        dimensions=("page_list", "action_availability", "recovery"),
+        privacy_matrix_label="/network",
+    ),
+    SurfaceContract(
+        key="studio",
+        route_family="/studio and /studio/*",
+        page_path="src/elbysodic/web/pages/studio/page.py",
+        service_calls=("services.director_studio()",),
+        read_models=("DirectorStudio",),
+        viewer_modes=("member", "staff", "director", "inactive", "cross_tenant"),
+        dimensions=("shell_count", "page_list", "detail_view", "action_availability", "recovery"),
+        privacy_matrix_label="/studio",
+    ),
+    SurfaceContract(
+        key="studio_operations",
+        route_family="/studio/operations",
+        page_path="src/elbysodic/web/pages/studio/operations/page.py",
+        service_calls=("services.director_operations(",),
+        read_models=("DirectorOperations", "OperationsInspection"),
+        viewer_modes=("member", "staff", "director", "inactive", "cross_tenant"),
+        dimensions=("page_list", "action_availability", "diagnostics"),
+        privacy_matrix_label="/studio",
+    ),
+)
+
+
+def surface_contracts_by_key() -> dict[str, SurfaceContract]:
+    return {contract.key: contract for contract in SURFACE_CONTRACTS}

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -10,6 +10,7 @@ import pytest
 from elbysodic.db import ForumRepository, connect
 from elbysodic.services import create_services
 from elbysodic.web.state import close_request_services, configure_services, get_services
+from elbysodic.web.surface_contracts import SURFACE_CONTRACTS
 
 REPO_ROOT = Path(__file__).parents[1]
 WEB_DIR = REPO_ROOT / "src" / "elbysodic" / "web"
@@ -198,23 +199,47 @@ def test_web_page_handlers_do_not_make_policy_decisions_directly() -> None:
 
 
 def test_critical_rendered_pages_use_named_service_surface_contracts() -> None:
-    expected_calls = {
-        "src/elbysodic/web/pages/page.py": "services.realm_home()",
-        "src/elbysodic/web/pages/claims/page.py": "services.claims_page(",
-        "src/elbysodic/web/pages/characters/page.py": "services.character_roster_page(",
-        "src/elbysodic/web/pages/notifications/page.py": "services.notification_center()",
-        "src/elbysodic/web/pages/wanted/page.py": "services.wanted_ads()",
-        "src/elbysodic/web/pages/boards/{board_slug}/page.py": "services.board_page(",
-        "src/elbysodic/web/pages/studio/page.py": "services.director_studio()",
-    }
-
     missing: list[str] = []
-    for relative_path, service_call in expected_calls.items():
-        source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
-        if service_call not in source:
-            missing.append(f"{relative_path}: {service_call}")
+    for contract in SURFACE_CONTRACTS:
+        source = (REPO_ROOT / contract.page_path).read_text(encoding="utf-8")
+        missing.extend(
+            f"{contract.key}: {contract.page_path}: {service_call}"
+            for service_call in contract.service_calls
+            if service_call not in source
+        )
 
     assert missing == []
+
+
+def test_rendered_surface_contract_registry_is_complete_enough() -> None:
+    privacy_matrix = (REPO_ROOT / "docs/architecture/rendered-route-privacy-matrix.md").read_text(
+        encoding="utf-8"
+    )
+    keys = [contract.key for contract in SURFACE_CONTRACTS]
+    missing_paths = [
+        contract.page_path
+        for contract in SURFACE_CONTRACTS
+        if not (REPO_ROOT / contract.page_path).exists()
+    ]
+    incomplete = [
+        contract.key
+        for contract in SURFACE_CONTRACTS
+        if not contract.service_calls
+        or not contract.read_models
+        or not contract.viewer_modes
+        or not contract.dimensions
+    ]
+    missing_matrix_labels = [
+        contract.key
+        for contract in SURFACE_CONTRACTS
+        if contract.privacy_matrix_label not in privacy_matrix
+    ]
+
+    assert len(keys) == len(set(keys))
+    assert len(SURFACE_CONTRACTS) >= 10
+    assert missing_paths == []
+    assert incomplete == []
+    assert missing_matrix_labels == []
 
 
 def test_service_raw_sql_stays_limited_to_lifecycle_and_operations_diagnostics() -> None:


### PR DESCRIPTION
## Summary
- add a typed rendered surface contract registry for critical route families, service calls, read models, viewer modes, and parity dimensions
- make backend contract tests consume the registry instead of a local hard-coded service-call map
- document the registry as the executable companion to the surface architecture and privacy matrix

## Steward Notes
- Steward: Surface Contract Steward
- Accepted: repeated rendered surfaces need one lightweight registry tying service methods, read models, viewer modes, and proof dimensions together.
- Steward: Service Layer Steward
- Accepted: critical page handlers keep naming service-owned contracts rather than template-local privacy/ranking decisions.
- Steward: Rendering And UI Steward
- Accepted: registry entries stay route-family level and do not change rendered UI behavior.
- Collateral: surface contract architecture docs updated.
- Remaining risk: future route families still need registry entries when they expose new scoped state; this PR adds the guardrail, not every possible future row.

## Verification
- `uv run pytest -q --tb=short tests/test_backend_contracts.py -k "surface_contract or critical_rendered"`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run pytest -q --tb=short`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path='':memory:'').check()"`

Closes #87