### PR TITLE
Prove Blueprint apply gate rollback

### DIFF
--- a/docs/product/program-blueprints.md
+++ b/docs/product/program-blueprints.md
@@ -308,6 +308,9 @@ that apply is still gated without writing rows. The readiness review shown with
 that gate is diff-aware: it summarizes create, update, skip, blocked, and
 warning counts, and it names skipped live face or wanted-hook collisions that
 need explicit update semantics before real apply can be enabled.
+Regression proof covers the current gate order: non-staff and stale-preview
+attempts do not enter a transaction, while accepted gated attempts enter the
+transaction boundary and roll back any probe writes when apply remains disabled.
 
 ## Hydration Gate
 

--- a/tests/test_program_blueprints.py
+++ b/tests/test_program_blueprints.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 import pytest
 
 from elbysodic.blueprints import (
@@ -969,6 +972,145 @@ wanted:
         "Skipped live collisions need explicit update mode before apply: "
         "face: Rogue, wanted hook: Iceman winter rescue specialist."
     ) in readiness.items
+
+
+def test_program_blueprint_apply_rejects_non_staff_before_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = connect()
+    create_schema(connection)
+    repo = ForumRepository(connection)
+    seed = seed_demo_forum(repo)
+    writer = repo.get_membership_by_username(seed.community.id, "starlane")
+    services = AppServices(
+        repo,
+        DemoSeed(
+            seed.community,
+            repo.get_user(writer.user_id),
+            writer,
+            repo.get_character_by_slug(seed.community.id, "rogue"),
+        ),
+    )
+
+    def fail_transaction() -> Iterator[None]:
+        raise AssertionError("apply should not enter a transaction")
+        yield
+
+    monkeypatch.setattr(repo, "transaction", fail_transaction)
+
+    with pytest.raises(PermissionError, match="cannot preview program blueprints"):
+        services.apply_program_blueprint_preview(
+            _transaction_probe_blueprint_source(),
+            "stale-preview",
+        )
+
+
+def test_program_blueprint_apply_rejects_stale_fingerprint_before_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = connect()
+    create_schema(connection)
+    repo = ForumRepository(connection)
+    seed = seed_demo_forum(repo)
+    moira = repo.get_membership_by_username(seed.community.id, "moira")
+    services = AppServices(
+        repo,
+        DemoSeed(
+            seed.community,
+            repo.get_user(moira.user_id),
+            moira,
+            repo.get_character_by_slug(seed.community.id, "moira-mactaggert"),
+        ),
+    )
+
+    def fail_transaction() -> Iterator[None]:
+        raise AssertionError("stale apply should not enter a transaction")
+        yield
+
+    monkeypatch.setattr(repo, "transaction", fail_transaction)
+
+    with pytest.raises(ValueError, match="preview changed"):
+        services.apply_program_blueprint_preview(
+            _transaction_probe_blueprint_source(),
+            "stale-preview",
+        )
+
+
+def test_program_blueprint_apply_gate_rolls_back_transaction_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = connect()
+    create_schema(connection)
+    repo = ForumRepository(connection)
+    seed = seed_demo_forum(repo)
+    moira = repo.get_membership_by_username(seed.community.id, "moira")
+    services = AppServices(
+        repo,
+        DemoSeed(
+            seed.community,
+            repo.get_user(moira.user_id),
+            moira,
+            repo.get_character_by_slug(seed.community.id, "moira-mactaggert"),
+        ),
+    )
+    source = _transaction_probe_blueprint_source()
+    preview = services.preview_program_blueprint(source)
+    assert preview.preview_fingerprint
+    original_transaction = repo.transaction
+    entered = False
+
+    @contextmanager
+    def transaction_with_probe() -> Iterator[None]:
+        nonlocal entered
+        with original_transaction():
+            entered = True
+            repo.connection.execute(
+                """
+                INSERT INTO communities (slug, name, created_at, updated_at)
+                VALUES ('blueprint-rollback-probe', 'Blueprint Rollback Probe',
+                        '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')
+                """
+            )
+            yield
+
+    monkeypatch.setattr(repo, "transaction", transaction_with_probe)
+
+    with pytest.raises(ValueError, match="apply remains gated"):
+        services.apply_program_blueprint_preview(source, preview.preview_fingerprint)
+
+    assert entered
+    assert not repo.connection.in_transaction
+    with pytest.raises(LookupError):
+        repo.get_community_by_slug("blueprint-rollback-probe")
+
+
+def _transaction_probe_blueprint_source() -> str:
+    return """
+elbysodic_blueprint: 1
+program:
+  slug: rl-small-town-preview
+  name: RL Small Town Preview
+  role:
+    slug: director
+    name: Director
+    is_admin: true
+characters:
+  - slug: june-calloway
+    name: June Calloway
+    summary: Florist and town council note-taker.
+boards:
+  - slug: main-street
+    name: Main Street
+    kind: location
+    tagline: One stoplight, twelve opinions.
+    description: The town's public spine.
+materials:
+  - slug: premise
+    title: Premise
+    type: premise
+    summary: A small-town ensemble.
+    body: Founder's Week should be a cozy pressure cooker.
+"""
 
 
 def test_seed_hydrates_blueprint_board_media_fields(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add regression proof for the current Program Blueprint apply gate order
- prove non-staff and stale-preview attempts do not enter a transaction
- prove accepted gated apply attempts enter the transaction boundary and roll back probe writes while apply remains disabled
- document the current gate-order proof in the Blueprint product contract

## Steward Notes
- Steward: Blueprint steward
- Accepted: apply remains intentionally gated, but the current no-op gate must still prove permission, stale-preview, transaction, and rollback behavior.
- Steward: Service Layer Steward
- Accepted: gate checks stay in the service boundary and use the existing preview/fingerprint path.
- Steward: Storage steward
- Accepted: rollback proof uses the repository transaction boundary and verifies no probe row persists.
- Deferred: real hydration writes, collision update modes, audit events, and schema changes remain future work requiring stop-and-ask.
- Collateral: Program Blueprint docs updated.

## Verification
- `uv run pytest -q --tb=short tests/test_program_blueprints.py -k "apply"`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run pytest -q --tb=short`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path='':memory:'').check()"`

Addresses #85