### PR TITLE
Wrap thread replies in a service transaction

### DIFF
--- a/docs/architecture/request-identity-and-command-protocol.md
+++ b/docs/architecture/request-identity-and-command-protocol.md
@@ -58,6 +58,13 @@ Commands that create posts, scenes, rooms, reserves, claims, applications,
 notifications, or identity transitions need either idempotency or a deliberate
 duplicate policy.
 
+High-risk multi-row commands should put story-visible and attention-visible
+side effects in one service transaction. Replying to a thread creates the post,
+fanout notifications, watch state, and read marker inside one transaction so a
+late notification/watch failure cannot leave a stranded reply. Starting a thread
+similarly keeps thread, participants, opening post, watch, and read marker
+together.
+
 When a command-token form reserves a server idempotency key and then fails
 before producing the canonical result path, the incomplete reservation must be
 discarded. Validation errors, stale actor failures, and rolled-back service

--- a/src/elbysodic/services/posting.py
+++ b/src/elbysodic/services/posting.py
@@ -346,10 +346,11 @@ def reply_to_thread(
     cleaned = body.strip()
     if not cleaned:
         raise ValueError("reply body is required")
-    post = repo.create_post(viewer.community.id, thread.id, character.id, cleaned)
-    notify_post_created(repo, viewer, thread, post)
-    repo.watch_thread(viewer.community.id, thread.id, viewer.membership.id)
-    repo.mark_thread_read(viewer.community.id, thread.id, viewer.membership.id)
+    with repo.transaction():
+        post = repo.create_post(viewer.community.id, thread.id, character.id, cleaned)
+        notify_post_created(repo, viewer, thread, post)
+        repo.watch_thread(viewer.community.id, thread.id, viewer.membership.id)
+        repo.mark_thread_read(viewer.community.id, thread.id, viewer.membership.id)
     return post
 
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -10103,6 +10103,46 @@ def test_notifications_track_watched_thread_replies_and_open_read_state() -> Non
     asyncio.run(run())
 
 
+def test_reply_notification_failure_rolls_back_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    services.watch_thread("plotting", "open-thread-roster")
+    board = repo.get_board_by_slug(services.seed.community.id, "plotting")
+    thread = repo.get_thread_by_slug(
+        services.seed.community.id,
+        board.id,
+        "open-thread-roster",
+    )
+    before_posts = repo.list_posts(services.seed.community.id, thread.id)
+    outsider_services, outsider_character_id = _outsider_services(
+        services,
+        prefix="rollback-notify",
+    )
+
+    def fail_create_notification(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("notification fanout failed")
+
+    monkeypatch.setattr(repo, "create_notification", fail_create_notification)
+    with pytest.raises(RuntimeError, match="notification fanout failed"):
+        outsider_services.reply_to_thread(
+            "plotting",
+            "open-thread-roster",
+            outsider_character_id,
+            "This reply should roll back with notification fanout.",
+        )
+
+    after_posts = repo.list_posts(services.seed.community.id, thread.id)
+
+    assert [post.id for post in after_posts] == [post.id for post in before_posts]
+    assert (
+        repo.count_unread_notifications(
+            services.seed.community.id,
+            services.seed.membership.id,
+        )
+        == 0
+    )
+
+
 def test_notification_inbox_limit_applies_after_visibility_filtering() -> None:
     async def run() -> None:
         app = _app()


### PR DESCRIPTION
## Summary
- wrap reply post creation, notification fanout, watch state, and read marker writes in one repository transaction
- add rollback proof that a notification fanout failure does not leave a stranded story-visible reply
- document the reply/start-thread transaction boundary in the command protocol guide

## Steward Notes
- Service steward: the reply command now owns the multi-row workflow boundary instead of relying on individual repository commits.
- Storage steward: rollback proof simulates a late notification failure after post insertion and verifies the persisted post list is unchanged.
- Tests steward: focused regression covers failure behavior plus the normal watched-thread notification path.
- Collateral: request identity and command protocol docs updated; no schema, route, or public command shape changed.

## Verification
- uv run pytest -q --tb=short tests/test_forum_slice.py -k "reply_notification_failure_rolls_back_post or notifications_track_watched_thread_replies_and_open_read_state"
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

Addresses #56