### PR TITLE
Record access request account-link history

### DIFF
--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -122,7 +122,9 @@ Duplicate open access requests are deduplicated by email inside one community.
 If a later duplicate arrives from a signed-in account for the same email, the
 existing anonymous request may link `account_user_id`; it must not create a
 second request or grant membership, role, face, invite, reserve, claim, session,
-or active-face state.
+or active-face state. The account-link event is recorded for director-visible
+history, but it does not change request status or expose private request details
+to the applicant or public preview.
 
 The access-request lifecycle is `pending -> reviewed -> invited` or
 `pending/reviewed -> declined`. An invited request may link to the invitation
@@ -133,7 +135,8 @@ access request remains the audit trail for why the invite was issued.
 Director-visible access-request activity events are stored in
 `community_access_request_events` with `community_id`, request id, optional
 actor membership, status transition, optional invitation id, and timestamp.
-These events are staff workflow history, not public preview data.
+Submitted, account-linked, reviewed, invited, and declined events are staff
+workflow history, not public preview data.
 
 First-realm creation is not a public web permission. The current setup path is
 the operator-only `bootstrap-first-realm` CLI command, which creates a global

--- a/docs/operations/invite-only-alpha.md
+++ b/docs/operations/invite-only-alpha.md
@@ -37,7 +37,8 @@ replica, and explicit smoke evidence before writers are invited.
 - Confirm expired, revoked, and accepted links do not grant access.
 - If a prospect submitted request-access before logging in, a later signed-in
   duplicate for the same email should link that account to the existing open
-  request instead of creating a second queue item or granting membership.
+  request instead of creating a second queue item or granting membership. Studio
+  records that account-link event in the director-visible request history.
 
 ### Invitation Delivery Policy
 

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -1146,16 +1146,23 @@ class IdentityRepositoryMixin(RepositoryBase):
             if access_request.account_user_id != account_user_id:
                 raise PermissionError("access request is already linked to another account")
             return access_request
-        self.connection.execute(
-            """
-            UPDATE community_access_requests
-            SET account_user_id = ?,
-                updated_at = ?
-            WHERE community_id = ? AND id = ?
-            """,
-            (account_user_id, _utc_now(), community_id, request_id),
-        )
-        self._commit()
+        with self.transaction():
+            self.connection.execute(
+                """
+                UPDATE community_access_requests
+                SET account_user_id = ?,
+                    updated_at = ?
+                WHERE community_id = ? AND id = ?
+                """,
+                (account_user_id, _utc_now(), community_id, request_id),
+            )
+            self.create_community_access_request_event(
+                community_id,
+                request_id,
+                event_type="account_linked",
+                from_status=access_request.status,
+                to_status=access_request.status,
+            )
         return self.get_community_access_request(community_id, request_id)
 
     def update_community_access_request_status(
@@ -1212,7 +1219,13 @@ class IdentityRepositoryMixin(RepositoryBase):
         actor_membership_id: int | None = None,
         invitation_id: int | None = None,
     ) -> CommunityAccessRequestEvent:
-        if event_type not in {"submitted", "reviewed", "invited", "declined"}:
+        if event_type not in {
+            "account_linked",
+            "submitted",
+            "reviewed",
+            "invited",
+            "declined",
+        }:
             raise ValueError("access request event type is not supported")
         access_request = self.get_community_access_request(community_id, request_id)
         if actor_membership_id is not None:

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -5068,12 +5068,15 @@ def _access_request_activity_item(
     event: CommunityAccessRequestEvent,
 ) -> AccessRequestActivityItem:
     labels = {
+        "account_linked": "Account linked",
         "submitted": "Requested access",
         "reviewed": "Marked for review",
         "invited": "Invitation created",
         "declined": "Request declined",
     }
     detail = f"{_access_request_status_label(event.from_status)} to {event.to_status.title()}"
+    if event.event_type == "account_linked":
+        detail = "Existing request linked to an Elbysodic account"
     if event.event_type == "submitted":
         detail = "Entered the access queue"
     if event.invitation_id is not None:

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -4218,6 +4218,12 @@ def test_access_request_detail_shows_activity_history() -> None:
             wanted_hook="Activity opening",
             notes="Ready for review.",
         )
+        account = services.repo.create_user("activity-prospect@example.com", "hash")
+        services.repo.link_community_access_request_account_user(
+            staff.community.id,
+            access_request.id,
+            account.id,
+        )
         app = create_app(
             debug=False,
             services=AppServices(
@@ -4255,8 +4261,15 @@ def test_access_request_detail_shows_activity_history() -> None:
         )
         assert reviewed.status == 200
         assert invited.status == 200
-        assert [event.event_type for event in events] == ["submitted", "reviewed", "invited"]
+        assert [event.event_type for event in events] == [
+            "submitted",
+            "account_linked",
+            "reviewed",
+            "invited",
+        ]
         assert "Requested access" in detail.text
+        assert "Account linked" in detail.text
+        assert "Existing request linked to an Elbysodic account" in detail.text
         assert "Marked for review" in detail.text
         assert "Invitation created" in detail.text
         assert f"with invitation #{events[-1].invitation_id}" in detail.text

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -779,6 +779,10 @@ def test_access_request_account_linking_preserves_existing_open_request(
     assert linked.account_user_id == user.id
     assert linked_again == linked
     assert repo.list_community_access_requests(default.id) == [linked]
+    assert [
+        event.event_type
+        for event in repo.list_community_access_request_events(default.id, linked.id)
+    ] == ["submitted", "account_linked"]
     assert (
         repo.find_open_community_access_request(default.id, email="linked-request@example.com")
         == linked


### PR DESCRIPTION
## Summary
- record an account_linked lifecycle event when a signed-in duplicate links to an existing open access request
- keep duplicate account linking idempotent so repeated submissions do not create extra queue rows or extra account-link events
- render the account-link event in director-only access-request activity and update lifecycle docs

## Steward Notes
- Security steward: account-link history stays director-visible and does not grant membership, role, face, invitation, session, reserve, claim, or active-face state.
- Storage steward: account linking and event creation are wrapped in the existing repository transaction; no schema or migration changes.
- Service steward: director activity read models now label account-link recovery explicitly.
- Tests steward: repository idempotency, rendered director activity, and production duplicate-link recovery paths are covered.

## Verification
- uv run pytest -q --tb=short tests/test_tenant_repository.py -k access_request_account_linking_preserves_existing_open_request
- uv run pytest -q --tb=short tests/test_forum_slice.py -k access_request_detail_shows_activity_history
- uv run pytest -q --tb=short tests/test_web_security.py -k production_signed_in_duplicate_access_request_links_existing_record
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

Addresses #86