### PR TITLE
Add a community export manifest backend

### DIFF
--- a/docs/architecture/primitives.md
+++ b/docs/architecture/primitives.md
@@ -255,6 +255,19 @@ thread between visible boards.
 Moving a thread must not rewrite post history, revisions, read state, watches,
 or notification targets.
 
+## Community Export
+
+Community export currently starts as an internal service-owned manifest, not a
+public CLI, API, or self-serve UI. The manifest is scoped to one community and
+summarizes counts, ownership edges, stable source links, and redaction rules
+through tenant-aware repository methods.
+
+The export contract preserves membership ownership and character authorship as
+separate facts. It deliberately excludes global login users, password hashes,
+sessions, token hashes, raw invite tokens, and private access-request notes from
+the general community archive manifest. Director-only detail export can be
+designed later if those private workflow records need a separate archive path.
+
 ## Continuity Graph
 
 Continuity Graph is not yet a persistence primitive in this repo. Existing

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -135,6 +135,14 @@ Director-visible access-request activity events are stored in
 actor membership, status transition, optional invitation id, and timestamp.
 These events are staff workflow history, not public preview data.
 
+Community export manifests are director-only backend read models. They may count
+community-scoped workflow rows and preserve source links, membership ownership,
+and character authorship, but the general manifest excludes global users,
+password hashes, session state, token hashes, raw invitation tokens, and private
+access-request notes. A future detail export for staff workflow records needs a
+separate privacy review before it can include applicant emails, notes, or
+invitation audit material.
+
 First-realm creation is not a public web permission. The current setup path is
 the operator-only `bootstrap-first-realm` CLI command, which creates a global
 login user plus a community-local director membership in the same transaction.

--- a/src/elbysodic/services/exports.py
+++ b/src/elbysodic/services/exports.py
@@ -1,0 +1,301 @@
+"""Community export manifest read models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from elbysodic.domain.models import (
+    Board,
+    Character,
+    CharacterClaim,
+    CharacterPlotHook,
+    CharacterReserve,
+    ClaimType,
+    Community,
+    CommunityAccessRequest,
+    CommunityInvitation,
+    CommunityMembership,
+    Material,
+    PlottingRoom,
+    Post,
+    Role,
+    Thread,
+    WantedAd,
+)
+from elbysodic.services import policies
+from elbysodic.services.read_models import ForumView
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityExportCount:
+    label: str
+    count: int
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityExportOwnership:
+    kind: str
+    record_id: int
+    membership_id: int | None
+    character_id: int | None
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityExportSourceLink:
+    kind: str
+    record_id: int
+    href: str
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityExportRedaction:
+    scope: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityExportManifest:
+    community_id: int
+    community_slug: str
+    community_name: str
+    counts: tuple[CommunityExportCount, ...]
+    ownership: tuple[CommunityExportOwnership, ...]
+    source_links: tuple[CommunityExportSourceLink, ...]
+    redactions: tuple[CommunityExportRedaction, ...]
+
+
+class CommunityExportRepository(Protocol):
+    def get_community(self, community_id: int) -> Community: ...
+
+    def list_memberships(self, community_id: int) -> list[CommunityMembership]: ...
+
+    def roles_for_memberships(self, membership_ids: list[int]) -> dict[int, Role]: ...
+
+    def list_community_characters(self, community_id: int) -> list[Character]: ...
+
+    def list_boards(self, community_id: int) -> list[Board]: ...
+
+    def list_threads(self, community_id: int, board_id: int | None = None) -> list[Thread]: ...
+
+    def list_posts_for_threads(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+    ) -> dict[int, list[Post]]: ...
+
+    def list_materials(self, community_id: int, *, status: str | None = None) -> list[Material]: ...
+
+    def list_claim_types(self, community_id: int) -> list[ClaimType]: ...
+
+    def list_character_claims(
+        self,
+        community_id: int,
+        *,
+        status: str | None = "claimed",
+        claim_type_id: int | None = None,
+    ) -> list[CharacterClaim]: ...
+
+    def list_character_reserves_for_community(
+        self,
+        community_id: int,
+        *,
+        status: str | None = "active",
+    ) -> list[CharacterReserve]: ...
+
+    def list_wanted_ads(
+        self,
+        community_id: int,
+        *,
+        status: str | None = "open",
+    ) -> list[WantedAd]: ...
+
+    def list_character_plot_hooks(
+        self,
+        community_id: int,
+        *,
+        status: str | None = "open",
+    ) -> list[CharacterPlotHook]: ...
+
+    def list_plotting_rooms(
+        self,
+        community_id: int,
+        *,
+        status: str | None = None,
+    ) -> list[PlottingRoom]: ...
+
+    def list_community_access_requests(
+        self,
+        community_id: int,
+        *,
+        status: str | None = None,
+    ) -> list[CommunityAccessRequest]: ...
+
+    def list_community_invitations(self, community_id: int) -> list[CommunityInvitation]: ...
+
+
+def community_export_manifest(
+    repo: CommunityExportRepository,
+    viewer: ForumView,
+) -> CommunityExportManifest:
+    if not policies.can_manage_world(viewer.membership, viewer.role):
+        raise PermissionError("director access is required to export community archives")
+    community = repo.get_community(viewer.community.id)
+    memberships = repo.list_memberships(community.id)
+    roles = repo.roles_for_memberships([membership.id for membership in memberships])
+    characters = repo.list_community_characters(community.id)
+    boards = repo.list_boards(community.id)
+    threads = repo.list_threads(community.id)
+    posts_by_thread = repo.list_posts_for_threads(
+        community.id,
+        [thread.id for thread in threads],
+    )
+    materials = repo.list_materials(community.id, status=None)
+    claim_types = repo.list_claim_types(community.id)
+    claims = repo.list_character_claims(community.id, status=None)
+    reserves = repo.list_character_reserves_for_community(community.id, status=None)
+    wanted_ads = repo.list_wanted_ads(community.id, status=None)
+    plot_hooks = repo.list_character_plot_hooks(community.id, status=None)
+    plotting_rooms = repo.list_plotting_rooms(community.id, status=None)
+    access_requests = repo.list_community_access_requests(community.id, status=None)
+    invitations = repo.list_community_invitations(community.id)
+    posts = [post for thread_posts in posts_by_thread.values() for post in thread_posts]
+    return CommunityExportManifest(
+        community_id=community.id,
+        community_slug=community.slug,
+        community_name=community.name,
+        counts=(
+            CommunityExportCount("memberships", len(memberships)),
+            CommunityExportCount("roles", len({role.id for role in roles.values()})),
+            CommunityExportCount("characters", len(characters)),
+            CommunityExportCount("boards", len(boards)),
+            CommunityExportCount("threads", len(threads)),
+            CommunityExportCount("posts", len(posts)),
+            CommunityExportCount("materials", len(materials)),
+            CommunityExportCount("claim_types", len(claim_types)),
+            CommunityExportCount("claims", len(claims)),
+            CommunityExportCount("reserves", len(reserves)),
+            CommunityExportCount("wanted_ads", len(wanted_ads)),
+            CommunityExportCount("plot_hooks", len(plot_hooks)),
+            CommunityExportCount("plotting_rooms", len(plotting_rooms)),
+            CommunityExportCount("access_requests", len(access_requests)),
+            CommunityExportCount("invitations", len(invitations)),
+        ),
+        ownership=(
+            *(
+                CommunityExportOwnership(
+                    "character",
+                    character.id,
+                    character.membership_id,
+                    character.id,
+                    character.name,
+                )
+                for character in characters
+            ),
+            *(
+                CommunityExportOwnership(
+                    "post",
+                    post.id,
+                    post.author_membership_id,
+                    post.author_character_id,
+                    f"post #{post.post_number}",
+                )
+                for post in posts
+            ),
+            *(
+                CommunityExportOwnership(
+                    "wanted_ad",
+                    wanted_ad.id,
+                    wanted_ad.creator_membership_id,
+                    wanted_ad.creator_character_id,
+                    wanted_ad.title,
+                )
+                for wanted_ad in wanted_ads
+            ),
+            *(
+                CommunityExportOwnership(
+                    "plot_hook",
+                    plot_hook.id,
+                    plot_hook.author_membership_id,
+                    plot_hook.character_id,
+                    plot_hook.title,
+                )
+                for plot_hook in plot_hooks
+            ),
+            *(
+                CommunityExportOwnership(
+                    "plotting_room",
+                    room.id,
+                    room.owner_membership_id,
+                    None,
+                    room.title,
+                )
+                for room in plotting_rooms
+            ),
+        ),
+        source_links=(
+            *(
+                CommunityExportSourceLink(
+                    "board",
+                    board.id,
+                    f"/c/{community.slug}/boards/{board.slug}",
+                    board.name,
+                )
+                for board in boards
+            ),
+            *(
+                CommunityExportSourceLink(
+                    "thread",
+                    thread.id,
+                    f"/c/{community.slug}/boards/{_board_slug(boards, thread.board_id)}/threads/{thread.slug}",
+                    thread.title,
+                )
+                for thread in threads
+            ),
+            *(
+                CommunityExportSourceLink(
+                    "material",
+                    material.id,
+                    f"/c/{community.slug}/world/{material.slug}",
+                    material.title,
+                )
+                for material in materials
+            ),
+            *(
+                CommunityExportSourceLink(
+                    "wanted_ad",
+                    wanted_ad.id,
+                    f"/c/{community.slug}/wanted/{wanted_ad.slug}",
+                    wanted_ad.title,
+                )
+                for wanted_ad in wanted_ads
+            ),
+        ),
+        redactions=(
+            CommunityExportRedaction(
+                "global_users",
+                "global login accounts and password hashes are outside one community export",
+            ),
+            CommunityExportRedaction(
+                "sessions",
+                "session cookies, token hashes, and selected identity state are never archived",
+            ),
+            CommunityExportRedaction(
+                "invitations",
+                "raw invite tokens are unavailable after creation because only token hashes are stored",
+            ),
+            CommunityExportRedaction(
+                "access_requests",
+                "private request notes and applicant emails require a director-only detail export",
+            ),
+        ),
+    )
+
+
+def _board_slug(boards: list[Board], board_id: int) -> str:
+    for board in boards:
+        if board.id == board_id:
+            return board.slug
+    return "missing-board"

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -143,6 +143,8 @@ from elbysodic.services.claims import (
 )
 from elbysodic.services.claims import claims_directory as _claims_directory
 from elbysodic.services.discovery import discover_plots as _discover_plots
+from elbysodic.services.exports import CommunityExportManifest
+from elbysodic.services.exports import community_export_manifest as _community_export_manifest
 from elbysodic.services.facets import (
     current_character_facet_ids as _current_character_facet_ids,
 )
@@ -1534,6 +1536,9 @@ class AppServices:
             preview_card=preview_card,
             choice_groups=discovery_profile_choice_groups(),
         )
+
+    def community_export_manifest(self) -> CommunityExportManifest:
+        return _community_export_manifest(self.repo, self.viewer())
 
     def update_discovery_profile(
         self,

--- a/tests/test_community_exports.py
+++ b/tests/test_community_exports.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from elbysodic.db.seed import DemoSeed, resolve_seed_persona
+from elbysodic.services import AppServices, create_services
+
+
+def test_director_export_manifest_is_tenant_scoped_and_redacted() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    staff = resolve_seed_persona(repo, "xmen_staff")
+    hp = repo.get_community_by_slug("hp-universe")
+    repo.create_community_access_request(
+        staff.community.id,
+        email="xmen-export@example.com",
+        display_name="X-Men Export Prospect",
+        face_concept="X-Men private export concept",
+        wanted_hook="X-Men private wanted hook",
+        notes="X-Men private request note",
+    )
+    repo.create_community_access_request(
+        hp.id,
+        email="hp-export@example.com",
+        display_name="HP Export Prospect",
+        face_concept="HP private export concept",
+        wanted_hook="HP private wanted hook",
+        notes="HP private request note",
+    )
+    staff_services = AppServices(
+        repo,
+        DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+    )
+
+    manifest = staff_services.community_export_manifest()
+    counts = {item.label: item.count for item in manifest.counts}
+    rendered_manifest = repr(manifest)
+
+    assert manifest.community_slug == "x-men-apocalypse"
+    assert counts["memberships"] > 0
+    assert counts["characters"] > 0
+    assert counts["threads"] > 0
+    assert counts["posts"] > 0
+    assert counts["access_requests"] >= 1
+    assert all(link.href.startswith("/c/x-men-apocalypse/") for link in manifest.source_links)
+    assert {redaction.scope for redaction in manifest.redactions} >= {
+        "access_requests",
+        "global_users",
+        "invitations",
+        "sessions",
+    }
+    assert any(
+        item.kind == "post" and item.membership_id is not None and item.character_id is not None
+        for item in manifest.ownership
+    )
+    assert "xmen-export@example.com" not in rendered_manifest
+    assert "X-Men private request note" not in rendered_manifest
+    assert "HP private request note" not in rendered_manifest
+    assert "hp-export@example.com" not in rendered_manifest
+    assert "HP Universe" not in rendered_manifest
+    assert "dev-password-hash" not in rendered_manifest
+
+
+def test_member_cannot_create_community_export_manifest() -> None:
+    services = create_services(path=":memory:")
+
+    with pytest.raises(PermissionError, match="director access is required"):
+        services.community_export_manifest()


### PR DESCRIPTION
## Summary
- add an internal director-only community export manifest service for counts, ownership edges, source links, and redaction posture
- preserve membership ownership and character authorship separately in manifest rows
- prove the manifest stays tenant-scoped and excludes global users, password/session/token data, raw invite tokens, applicant emails, and private access-request notes

## Steward Notes
- Service steward: export assembly is service-owned and uses existing tenant-aware repository APIs, not page SQL.
- Security steward: this does not add public CLI/API/routes; the manifest is director-only and redacts secrets/private workflow details.
- Domain steward: ownership rows keep membership and character identity separate for posts, wanted hooks, plot hooks, rooms, and characters.
- Docs steward: primitives and security-boundary docs now describe the internal manifest contract and deferred detail-export path.

## Verification
- uv run pytest -q --tb=short tests/test_community_exports.py
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

Addresses #81