### PR TITLE
Prove invite acceptance stays realm-local

### DIFF
--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -152,6 +152,11 @@ other realm. Studio invitation management may list invitation state and revoke
 pending invites, but only the creation response renders the raw invite link
 because stored invitations retain token hashes.
 
+When an existing global account accepts an invitation for another community,
+the new membership and optional first face are local to the invited community.
+Existing memberships, default faces, roles, and active-face state in other
+communities must not be changed by the invite acceptance flow.
+
 Invitation delivery is copy-only until a sender policy exists. "Resend" means
 reissue, not recover: a director revokes the pending invitation and creates a
 fresh token for the same email. Accepted, revoked, or expired invitations do

--- a/docs/operations/invite-only-alpha.md
+++ b/docs/operations/invite-only-alpha.md
@@ -35,6 +35,9 @@ replica, and explicit smoke evidence before writers are invited.
   pending, use `Reissue invitation` to revoke it and create a fresh invitation
   for the same email.
 - Confirm expired, revoked, and accepted links do not grant access.
+- When inviting an existing Elbysodic account into another realm, acceptance
+  reuses the global account but creates membership and any first face only in
+  the invited realm.
 - If a prospect submitted request-access before logging in, a later signed-in
   duplicate for the same email should link that account to the existing open
   request instead of creating a second queue item or granting membership.

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -22,6 +22,7 @@ from elbysodic.db.seed import DemoSeed, resolve_seed_persona, seed_demo_forum
 from elbysodic.domain import Community, Thread
 from elbysodic.services import AppServices, create_services, default_database_path
 from elbysodic.services.access import TENANT_SLUG_CACHE_KEY
+from elbysodic.services.auth import hash_password
 from elbysodic.services.notifications import (
     count_visible_unread_notifications,
     mark_all_notifications_read,
@@ -4965,6 +4966,59 @@ def test_invitation_acceptance_uses_writer_activation_handoff() -> None:
     assert accepted.activation.stage == "needs_face"
     assert accepted.activation.primary_href == "/applications/new"
     assert accepted.next_path == "/c/x-men-apocalypse/applications/new"
+
+
+def test_invitation_acceptance_keeps_existing_account_memberships_local() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    staff = resolve_seed_persona(repo, "xmen_staff")
+    hp = repo.get_community_by_slug("hp-universe")
+    hp_role = repo.create_role(hp.id, "cross-realm-member", "Cross Realm Member")
+    invite_password = "writer-" + "password"
+    user = repo.create_user("cross-realm-invite@example.com", hash_password(invite_password))
+    hp_membership = repo.create_membership(
+        hp.id,
+        user.id,
+        hp_role.id,
+        "cross-realm-hp",
+        "Cross Realm HP",
+    )
+    hp_character = repo.create_character(
+        hp.id,
+        hp_membership.id,
+        "cross-realm-hp-face",
+        "Cross Realm HP Face",
+        make_default=True,
+    )
+    staff_services = AppServices(
+        repo,
+        DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+    )
+    created = staff_services.create_writer_invitation("cross-realm-invite@example.com")
+
+    accepted = staff_services.accept_invitation(
+        created.token,
+        username="cross-realm-xmen",
+        display_name="Cross Realm X-Men",
+        password=invite_password,
+        first_face_name="Cross Realm X-Men Face",
+    )
+
+    xmen_membership = repo.get_membership_for_user(staff.community.id, user.id)
+    xmen_character = repo.get_character_by_slug(staff.community.id, "cross-realm-x-men-face")
+    refreshed_hp_membership = repo.get_membership(hp.id, hp_membership.id)
+
+    assert accepted.identity.user_id == user.id
+    assert accepted.identity.community_id == staff.community.id
+    assert accepted.identity.membership_id == xmen_membership.id
+    assert accepted.first_character == xmen_character
+    assert accepted.next_path == "/c/x-men-apocalypse/desk"
+    assert xmen_membership.user_id == user.id
+    assert xmen_membership.default_character_id == xmen_character.id
+    assert xmen_character.membership_id == xmen_membership.id
+    assert refreshed_hp_membership.default_character_id == hp_character.id
+    assert repo.get_character(hp.id, hp_character.id).membership_id == hp_membership.id
+    assert repo.list_community_invitations(staff.community.id)[0].accepted_user_id == user.id
 
 
 def test_realm_launch_room_requires_director_membership() -> None:


### PR DESCRIPTION
## Summary
- add backend proof that an existing global account accepting an invite into another realm gets only a local membership and optional first face in the invited community
- verify the existing membership/default face in the account's other realm is untouched
- document the realm-local invite acceptance invariant in security and invite-only alpha docs

## Steward Notes
- Security steward: global users remain separate from community-local memberships and default faces.
- Service steward: invite acceptance continues through the service flow and activation handoff; no page-local membership creation.
- Storage steward: test covers same global user across two communities with distinct memberships and characters.
- Collateral: docs updated; no schema, route, or public invitation surface changes.

## Verification
- uv run pytest -q --tb=short tests/test_forum_slice.py -k "invitation_acceptance_uses_writer_activation_handoff or invitation_acceptance_keeps_existing_account_memberships_local or studio_launch_invites_writer_into_forum"
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

Addresses #57