### PR TITLE
Expand tenant integrity diagnostics

### DIFF
--- a/docs/architecture/data-integrity.md
+++ b/docs/architecture/data-integrity.md
@@ -17,8 +17,10 @@ High-risk tenant-paired rows include:
 - boards, threads, posts, and public authorship
 - command submissions and the membership that reserved the command
 - applications and review events
+- realm interaction definitions, responses, answers, and options
 - wanted hooks, interests, reserves, and claims
-- plotting rooms, participants, and messages
+- plotting rooms, source interests, target scenes, participants, and messages
+- reactions, reads, watches, and thread participants
 - notifications and sidebar counts
 - user-session selected membership
 
@@ -36,7 +38,10 @@ operations surface for old data, migrations, imports, and local demo databases.
 `ForumRepository.list_tenant_pair_integrity_issues()` is the shared repository
 diagnostic for tenant-paired creative and workflow rows, including membership
 roles, default faces, character ownership, command submissions, authorship,
-claims, plotting, thread state, and notifications.
+claims, realm interactions, plotting rooms, reactions, thread state, and
+notifications. Diagnostic rows report ids, table names, tenant ids, and
+content-free relationship reasons so operators can plan repair work without
+exposing private posts, room notes, application answers, or staff-only details.
 
 ## Session Selection
 

--- a/docs/architecture/migrations.md
+++ b/docs/architecture/migrations.md
@@ -51,6 +51,11 @@ Tables that join community-scoped objects should either store `community_id`
 directly or enforce the community boundary in repository write methods before
 inserting rows.
 
+Before adding stricter tenant-pair constraints or triggers, add or expand the
+repository integrity diagnostic for the affected row family and prove it with a
+corrupt legacy-row test. The migration should then either repair, clear, or
+explicitly reject those diagnosed rows before the new constraint is installed.
+
 Partial unique indexes are preferred when a workflow allows one of several
 identity shapes, such as character-backed interest and prospective-character
 interest. Do not rely on nullable columns inside a broad unique constraint to

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -53,6 +53,13 @@ This applies to non-thread primitives too. A wanted hook, facet, material,
 claim, reserve, or application in one community must not be addressable through
 another community's resolver or service layer.
 
+Tenant-pair diagnostics cover stored workflow rows that join community-local
+objects, including plotting-room source interests and target scenes, realm
+interaction questions/options, reactions, thread reads/watches, notifications,
+and authorship rows. These diagnostics exist for operations and migration
+repair planning; repository and service methods still enforce tenant scope
+before normal writes.
+
 ## Route And Link Contract
 
 On shared hosts, `/` and `/network` are platform/network surfaces. A

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -2413,6 +2413,40 @@ class IdentityRepositoryMixin(RepositoryBase):
                 UNION ALL
 
                 SELECT
+                    'realm_interaction_questions' AS table_name,
+                    question.id AS row_id,
+                    question.community_id,
+                    CASE
+                        WHEN interaction.id IS NULL
+                            THEN 'realm interaction question interaction belongs to another community'
+                        ELSE 'realm interaction question tenant pair is invalid'
+                    END AS reason
+                FROM realm_interaction_questions AS question
+                LEFT JOIN realm_interactions AS interaction
+                    ON interaction.id = question.interaction_id
+                    AND interaction.community_id = question.community_id
+                WHERE interaction.id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    'realm_interaction_options' AS table_name,
+                    option.id AS row_id,
+                    option.community_id,
+                    CASE
+                        WHEN question.id IS NULL
+                            THEN 'realm interaction option question belongs to another community'
+                        ELSE 'realm interaction option tenant pair is invalid'
+                    END AS reason
+                FROM realm_interaction_options AS option
+                LEFT JOIN realm_interaction_questions AS question
+                    ON question.id = option.question_id
+                    AND question.community_id = option.community_id
+                WHERE question.id IS NULL
+
+                UNION ALL
+
+                SELECT
                     'realm_interaction_responses' AS table_name,
                     response.id AS row_id,
                     response.community_id,
@@ -2474,6 +2508,27 @@ class IdentityRepositoryMixin(RepositoryBase):
                         answer.option_id IS NOT NULL
                         AND option.id IS NULL
                     )
+
+                UNION ALL
+
+                SELECT
+                    'reactions' AS table_name,
+                    reaction.id AS row_id,
+                    reaction.community_id,
+                    CASE
+                        WHEN post.id IS NULL THEN 'reaction post belongs to another community'
+                        WHEN membership.id IS NULL THEN 'reaction membership belongs to another community'
+                        ELSE 'reaction tenant pair is invalid'
+                    END AS reason
+                FROM reactions AS reaction
+                LEFT JOIN posts AS post
+                    ON post.id = reaction.post_id
+                    AND post.community_id = reaction.community_id
+                LEFT JOIN community_memberships AS membership
+                    ON membership.id = reaction.membership_id
+                    AND membership.community_id = reaction.community_id
+                WHERE post.id IS NULL
+                    OR membership.id IS NULL
 
                 UNION ALL
 
@@ -2578,6 +2633,153 @@ class IdentityRepositoryMixin(RepositoryBase):
                     OR (
                         notification.character_id IS NOT NULL
                         AND target_character.id IS NULL
+                    )
+
+                UNION ALL
+
+                SELECT
+                    'plotting_rooms' AS table_name,
+                    room.id AS row_id,
+                    room.community_id,
+                    CASE
+                        WHEN owner.id IS NULL
+                            THEN 'plotting room owner membership belongs to another community'
+                        WHEN (
+                                room.source_plot_hook_id IS NULL
+                                AND room.source_plot_hook_interest_id IS NULL
+                                AND room.source_wanted_ad_id IS NULL
+                                AND room.source_wanted_ad_interest_id IS NULL
+                            )
+                            THEN 'plotting room source is missing'
+                        WHEN (
+                                (
+                                    room.source_plot_hook_id IS NOT NULL
+                                    OR room.source_plot_hook_interest_id IS NOT NULL
+                                )
+                                AND (
+                                    room.source_wanted_ad_id IS NOT NULL
+                                    OR room.source_wanted_ad_interest_id IS NOT NULL
+                                )
+                            )
+                            THEN 'plotting room has multiple source families'
+                        WHEN (
+                                room.source_plot_hook_id IS NULL
+                                AND room.source_plot_hook_interest_id IS NOT NULL
+                            )
+                            OR (
+                                room.source_plot_hook_id IS NOT NULL
+                                AND room.source_plot_hook_interest_id IS NULL
+                            )
+                            THEN 'plotting room plot source is incomplete'
+                        WHEN (
+                                room.source_wanted_ad_id IS NULL
+                                AND room.source_wanted_ad_interest_id IS NOT NULL
+                            )
+                            OR (
+                                room.source_wanted_ad_id IS NOT NULL
+                                AND room.source_wanted_ad_interest_id IS NULL
+                            )
+                            THEN 'plotting room wanted source is incomplete'
+                        WHEN hook.id IS NULL
+                            AND room.source_plot_hook_id IS NOT NULL
+                            THEN 'plotting room source plot hook belongs to another community'
+                        WHEN hook_interest.id IS NULL
+                            AND room.source_plot_hook_interest_id IS NOT NULL
+                            THEN 'plotting room plot hook interest does not match source hook'
+                        WHEN wanted.id IS NULL
+                            AND room.source_wanted_ad_id IS NOT NULL
+                            THEN 'plotting room source wanted hook belongs to another community'
+                        WHEN wanted_interest.id IS NULL
+                            AND room.source_wanted_ad_interest_id IS NOT NULL
+                            THEN 'plotting room wanted interest does not match source wanted hook'
+                        WHEN target_board.id IS NULL
+                            AND room.target_board_id IS NOT NULL
+                            THEN 'plotting room target board belongs to another community'
+                        WHEN target_thread.id IS NULL
+                            AND room.target_thread_id IS NOT NULL
+                            THEN 'plotting room target thread belongs to another community'
+                        ELSE 'plotting room tenant pair is invalid'
+                    END AS reason
+                FROM plotting_rooms AS room
+                LEFT JOIN community_memberships AS owner
+                    ON owner.id = room.owner_membership_id
+                    AND owner.community_id = room.community_id
+                LEFT JOIN character_plot_hooks AS hook
+                    ON hook.id = room.source_plot_hook_id
+                    AND hook.community_id = room.community_id
+                LEFT JOIN character_plot_hook_interests AS hook_interest
+                    ON hook_interest.id = room.source_plot_hook_interest_id
+                    AND hook_interest.community_id = room.community_id
+                    AND hook_interest.plot_hook_id = room.source_plot_hook_id
+                LEFT JOIN wanted_ads AS wanted
+                    ON wanted.id = room.source_wanted_ad_id
+                    AND wanted.community_id = room.community_id
+                LEFT JOIN wanted_ad_interests AS wanted_interest
+                    ON wanted_interest.id = room.source_wanted_ad_interest_id
+                    AND wanted_interest.community_id = room.community_id
+                    AND wanted_interest.wanted_ad_id = room.source_wanted_ad_id
+                LEFT JOIN boards AS target_board
+                    ON target_board.id = room.target_board_id
+                    AND target_board.community_id = room.community_id
+                LEFT JOIN threads AS target_thread
+                    ON target_thread.id = room.target_thread_id
+                    AND target_thread.community_id = room.community_id
+                WHERE owner.id IS NULL
+                    OR (
+                        room.source_plot_hook_id IS NULL
+                        AND room.source_plot_hook_interest_id IS NULL
+                        AND room.source_wanted_ad_id IS NULL
+                        AND room.source_wanted_ad_interest_id IS NULL
+                    )
+                    OR (
+                        (
+                            room.source_plot_hook_id IS NOT NULL
+                            OR room.source_plot_hook_interest_id IS NOT NULL
+                        )
+                        AND (
+                            room.source_wanted_ad_id IS NOT NULL
+                            OR room.source_wanted_ad_interest_id IS NOT NULL
+                        )
+                    )
+                    OR (
+                        room.source_plot_hook_id IS NULL
+                        AND room.source_plot_hook_interest_id IS NOT NULL
+                    )
+                    OR (
+                        room.source_plot_hook_id IS NOT NULL
+                        AND room.source_plot_hook_interest_id IS NULL
+                    )
+                    OR (
+                        room.source_wanted_ad_id IS NULL
+                        AND room.source_wanted_ad_interest_id IS NOT NULL
+                    )
+                    OR (
+                        room.source_wanted_ad_id IS NOT NULL
+                        AND room.source_wanted_ad_interest_id IS NULL
+                    )
+                    OR (
+                        room.source_plot_hook_id IS NOT NULL
+                        AND hook.id IS NULL
+                    )
+                    OR (
+                        room.source_plot_hook_interest_id IS NOT NULL
+                        AND hook_interest.id IS NULL
+                    )
+                    OR (
+                        room.source_wanted_ad_id IS NOT NULL
+                        AND wanted.id IS NULL
+                    )
+                    OR (
+                        room.source_wanted_ad_interest_id IS NOT NULL
+                        AND wanted_interest.id IS NULL
+                    )
+                    OR (
+                        room.target_board_id IS NOT NULL
+                        AND target_board.id IS NULL
+                    )
+                    OR (
+                        room.target_thread_id IS NOT NULL
+                        AND target_thread.id IS NULL
                     )
 
                 UNION ALL

--- a/tests/test_tenant_repository.py
+++ b/tests/test_tenant_repository.py
@@ -2160,6 +2160,18 @@ def test_realm_interactions_are_scoped_and_accept_one_membership_response(
         "hosted-library",
         "The hosted library",
     )
+    stray_question = repo.create_realm_interaction_question(
+        default.id,
+        interaction.id,
+        "Which quiet corner should be diagnosed?",
+        is_required=False,
+    )
+    stray_option = repo.create_realm_interaction_option(
+        default.id,
+        stray_question.id,
+        "quiet-corner",
+        "A quiet corner",
+    )
 
     response = repo.submit_realm_interaction_response(
         default.id,
@@ -2244,6 +2256,22 @@ def test_realm_interactions_are_scoped_and_accept_one_membership_response(
         """,
         (hosted_option.id, default.id, answer_id),
     )
+    repo.connection.execute(
+        """
+        UPDATE realm_interaction_questions
+        SET interaction_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_interaction.id, default.id, stray_question.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE realm_interaction_options
+        SET question_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_question.id, default.id, stray_option.id),
+    )
     repo.connection.commit()
 
     issue_map = {
@@ -2256,6 +2284,156 @@ def test_realm_interactions_are_scoped_and_accept_one_membership_response(
     )
     assert issue_map[("realm_interaction_answers", answer_id)] == (
         "realm interaction answer option does not match question"
+    )
+    assert issue_map[("realm_interaction_questions", stray_question.id)] == (
+        "realm interaction question interaction belongs to another community"
+    )
+    assert issue_map[("realm_interaction_options", stray_option.id)] == (
+        "realm interaction option question belongs to another community"
+    )
+
+
+def test_plotting_room_integrity_detects_source_owner_and_target_drift(
+    repo: ForumRepository,
+) -> None:
+    default = repo.get_community(1)
+    hosted = repo.create_community("hosted-plotting-room-integrity", "Hosted Plotting Room")
+    default_role = repo.create_role(default.id, "member", "Member")
+    hosted_role = repo.create_role(hosted.id, "member", "Member")
+    owner = repo.create_membership(
+        default.id,
+        repo.create_user("plot-room-owner@example.com", "hash").id,
+        default_role.id,
+        "plot-room-owner",
+        "Plot Room Owner",
+    )
+    prospect = repo.create_membership(
+        default.id,
+        repo.create_user("plot-room-prospect@example.com", "hash").id,
+        default_role.id,
+        "plot-room-prospect",
+        "Plot Room Prospect",
+    )
+    hosted_membership = repo.create_membership(
+        hosted.id,
+        repo.create_user("hosted-plot-room@example.com", "hash").id,
+        hosted_role.id,
+        "hosted-plot-room",
+        "Hosted Plot Room",
+    )
+    owner_character = repo.create_character(
+        default.id,
+        owner.id,
+        "plot-room-owner",
+        "Plot Room Owner",
+    )
+    prospect_character = repo.create_character(
+        default.id,
+        prospect.id,
+        "plot-room-prospect",
+        "Plot Room Prospect",
+    )
+    hosted_character = repo.create_character(
+        hosted.id,
+        hosted_membership.id,
+        "hosted-plot-room",
+        "Hosted Plot Room",
+    )
+    default_board = repo.create_board(default.id, "plot-room", "Plot Room")
+    hosted_board = repo.create_board(hosted.id, "plot-room", "Hosted Plot Room")
+    default_thread = repo.create_thread(
+        default.id,
+        default_board.id,
+        owner_character.id,
+        "plot-room",
+        "Plot Room",
+    )
+    hosted_thread = repo.create_thread(
+        hosted.id,
+        hosted_board.id,
+        hosted_character.id,
+        "hosted-plot-room",
+        "Hosted Plot Room",
+    )
+    hosted_wanted = repo.create_wanted_ad(
+        hosted.id,
+        hosted_membership.id,
+        "hosted-plot-room",
+        "Hosted Plot Room",
+        creator_character_id=hosted_character.id,
+    )
+    hosted_interest = repo.create_wanted_ad_interest(
+        hosted.id,
+        hosted_wanted.id,
+        hosted_membership.id,
+        hosted_character.id,
+    )
+    rooms = []
+    for index, room_title in enumerate(("Owner drift", "Source drift", "Target drift"), start=1):
+        wanted = repo.create_wanted_ad(
+            default.id,
+            owner.id,
+            f"plot-room-{index}",
+            room_title,
+            creator_character_id=owner_character.id,
+        )
+        interest = repo.create_wanted_ad_interest(
+            default.id,
+            wanted.id,
+            prospect.id,
+            prospect_character.id,
+        )
+        rooms.append(
+            repo.create_plotting_room(
+                default.id,
+                owner.id,
+                room_title,
+                source_wanted_ad_id=wanted.id,
+                source_wanted_ad_interest_id=interest.id,
+            )
+        )
+    owner_room, source_room, target_room = rooms
+
+    repo.connection.execute(
+        """
+        UPDATE plotting_rooms
+        SET owner_membership_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_membership.id, default.id, owner_room.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE plotting_rooms
+        SET source_wanted_ad_interest_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_interest.id, default.id, source_room.id),
+    )
+    repo.connection.execute(
+        """
+        UPDATE plotting_rooms
+        SET target_thread_id = ?
+        WHERE community_id = ? AND id = ?
+        """,
+        (hosted_thread.id, default.id, target_room.id),
+    )
+    repo.connection.commit()
+
+    assert repo.get_thread(default.id, default_thread.id).id == default_thread.id
+    issue_map = {
+        (issue.table_name, issue.row_id): issue.reason
+        for issue in repo.list_tenant_pair_integrity_issues()
+    }
+
+    assert issue_map[("plotting_rooms", owner_room.id)] == (
+        "plotting room owner membership belongs to another community"
+    )
+    assert issue_map[("plotting_rooms", source_room.id)] == (
+        "plotting room wanted interest does not match source wanted hook"
+    )
+    assert issue_map[("plotting_rooms", target_room.id)] == (
+        "plotting room target thread belongs to another community"
     )
 
 
@@ -4437,11 +4615,45 @@ def test_thread_read_and_watch_boundaries_are_tenant_scoped(repo: ForumRepositor
         "hosted-thread-state",
         "Hosted Thread State",
     )
+    second_default_post = repo.create_post(
+        default.id,
+        second_default_thread.id,
+        default_character.id,
+        "Second reaction target.",
+    )
+    hosted_post = repo.create_post(
+        hosted.id,
+        hosted_thread.id,
+        hosted_character.id,
+        "Hosted reaction target.",
+    )
 
     repo.mark_thread_read(default.id, default_thread.id, default_membership.id)
     repo.mark_thread_read(default.id, second_default_thread.id, default_membership.id)
     repo.watch_thread(default.id, default_thread.id, default_membership.id)
     repo.watch_thread(default.id, second_default_thread.id, default_membership.id)
+    repo.connection.execute(
+        """
+        INSERT INTO reactions (community_id, post_id, membership_id, reaction_key, created_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (default.id, hosted_post.id, default_membership.id, "spark", "2026-01-01T00:00:00+00:00"),
+    )
+    reaction_post_id = repo.connection.execute("SELECT last_insert_rowid()").fetchone()[0]
+    repo.connection.execute(
+        """
+        INSERT INTO reactions (community_id, post_id, membership_id, reaction_key, created_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            default.id,
+            second_default_post.id,
+            hosted_membership.id,
+            "watching",
+            "2026-01-01T00:00:01+00:00",
+        ),
+    )
+    reaction_membership_id = repo.connection.execute("SELECT last_insert_rowid()").fetchone()[0]
 
     with pytest.raises(LookupError, match="thread not found"):
         repo.unwatch_thread(default.id, hosted_thread.id, default_membership.id)
@@ -4495,6 +4707,12 @@ def test_thread_read_and_watch_boundaries_are_tenant_scoped(repo: ForumRepositor
     )
     assert issue_map[("thread_watches", watch_id)] == (
         "thread watch membership belongs to another community"
+    )
+    assert issue_map[("reactions", reaction_post_id)] == (
+        "reaction post belongs to another community"
+    )
+    assert issue_map[("reactions", reaction_membership_id)] == (
+        "reaction membership belongs to another community"
     )
 
 


### PR DESCRIPTION
## Summary
- expand tenant-pair diagnostics for plotting rooms, realm interaction questions/options, and stored reactions
- add corrupt legacy-row tests proving owner/source/target, interaction definition, and reaction pair drift are reported without rendering private content
- update data-integrity, multi-tenancy, and migration docs to keep schema hardening diagnostic-first

## Steward Notes
- Storage steward: accepted diagnostic-first slice before stricter SQLite constraints; no schema, trigger, or migration changes in this PR.
- Test steward: accepted corrupt legacy-row proof in tests/test_tenant_repository.py with two-community fixtures.
- Docs steward: accepted collateral updates for data-integrity, multi-tenancy, and migration sequencing.
- Deferred: composite foreign keys/triggers, legacy repair migrations, and fresh/upgraded schema parity proof remain follow-up #55 work because they require stop-and-ask schema approval.

## Verification
- uv run pytest tests/test_tenant_repository.py -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

Addresses #55