### PR TITLE
Add read-only restore check service

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,17 @@ elbysodic dev db backup --output var/elbysodic-backup.sqlite3
 `backup` uses SQLite's online backup API and refuses to overwrite an existing
 file unless `--overwrite` is passed.
 
+To verify a copied database without restoring it destructively, run the
+read-only restore-check service against the candidate file:
+
+```bash
+uv run python -c "from pathlib import Path; from elbysodic.services.operations import format_restore_check_report, restore_check_database; print(format_restore_check_report(restore_check_database(Path('var/elbysodic-backup.sqlite3'))))"
+```
+
+The report includes integrity, schema/migration versions, core counts, and
+service readback status. It deliberately omits emails, token hashes, session
+tokens, post bodies, private notes, and credentials.
+
 Before handing off a branch, run the developer gate:
 
 ```bash

--- a/docs/operations/invite-only-alpha.md
+++ b/docs/operations/invite-only-alpha.md
@@ -67,6 +67,8 @@ second invite.
 Stay invite-only unless all are true:
 
 - backup/restore has been rehearsed recently
+- the copied backup reports `restore-check ok` without leaking secrets or
+  private content
 - notification/sidebar privacy tests are green
 - public catalog copy is intentional
 - signed-out preview routes expose only published public content

--- a/docs/operations/production-bootstrap.md
+++ b/docs/operations/production-bootstrap.md
@@ -13,6 +13,8 @@ production bootstrap creates the first real director identity and realm.
 - `ELBYSODIC_SECRET_KEY` is present and at least 32 characters.
 - Demo mode is off for production unless the session is explicitly a demo.
 - A fresh backup exists, or the database is confirmed empty.
+- If a backup exists, the read-only restore-check service reports `restore-check
+  ok` against the copied database without exposing secrets or private content.
 - Studio Operations shows the expected environment, database path, journal
   mode, integrity check, schema version, migration ledger, realm count, and
   launch status.
@@ -57,6 +59,7 @@ Production bootstrap:
 - Director username:
 - Launch status after:
 - Backup path or empty-DB proof:
+- Restore-check result:
 - Result:
 ```
 

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -77,6 +77,8 @@ Staging smoke should include:
 - At least one seed media URL, such as
   `/elbysodic-static/seed-media/xmen-hero.svg`, returns `200`.
 - A restart preserves database row counts and rendered seeded realms.
+- A copied staging database reports `restore-check ok` through the read-only
+  restore-check service before any destructive restore rehearsal.
 - Demo login works for the intended seed account policy.
 
 Known follow-up: `HEAD` requests to some app and static routes can currently

--- a/docs/operations/sqlite-production.md
+++ b/docs/operations/sqlite-production.md
@@ -103,6 +103,20 @@ mode, `ok` integrity check, schema version, migration ledger, and realm count
 expected for the source environment. Do not paste secrets, session cookies,
 reset links, or raw credentials into the drill record.
 
+For a copied candidate database, run the read-only restore-check service before
+any destructive restore step:
+
+```bash
+uv run python -c "from pathlib import Path; from elbysodic.services.operations import format_restore_check_report, restore_check_database; print(format_restore_check_report(restore_check_database(Path('/app/var/elbysodic-backup.sqlite3'))))"
+```
+
+The restore-check opens the file read-only, runs `PRAGMA integrity_check`,
+`PRAGMA foreign_key_check`, schema and migration version checks, core row
+counts, and service readback for communities, memberships, boards/materials,
+threads/posts, sessions, and workflow rows. The formatted report is redacted:
+record counts and statuses only, not emails, token hashes, session tokens,
+private notes, post bodies, application answers, or credentials.
+
 ## Backup/Restore Drill Record
 
 Latest known staging drill:

--- a/src/elbysodic/services/operations.py
+++ b/src/elbysodic/services/operations.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 from typing import Protocol
 
 from elbysodic.db.migrations import CURRENT_SCHEMA_VERSION
@@ -45,6 +46,52 @@ class OperationsRepository(Protocol):
     def list_community_characters(self, community_id: int) -> list[Character]: ...
 
     def list_memberships(self, community_id: int) -> list[CommunityMembership]: ...
+
+
+class RestoreCheckRepository(OperationsRepository, Protocol):
+    def list_boards(self, community_id: int) -> Sequence[object]: ...
+
+    def list_materials(
+        self,
+        community_id: int,
+        *,
+        status: str | None = "published",
+    ) -> Sequence[object]: ...
+
+    def list_threads(
+        self,
+        community_id: int,
+        board_id: int | None = None,
+    ) -> Sequence[RestoreCheckRowWithId]: ...
+
+    def list_posts_for_threads(
+        self,
+        community_id: int,
+        thread_ids: list[int],
+    ) -> Mapping[int, Sequence[object]]: ...
+
+
+class RestoreCheckRowWithId(Protocol):
+    id: int
+
+
+RESTORE_CHECK_CORE_TABLES: tuple[tuple[str, str], ...] = (
+    ("users", "users"),
+    ("communities", "communities"),
+    ("memberships", "community_memberships"),
+    ("roles", "roles"),
+    ("characters", "characters"),
+    ("boards", "boards"),
+    ("materials", "materials"),
+    ("threads", "threads"),
+    ("posts", "posts"),
+    ("sessions", "user_sessions"),
+    ("command submissions", "command_submissions"),
+    ("invitations", "community_invitations"),
+    ("access requests", "community_access_requests"),
+    ("plotting rooms", "plotting_rooms"),
+    ("notifications", "notifications"),
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,6 +142,48 @@ class OperationsInspection:
     latest_migration_version: int
     community_count: int
     launch_status: str
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreCheckCount:
+    label: str
+    table_name: str
+    count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreCheckReadback:
+    label: str
+    status: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreCheckResult:
+    database_path: str
+    opened_read_only: bool
+    integrity_check: str
+    foreign_key_violations: int
+    journal_mode: str
+    sqlite_user_version: int
+    current_schema_version: int
+    latest_migration_version: int
+    community_count: int
+    core_counts: tuple[RestoreCheckCount, ...]
+    readback_checks: tuple[RestoreCheckReadback, ...]
+    failures: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return (
+            self.integrity_check == "ok"
+            and self.foreign_key_violations == 0
+            and self.sqlite_user_version == self.current_schema_version
+            and self.latest_migration_version == self.current_schema_version
+            and self.community_count > 0
+            and not self.failures
+            and all(check.status == "ok" for check in self.readback_checks)
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -400,6 +489,300 @@ def operations_inspection(
         community_count=int(community_count["count"] if community_count is not None else 0),
         launch_status=viewer.community.launch_status,
     )
+
+
+def restore_check_database(path: Path) -> RestoreCheckResult:
+    """Open a candidate SQLite backup read-only and verify service readback."""
+
+    if str(path) == ":memory:":
+        raise ValueError("restore check requires a filesystem database path")
+    if not path.exists():
+        raise FileNotFoundError(path)
+    resolved = path.resolve()
+    connection = sqlite3.connect(f"{resolved.as_uri()}?mode=ro", uri=True)
+    connection.row_factory = sqlite3.Row
+    try:
+        connection.execute("PRAGMA query_only = ON")
+        return _restore_check_connection(connection, resolved)
+    finally:
+        connection.close()
+
+
+def format_restore_check_report(result: RestoreCheckResult) -> str:
+    status = "ok" if result.ok else "failed"
+    lines = [
+        f"restore-check {status}",
+        f"database: {result.database_path}",
+        f"read-only: {'yes' if result.opened_read_only else 'no'}",
+        f"integrity_check: {result.integrity_check}",
+        f"foreign_key_violations: {result.foreign_key_violations}",
+        f"journal_mode: {result.journal_mode}",
+        (
+            "schema: "
+            f"user_version={result.sqlite_user_version} "
+            f"current={result.current_schema_version} "
+            f"latest_migration={result.latest_migration_version}"
+        ),
+        f"communities: {result.community_count}",
+        "counts:",
+    ]
+    lines.extend(f"- {count.label}: {count.count}" for count in result.core_counts)
+    lines.append("readback:")
+    lines.extend(
+        f"- {check.label}: {check.status} ({check.detail})" for check in result.readback_checks
+    )
+    if result.failures:
+        lines.append("failures:")
+        lines.extend(f"- {failure}" for failure in result.failures)
+    return "\n".join(lines) + "\n"
+
+
+def _restore_check_connection(
+    connection: sqlite3.Connection,
+    path: Path,
+) -> RestoreCheckResult:
+    failures: list[str] = []
+    table_names = _restore_check_table_names(connection)
+    integrity_check = _restore_check_integrity(connection, failures)
+    foreign_key_violations = _restore_check_foreign_keys(connection, failures)
+    journal_mode = _restore_check_text_pragma(connection, "journal_mode", failures)
+    sqlite_user_version = _restore_check_int_pragma(connection, "user_version", failures)
+    latest_migration_version = _restore_check_latest_migration(connection, failures)
+    core_counts = _restore_check_counts(connection, table_names, failures)
+    community_count = next(
+        (count.count for count in core_counts if count.table_name == "communities"),
+        0,
+    )
+    if integrity_check != "ok":
+        failures.append(f"integrity_check failed: {integrity_check}")
+    if foreign_key_violations != 0:
+        failures.append(f"foreign_key_check reported {foreign_key_violations} violation(s)")
+    if sqlite_user_version != CURRENT_SCHEMA_VERSION:
+        failures.append(
+            f"schema user_version mismatch: {sqlite_user_version} != {CURRENT_SCHEMA_VERSION}"
+        )
+    if latest_migration_version != CURRENT_SCHEMA_VERSION:
+        failures.append(
+            f"migration ledger mismatch: {latest_migration_version} != {CURRENT_SCHEMA_VERSION}"
+        )
+    if community_count == 0:
+        failures.append("no communities found")
+    readback_checks = _restore_check_readback(connection, table_names)
+    failures.extend(
+        f"service readback failed: {check.label}"
+        for check in readback_checks
+        if check.status != "ok"
+    )
+    return RestoreCheckResult(
+        database_path=str(path),
+        opened_read_only=True,
+        integrity_check=integrity_check,
+        foreign_key_violations=foreign_key_violations,
+        journal_mode=journal_mode,
+        sqlite_user_version=sqlite_user_version,
+        current_schema_version=CURRENT_SCHEMA_VERSION,
+        latest_migration_version=latest_migration_version,
+        community_count=community_count,
+        core_counts=tuple(core_counts),
+        readback_checks=tuple(readback_checks),
+        failures=tuple(failures),
+    )
+
+
+def _restore_check_table_names(connection: sqlite3.Connection) -> set[str]:
+    rows = connection.execute(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+        """
+    ).fetchall()
+    return {str(row["name"]) for row in rows}
+
+
+def _restore_check_integrity(
+    connection: sqlite3.Connection,
+    failures: list[str],
+) -> str:
+    try:
+        row = connection.execute("PRAGMA integrity_check").fetchone()
+    except sqlite3.Error as exc:
+        failures.append(f"integrity_check unavailable: {_restore_check_error(exc)}")
+        return "unavailable"
+    return str(row[0] if row is not None else "unavailable")
+
+
+def _restore_check_foreign_keys(
+    connection: sqlite3.Connection,
+    failures: list[str],
+) -> int:
+    try:
+        return len(connection.execute("PRAGMA foreign_key_check").fetchall())
+    except sqlite3.Error as exc:
+        failures.append(f"foreign_key_check unavailable: {_restore_check_error(exc)}")
+        return -1
+
+
+def _restore_check_text_pragma(
+    connection: sqlite3.Connection,
+    pragma_name: str,
+    failures: list[str],
+) -> str:
+    try:
+        row = connection.execute(f"PRAGMA {pragma_name}").fetchone()
+    except sqlite3.Error as exc:
+        failures.append(f"{pragma_name} unavailable: {_restore_check_error(exc)}")
+        return "unavailable"
+    return str(row[0] if row is not None else "unavailable")
+
+
+def _restore_check_int_pragma(
+    connection: sqlite3.Connection,
+    pragma_name: str,
+    failures: list[str],
+) -> int:
+    try:
+        row = connection.execute(f"PRAGMA {pragma_name}").fetchone()
+    except sqlite3.Error as exc:
+        failures.append(f"{pragma_name} unavailable: {_restore_check_error(exc)}")
+        return -1
+    return int(row[0] if row is not None else -1)
+
+
+def _restore_check_latest_migration(
+    connection: sqlite3.Connection,
+    failures: list[str],
+) -> int:
+    try:
+        row = connection.execute("SELECT MAX(version) AS version FROM schema_migrations").fetchone()
+    except sqlite3.Error as exc:
+        failures.append(f"migration ledger unavailable: {_restore_check_error(exc)}")
+        return 0
+    return int(row["version"] or 0)
+
+
+def _restore_check_counts(
+    connection: sqlite3.Connection,
+    table_names: set[str],
+    failures: list[str],
+) -> list[RestoreCheckCount]:
+    counts: list[RestoreCheckCount] = []
+    for label, table_name in RESTORE_CHECK_CORE_TABLES:
+        if table_name not in table_names:
+            failures.append(f"missing table: {table_name}")
+            continue
+        row = connection.execute(
+            f"SELECT COUNT(*) AS count FROM {table_name}"  # noqa: S608 - fixed constants.
+        ).fetchone()
+        counts.append(
+            RestoreCheckCount(
+                label=label,
+                table_name=table_name,
+                count=int(row["count"] if row is not None else 0),
+            )
+        )
+    return counts
+
+
+def _restore_check_readback(
+    connection: sqlite3.Connection,
+    table_names: set[str],
+) -> list[RestoreCheckReadback]:
+    if "communities" not in table_names:
+        return [RestoreCheckReadback("communities", "failed", "communities table missing")]
+    from elbysodic.db import ForumRepository
+
+    repo = ForumRepository(connection)
+    checks: list[RestoreCheckReadback] = []
+    try:
+        communities = repo.list_communities()
+    except (LookupError, sqlite3.Error) as exc:
+        return [RestoreCheckReadback("communities", "failed", _restore_check_error(exc))]
+    if not communities:
+        return [RestoreCheckReadback("communities", "failed", "no community rows")]
+    community = communities[0]
+    checks.append(
+        RestoreCheckReadback(
+            "communities",
+            "ok",
+            f"{len(communities)} community row(s), first id {community.id}",
+        )
+    )
+    checks.append(_restore_check_membership_readback(repo, community.id))
+    checks.append(_restore_check_world_readback(repo, community.id))
+    checks.append(_restore_check_thread_readback(repo, community.id))
+    workflow_tables = (
+        "user_sessions",
+        "command_submissions",
+        "community_invitations",
+        "community_access_requests",
+        "plotting_rooms",
+        "notifications",
+    )
+    workflow_total = sum(
+        count.count
+        for count in _restore_check_counts(connection, table_names, [])
+        if count.table_name in workflow_tables
+    )
+    checks.append(
+        RestoreCheckReadback(
+            "workflow rows",
+            "ok",
+            f"{workflow_total} counted session/workflow row(s)",
+        )
+    )
+    return checks
+
+
+def _restore_check_membership_readback(
+    repo: OperationsRepository,
+    community_id: int,
+) -> RestoreCheckReadback:
+    try:
+        memberships = repo.list_memberships(community_id)
+    except (LookupError, sqlite3.Error) as exc:
+        return RestoreCheckReadback("memberships", "failed", _restore_check_error(exc))
+    return RestoreCheckReadback("memberships", "ok", f"{len(memberships)} membership row(s)")
+
+
+def _restore_check_world_readback(
+    repo: RestoreCheckRepository,
+    community_id: int,
+) -> RestoreCheckReadback:
+    try:
+        boards = repo.list_boards(community_id)
+        materials = repo.list_materials(community_id, status=None)
+    except (LookupError, sqlite3.Error) as exc:
+        return RestoreCheckReadback("world rows", "failed", _restore_check_error(exc))
+    return RestoreCheckReadback(
+        "world rows",
+        "ok",
+        f"{len(boards)} board row(s), {len(materials)} material row(s)",
+    )
+
+
+def _restore_check_thread_readback(
+    repo: RestoreCheckRepository,
+    community_id: int,
+) -> RestoreCheckReadback:
+    try:
+        threads = repo.list_threads(community_id)
+        posts_by_thread = repo.list_posts_for_threads(
+            community_id,
+            [thread.id for thread in threads[:20]],
+        )
+    except (LookupError, sqlite3.Error) as exc:
+        return RestoreCheckReadback("thread rows", "failed", _restore_check_error(exc))
+    post_count = sum(len(posts) for posts in posts_by_thread.values())
+    return RestoreCheckReadback(
+        "thread rows",
+        "ok",
+        f"{len(threads)} thread row(s), {post_count} sampled post row(s)",
+    )
+
+
+def _restore_check_error(exc: BaseException) -> str:
+    return f"{exc.__class__.__name__}: {exc}"
 
 
 def _writer_activation_card(

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -251,9 +251,31 @@ def test_service_raw_sql_stays_limited_to_lifecycle_and_operations_diagnostics()
             "src/elbysodic/services/operations.py",
             'community_count = connection.execute("SELECT COUNT(*) AS count FROM communities").fetchone()',
         ),
+        (
+            "src/elbysodic/services/operations.py",
+            'connection.execute("PRAGMA query_only = ON")',
+        ),
+        (
+            "src/elbysodic/services/operations.py",
+            'row = connection.execute("PRAGMA integrity_check").fetchone()',
+        ),
+        (
+            "src/elbysodic/services/operations.py",
+            'return len(connection.execute("PRAGMA foreign_key_check").fetchall())',
+        ),
+        (
+            "src/elbysodic/services/operations.py",
+            'row = connection.execute(f"PRAGMA {pragma_name}").fetchone()',
+        ),
+        (
+            "src/elbysodic/services/operations.py",
+            'row = connection.execute("SELECT MAX(version) AS version FROM schema_migrations").fetchone()',
+        ),
     }
     prefix_allowed = {
         ("src/elbysodic/services/operations.py", "migration_row = connection.execute("),
+        ("src/elbysodic/services/operations.py", "rows = connection.execute("),
+        ("src/elbysodic/services/operations.py", "row = connection.execute("),
     }
     offenders: list[str] = []
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -27,7 +27,12 @@ from elbysodic.services.notifications import (
     mark_all_notifications_read,
     visible_unread_notification_counts,
 )
-from elbysodic.services.operations import OperationsInspectionConfig, operations_inspection
+from elbysodic.services.operations import (
+    OperationsInspectionConfig,
+    format_restore_check_report,
+    operations_inspection,
+    restore_check_database,
+)
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_scoped_path, scope_response_urls
@@ -12347,6 +12352,84 @@ def test_file_backed_operations_inspection_reports_wal_and_integrity(
     assert inspection.integrity_check == "ok"
     assert inspection.latest_migration_version == inspection.current_schema_version
     assert inspection.community_count > 0
+
+
+def test_restore_check_database_reports_redacted_service_readback(tmp_path: Path) -> None:
+    db_path = tmp_path / "restore-check.sqlite3"
+    services = create_services(path=db_path)
+    repo = services.repo
+    viewer = services.viewer()
+    assert viewer.current_character is not None
+    secret_user = repo.create_user("secret-restore@example.com", "secret-password-hash")
+    repo.create_user_session(
+        secret_user.id,
+        "secret-session-token",
+        expires_at="2026-06-01T00:00:00+00:00",
+    )
+    repo.create_material(
+        viewer.community.id,
+        "private-restore-note",
+        "Private Restore Note",
+        material_type="guide",
+        summary="Do not emit this summary.",
+        body="Do not emit this material body.",
+        status="draft",
+    )
+    services.start_thread(
+        board_slug="danger-room",
+        character_id=viewer.current_character.id,
+        title="Restore Check Scene",
+        body="Do not emit this post body.",
+    )
+    services.close()
+
+    result = restore_check_database(db_path)
+    report = format_restore_check_report(result)
+
+    assert result.ok is True
+    assert result.opened_read_only is True
+    assert result.integrity_check == "ok"
+    assert result.sqlite_user_version == result.current_schema_version
+    assert result.latest_migration_version == result.current_schema_version
+    assert result.community_count > 0
+    assert "restore-check ok" in report
+    assert "- users:" in report
+    assert "- thread rows: ok" in report
+    assert "secret-restore@example.com" not in report
+    assert "secret-password-hash" not in report
+    assert "secret-session-token" not in report
+    assert "Do not emit this summary." not in report
+    assert "Do not emit this material body." not in report
+    assert "Do not emit this post body." not in report
+
+
+def test_restore_check_database_reports_wrong_database_failure(tmp_path: Path) -> None:
+    db_path = tmp_path / "wrong.sqlite3"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("CREATE TABLE users (email TEXT)")
+        connection.execute("INSERT INTO users (email) VALUES ('wrong@example.com')")
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = restore_check_database(db_path)
+    report = format_restore_check_report(result)
+
+    assert result.ok is False
+    assert "restore-check failed" in report
+    assert "missing table: communities" in result.failures
+    assert "migration ledger unavailable" in "\n".join(result.failures)
+    assert "no communities found" in result.failures
+    assert "wrong@example.com" not in report
+
+
+def test_restore_check_database_requires_filesystem_path(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="filesystem database path"):
+        restore_check_database(Path(":memory:"))
+
+    with pytest.raises(FileNotFoundError):
+        restore_check_database(tmp_path / "missing.sqlite3")
 
 
 def test_composer_pages_point_empty_roster_to_character_setup() -> None:


### PR DESCRIPTION
## Summary
- add a read-only restore-check service that opens a candidate SQLite file with mode=ro and reports integrity, foreign-key, schema/migration, count, and service readback status
- add redacted report formatting that omits emails, token hashes, session tokens, credentials, private notes, material bodies, and post bodies
- document the service-only restore-check workflow in README and operations runbooks

## Steward Notes
- Service steward: accepted a service-owned restore-check contract beside Studio Operations inspection; no route or CLI command added.
- Storage steward: accepted read-only SQLite checks plus repository readback against the copied database; no schema or migration changes.
- Security steward: accepted redacted operator report and explicit tests proving secret/private text is absent.
- Tests steward: accepted file-backed readback, wrong-database failure, filesystem-path failure, and raw-SQL contract coverage.
- Deferred: first-class elbysodic dev db restore-check CLI remains follow-up because adding a CLI command is a public command-surface change that needs explicit approval.

## Verification
- uv run pytest tests/test_forum_slice.py -q --tb=short -k restore_check or operations_inspection
- uv run pytest tests/test_backend_contracts.py::test_service_raw_sql_stays_limited_to_lifecycle_and_operations_diagnostics -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- app construction check: create_app(debug=False, db_path=':memory:').check()

Addresses #80