### PR TITLE
Add staff capability audit contract

### DIFF
--- a/docs/architecture/primitives.md
+++ b/docs/architecture/primitives.md
@@ -24,6 +24,11 @@ capabilities through an admin role, but the product contract remains
 capability-shaped so a future partial-staff role can be added without teaching
 pages to read storage flags directly.
 
+The service policy module keeps an executable capability contract registry for
+the current staff surface. It names protected workflow families and future
+audit-event candidates while preserving the V1 storage shorthand until
+community-scoped capability and audit tables are approved.
+
 `Character` is the public posting identity. Characters are not global. A
 character belongs to exactly one membership in exactly one community.
 

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -66,6 +66,12 @@ become product-visible. Even while storage is coarse, page handlers and
 workflow services should still depend on named policy helpers rather than the
 storage flag.
 
+`src/elbysodic/services/policies.py` owns the current staff capability contract
+registry. Each entry names the helper, V1 storage shorthand, membership actor
+contract, protected workflow families, and candidate audit-event actions for
+future storage. This is an audit map, not a role editor: it must not introduce
+global user staff power, page-local checks, or public audit output.
+
 ## Production Request Identity
 
 Production mode is enabled with `ELBYSODIC_ENV=production` or `staging`.

--- a/src/elbysodic/services/policies.py
+++ b/src/elbysodic/services/policies.py
@@ -44,6 +44,113 @@ class CapabilityDiagnostic:
     message: str
 
 
+@dataclass(frozen=True, slots=True)
+class StaffCapabilityContract:
+    capability: Capability
+    helper_name: str
+    storage_contract: str
+    actor_contract: str
+    protected_workflows: tuple[str, ...]
+    audit_event_candidates: tuple[str, ...]
+
+
+STAFF_CAPABILITY_CONTRACTS: dict[Capability, StaffCapabilityContract] = {
+    "manage_applications": StaffCapabilityContract(
+        capability="manage_applications",
+        helper_name="can_manage_applications",
+        storage_contract="roles.is_admin grants every V1 staff capability",
+        actor_contract="community membership actor; optional public character context",
+        protected_workflows=(
+            "application review queue",
+            "application approval and revision requests",
+            "claim conflict resolution during review",
+        ),
+        audit_event_candidates=(
+            "application_reviewed",
+            "application_approved",
+            "application_revision_requested",
+        ),
+    ),
+    "manage_casting": StaffCapabilityContract(
+        capability="manage_casting",
+        helper_name="can_manage_casting",
+        storage_contract="roles.is_admin grants every V1 staff capability",
+        actor_contract="community membership actor; optional public character context",
+        protected_workflows=(
+            "claims directory maintenance",
+            "reserve lifecycle movement",
+            "wanted-hook interest handoff",
+            "plotting room staff recovery",
+        ),
+        audit_event_candidates=(
+            "claim_updated",
+            "reserve_updated",
+            "wanted_interest_handoff",
+            "plotting_room_recovered",
+        ),
+    ),
+    "manage_navigation": StaffCapabilityContract(
+        capability="manage_navigation",
+        helper_name="can_manage_navigation",
+        storage_contract="roles.is_admin grants every V1 staff capability",
+        actor_contract="community membership actor",
+        protected_workflows=(
+            "board structure editing",
+            "sidebar section configuration",
+            "public gateway slot curation",
+        ),
+        audit_event_candidates=(
+            "board_updated",
+            "sidebar_section_updated",
+            "gateway_slot_updated",
+        ),
+    ),
+    "manage_threads": StaffCapabilityContract(
+        capability="manage_threads",
+        helper_name="can_manage_threads",
+        storage_contract="roles.is_admin grants every V1 staff capability",
+        actor_contract="community membership actor; optional public character context",
+        protected_workflows=(
+            "private board access",
+            "locked thread replies",
+            "thread moderation",
+            "post edit moderation",
+        ),
+        audit_event_candidates=(
+            "thread_locked",
+            "thread_moved",
+            "thread_status_updated",
+            "post_moderated",
+        ),
+    ),
+    "manage_world": StaffCapabilityContract(
+        capability="manage_world",
+        helper_name="can_manage_world",
+        storage_contract="roles.is_admin grants every V1 staff capability",
+        actor_contract="community membership actor",
+        protected_workflows=(
+            "Studio structure and launch management",
+            "material and appearance editing",
+            "Program Blueprint apply",
+            "community export manifest",
+            "operations inspection",
+        ),
+        audit_event_candidates=(
+            "material_updated",
+            "appearance_updated",
+            "blueprint_applied",
+            "community_export_created",
+        ),
+    ),
+}
+
+
+def staff_capability_contracts() -> tuple[StaffCapabilityContract, ...]:
+    return tuple(
+        STAFF_CAPABILITY_CONTRACTS[capability] for capability in sorted(ADMIN_CAPABILITIES)
+    )
+
+
 def has_capability(
     membership: CommunityMembership,
     role: Role | None,

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -74,6 +74,23 @@ def test_named_capability_helpers_stay_registered(
     assert helper(membership, admin_role) is True
 
 
+def test_staff_capability_contracts_cover_named_helpers(
+    membership: CommunityMembership,
+    admin_role: Role,
+) -> None:
+    contracts = policies.staff_capability_contracts()
+
+    assert {contract.capability for contract in contracts} == policies.ADMIN_CAPABILITIES
+    for contract in contracts:
+        helper = getattr(policies, contract.helper_name)
+        assert helper(membership, admin_role) is True
+        assert contract.storage_contract == "roles.is_admin grants every V1 staff capability"
+        assert "membership" in contract.actor_contract
+        assert "global user" not in contract.actor_contract
+        assert contract.protected_workflows
+        assert contract.audit_event_candidates
+
+
 def test_page_handlers_and_services_do_not_check_admin_flag_directly() -> None:
     checked_paths = [
         *Path("src/elbysodic/web/pages").rglob("page.py"),


### PR DESCRIPTION
## Summary
- add a service-owned staff capability contract registry for the current V1 staff surface
- record helper names, V1 storage shorthand, membership actor contract, protected workflow families, and future audit-event candidates
- add policy tests proving every named capability has a helper and contract coverage
- update primitives and security-boundary docs

## Steward Notes
- Service steward: accepted named policy helpers as the stable authorization surface.
- Storage steward: V1 storage remains roles.is_admin; no schema, migration, or role behavior changes in this PR.
- Security steward: registry preserves membership-local actor contracts and rejects global user staff power.
- Tests steward: accepted executable policy coverage plus existing no page/service direct is_admin guard.
- Deferred: role-capability rows, audit-event storage, seeded partial staff personas, and rendered partial-staff behavior remain follow-up #78 work requiring schema/behavior approval.

## Verification
- uv run pytest tests/test_policies.py -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- app construction check: create_app(debug=False, db_path=':memory:').check()

Addresses #78