### PR TITLE
Add auth trust posture diagnostics

### DIFF
--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -85,6 +85,13 @@ Production request identity is session-backed:
 - logout revokes the stored session and clears its selected community and
   membership so stale cookies cannot carry forward active realm identity state
 
+`auth_trust_posture()` in `src/elbysodic/services/auth.py` provides a redacted
+operations diagnostic for this posture. It reports environment, production
+mode, demo-mode seed password posture, secret-key presence/minimum status,
+session cookie name, session TTL, development identity availability, and
+session-required status without exposing secret values, token hashes, raw
+cookies, account emails, membership names, or private identity state.
+
 The logged-out `/` and `/network` surfaces use public catalog read models.
 They can show realm names, public premise or current-event summaries, public
 media, roster counts, and wanted-hook counts. They must not render membership

--- a/docs/operations/production-bootstrap.md
+++ b/docs/operations/production-bootstrap.md
@@ -12,6 +12,8 @@ production bootstrap creates the first real director identity and realm.
 - `ELBYSODIC_ENV=production` or `staging` is intentional for the target.
 - `ELBYSODIC_SECRET_KEY` is present and at least 32 characters.
 - Demo mode is off for production unless the session is explicitly a demo.
+- The redacted auth trust posture reports the expected production, demo-mode,
+  secret-key minimum, session cookie, and session-required settings.
 - A fresh backup exists, or the database is confirmed empty.
 - Studio Operations shows the expected environment, database path, journal
   mode, integrity check, schema version, migration ledger, realm count, and
@@ -49,6 +51,7 @@ Production bootstrap:
 - Integrity check:
 - Schema version:
 - Migration ledger:
+- Auth trust posture:
 - Replica count:
 - Existing realm count before:
 - Realm name:

--- a/src/elbysodic/services/auth.py
+++ b/src/elbysodic/services/auth.py
@@ -21,6 +21,7 @@ SEED_LOGIN_PHRASE = "password"
 ENVIRONMENT_ENV = "ELBYSODIC_ENV"
 DEMO_MODE_ENV = "ELBYSODIC_DEMO_MODE"
 PRODUCTION_ENVS = frozenset({"production", "prod", "staging"})
+MIN_PRODUCTION_SECRET_KEY_LENGTH = 32
 
 
 class AuthRepository(Protocol):
@@ -67,6 +68,70 @@ class LoginSession:
     expires_at: str
 
 
+@dataclass(frozen=True, slots=True)
+class AuthTrustPosture:
+    environment: str
+    production: bool
+    demo_mode_enabled: bool
+    seed_passwords_enabled: bool
+    secret_key_configured: bool
+    secret_key_meets_minimum: bool
+    session_cookie_name: str
+    session_ttl_days: int
+    development_identity_allowed: bool
+    session_required_for_app_routes: bool
+
+    @property
+    def warnings(self) -> tuple[str, ...]:
+        warnings: list[str] = []
+        if self.production and not self.secret_key_meets_minimum:
+            warnings.append("production secret key is missing or too short")
+        if self.production and self.demo_mode_enabled:
+            warnings.append("production demo mode accepts seeded demo passwords")
+        if not self.production and self.development_identity_allowed:
+            warnings.append("development identity shortcuts are enabled")
+        return tuple(warnings)
+
+
+def auth_trust_posture() -> AuthTrustPosture:
+    env = (os.environ.get(ENVIRONMENT_ENV) or "development").strip().lower()
+    production = env in PRODUCTION_ENVS
+    demo_mode = _truthy_env(os.environ.get(DEMO_MODE_ENV))
+    secret_key = (os.environ.get("ELBYSODIC_SECRET_KEY") or "").strip()
+    return AuthTrustPosture(
+        environment=env,
+        production=production,
+        demo_mode_enabled=demo_mode,
+        seed_passwords_enabled=seed_passwords_enabled(),
+        secret_key_configured=bool(secret_key),
+        secret_key_meets_minimum=len(secret_key) >= MIN_PRODUCTION_SECRET_KEY_LENGTH,
+        session_cookie_name=SESSION_COOKIE,
+        session_ttl_days=SESSION_TTL.days,
+        development_identity_allowed=not production,
+        session_required_for_app_routes=production,
+    )
+
+
+def format_auth_trust_posture(posture: AuthTrustPosture) -> str:
+    lines = [
+        "auth trust posture",
+        f"environment: {posture.environment}",
+        f"production: {_yes_no(posture.production)}",
+        f"demo_mode_enabled: {_yes_no(posture.demo_mode_enabled)}",
+        f"seed_passwords_enabled: {_yes_no(posture.seed_passwords_enabled)}",
+        f"secret_key_configured: {_yes_no(posture.secret_key_configured)}",
+        f"secret_key_meets_minimum: {_yes_no(posture.secret_key_meets_minimum)}",
+        f"session_cookie: {posture.session_cookie_name}",
+        f"session_ttl_days: {posture.session_ttl_days}",
+        f"development_identity_allowed: {_yes_no(posture.development_identity_allowed)}",
+        f"session_required_for_app_routes: {_yes_no(posture.session_required_for_app_routes)}",
+    ]
+    if posture.warnings:
+        lines.append("warnings:")
+        lines.extend(f"- {warning}" for warning in posture.warnings)
+    return "\n".join(lines) + "\n"
+
+
 def hash_password(password: str, *, salt: str | None = None) -> str:
     normalized_salt = salt or secrets.token_urlsafe(16)
     derived = hashlib.pbkdf2_hmac(
@@ -106,8 +171,7 @@ def seed_passwords_enabled() -> bool:
     env = (os.environ.get(ENVIRONMENT_ENV) or "development").strip().lower()
     if env not in PRODUCTION_ENVS:
         return True
-    configured = (os.environ.get(DEMO_MODE_ENV) or "").strip().lower()
-    return configured in {"1", "true", "yes", "on"}
+    return _truthy_env(os.environ.get(DEMO_MODE_ENV))
 
 
 def create_login_session(repo: AuthRepository, email: str, password: str) -> LoginSession:
@@ -166,3 +230,11 @@ def session_for_session_token(
         if expires_at <= datetime.now(UTC):
             return None
     return repo.touch_user_session(session.id)
+
+
+def _truthy_env(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"

--- a/tests/test_auth_contracts.py
+++ b/tests/test_auth_contracts.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from elbysodic.services.auth import (
+    SESSION_COOKIE,
+    auth_trust_posture,
+    format_auth_trust_posture,
+    seed_passwords_enabled,
+)
+
+
+def test_auth_trust_posture_reports_production_demo_state_without_secret(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "production")
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+    monkeypatch.setenv("ELBYSODIC_SECRET_KEY", "super-secret-production-key-value")
+
+    posture = auth_trust_posture()
+    report = format_auth_trust_posture(posture)
+
+    assert posture.production is True
+    assert posture.demo_mode_enabled is True
+    assert posture.seed_passwords_enabled is True
+    assert posture.secret_key_configured is True
+    assert posture.secret_key_meets_minimum is True
+    assert posture.session_cookie_name == SESSION_COOKIE
+    assert posture.development_identity_allowed is False
+    assert posture.session_required_for_app_routes is True
+    assert seed_passwords_enabled() is True
+    assert "production demo mode accepts seeded demo passwords" in posture.warnings
+    assert "super-secret-production-key-value" not in report
+    assert "secret_key_configured: yes" in report
+    assert "secret_key_meets_minimum: yes" in report
+
+
+def test_auth_trust_posture_reports_production_secret_warning(monkeypatch) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "staging")
+    monkeypatch.delenv("ELBYSODIC_DEMO_MODE", raising=False)
+    monkeypatch.setenv("ELBYSODIC_SECRET_KEY", "tiny-secret-value")
+
+    posture = auth_trust_posture()
+    report = format_auth_trust_posture(posture)
+
+    assert posture.production is True
+    assert posture.demo_mode_enabled is False
+    assert posture.seed_passwords_enabled is False
+    assert posture.secret_key_configured is True
+    assert posture.secret_key_meets_minimum is False
+    assert posture.development_identity_allowed is False
+    assert posture.session_required_for_app_routes is True
+    assert seed_passwords_enabled() is False
+    assert posture.warnings == ("production secret key is missing or too short",)
+    assert "tiny-secret-value" not in report
+    assert "secret_key_meets_minimum: no" in report
+
+
+def test_auth_trust_posture_reports_development_shortcuts(monkeypatch) -> None:
+    monkeypatch.delenv("ELBYSODIC_ENV", raising=False)
+    monkeypatch.delenv("ELBYSODIC_DEMO_MODE", raising=False)
+    monkeypatch.delenv("ELBYSODIC_SECRET_KEY", raising=False)
+
+    posture = auth_trust_posture()
+
+    assert posture.environment == "development"
+    assert posture.production is False
+    assert posture.seed_passwords_enabled is True
+    assert posture.development_identity_allowed is True
+    assert posture.session_required_for_app_routes is False
+    assert posture.warnings == ("development identity shortcuts are enabled",)


### PR DESCRIPTION
## Summary
- add a redacted auth trust posture diagnostic for production/demo/secret/session settings
- format operator-safe output without exposing secret values, token hashes, cookies, account emails, membership names, or private identity state
- add focused auth contract tests for production demo mode, production secret warnings, and development identity posture
- document the diagnostic in security boundaries and production bootstrap runbooks

## Steward Notes
- Service/security steward: accepted diagnostics-only auth posture contract; no login, logout, session-selection, route recovery, CSRF, or cookie behavior changed.
- Docs steward: accepted production-bootstrap and security-boundary collateral for redacted operator records.
- Tests steward: accepted focused tests proving posture booleans and redaction.
- Deferred: request-identity recovery for valid signed-in accounts without local membership remains follow-up #54 work because it changes auth/request behavior and still needs explicit approval.

## Verification
- uv run pytest tests/test_auth_contracts.py -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- app construction check: create_app(debug=False, db_path=':memory:').check()

Addresses #54