### PR TITLE
Add surface contract drift gate

### DIFF
--- a/docs/architecture/rendered-route-privacy-matrix.md
+++ b/docs/architecture/rendered-route-privacy-matrix.md
@@ -67,6 +67,13 @@ For each new rendered surface, decide whether it needs tests for:
 Keep assertions semantic. It is usually better to assert that a title, note, or
 control appears or does not appear than to snapshot large HTML sections.
 
+Critical route families also need an entry in
+`src/elbysodic/web/surface_contracts.py`. The registry row should name the
+route-facing service method, read-model family, viewer modes, parity dimensions,
+this matrix label, and proof references. The backend drift gate fails when those
+links disappear; rendered privacy tests still prove the actual visible and
+hidden state.
+
 ## Covered Regressions
 
 - Browser QA smoke and deep profiles passed on 2026-05-12 against a local seeded

--- a/docs/architecture/surface-contract-architecture.md
+++ b/docs/architecture/surface-contract-architecture.md
@@ -35,9 +35,18 @@ The executable registry lives in
 `src/elbysodic/web/surface_contracts.py`. It is intentionally lightweight:
 each entry names the route family, handler path, route-facing service call,
 read model family, required viewer modes, parity dimensions, and the rendered
-privacy matrix label. Backend contract tests read the registry so critical
-page handlers keep calling named service methods and the privacy matrix stays
-connected to the code.
+privacy matrix label. Each entry also names proof references, usually focused
+rendered privacy tests or supporting contract tests. Backend contract tests run
+the registry drift gate so critical page handlers keep calling named service
+methods, proof remains discoverable, and the privacy matrix stays connected to
+the code.
+
+The drift gate is read-only. It does not replace rendered privacy tests or
+service tests; it fails when the registry loses required fields, points at a
+missing page/service call, references a privacy matrix label that no longer
+exists, or names proof that is no longer present. When adding or changing a
+critical rendered surface, update the registry, privacy matrix row, and proof
+references in the same change.
 
 ## Rules
 
@@ -138,6 +147,12 @@ The lightest acceptable proof depends on risk:
 - public discovery change: proof that drafts, backstage realms, member state,
   active faces, unread counts, staff signals, and mutating forms stay out of
   public output
+
+The surface contract drift gate complements those tests by checking that every
+critical registry entry still names its service/read-model owner, viewer modes,
+parity dimensions, privacy matrix label, and proof references. A passing drift
+gate means the contracts are wired together; it does not prove the rendered
+state is correct by itself.
 
 ## Critical Surface Matrix
 

--- a/src/elbysodic/web/surface_contracts.py
+++ b/src/elbysodic/web/surface_contracts.py
@@ -7,7 +7,9 @@ render them.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 type ViewerMode = Literal[
@@ -43,6 +45,14 @@ class SurfaceContract:
     viewer_modes: tuple[ViewerMode, ...]
     dimensions: tuple[SurfaceDimension, ...]
     privacy_matrix_label: str
+    proof_references: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceContractValidationIssue:
+    code: str
+    contract_key: str
+    message: str
 
 
 SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
@@ -55,6 +65,10 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("public", "account_visitor", "member", "staff", "cross_tenant"),
         dimensions=("shell_count", "page_list", "action_availability", "recovery"),
         privacy_matrix_label="/c/{community}/",
+        proof_references=(
+            "tests/test_forum_slice.py::test_rendered_surface_contract_parity_across_realm_viewers",
+            "tests/test_web_security.py::test_production_signed_out_public_realm_keeps_anonymous_posture",
+        ),
     ),
     SurfaceContract(
         key="claims_directory",
@@ -65,6 +79,10 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("member", "staff", "director", "cross_tenant"),
         dimensions=("page_list", "detail_view", "action_availability"),
         privacy_matrix_label="/claims",
+        proof_references=(
+            "tests/test_forum_slice.py::test_claims_directory_renders_seeded_claims_and_studio_summary",
+            "tests/test_forum_slice.py::test_rendered_surface_contract_parity_across_realm_viewers",
+        ),
     ),
     SurfaceContract(
         key="roster",
@@ -75,6 +93,10 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("member", "owner", "staff", "inactive", "cross_tenant"),
         dimensions=("page_list", "detail_view", "action_availability", "recovery"),
         privacy_matrix_label="/members",
+        proof_references=(
+            "tests/test_forum_slice.py::test_character_roster_and_profiles_are_community_scoped",
+            "tests/test_forum_slice.py::test_rendered_surface_contract_parity_across_realm_viewers",
+        ),
     ),
     SurfaceContract(
         key="thread_and_posting",
@@ -92,6 +114,11 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
             "recovery",
         ),
         privacy_matrix_label="/boards/{board}",
+        proof_references=(
+            "tests/test_forum_slice.py::test_forum_pages_render_seeded_boards_and_thread",
+            "tests/test_forum_slice.py::test_rendered_surface_contract_parity_across_realm_viewers",
+            "tests/test_forum_slice.py::test_reply_notification_failure_rolls_back_post",
+        ),
     ),
     SurfaceContract(
         key="wanted",
@@ -102,6 +129,10 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("public", "account_visitor", "member", "owner", "staff", "cross_tenant"),
         dimensions=("page_list", "detail_view", "action_availability", "notification_visibility"),
         privacy_matrix_label="/c/{community}/wanted",
+        proof_references=(
+            "tests/test_forum_slice.py::test_public_wanted_routes_hide_non_open_hooks",
+            "tests/test_forum_slice.py::test_wanted_ads_render_board_detail_and_character_hub",
+        ),
     ),
     SurfaceContract(
         key="plotting",
@@ -112,6 +143,10 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("member", "owner", "staff", "inactive", "cross_tenant"),
         dimensions=("page_list", "detail_view", "action_availability", "notification_visibility"),
         privacy_matrix_label="/plotting",
+        proof_references=(
+            "tests/test_forum_slice.py::test_tenant_prefixed_plotting_room_id_does_not_leak_cross_realm_room",
+            "tests/test_forum_slice.py::test_plotting_room_notifications_do_not_leak_to_non_participants",
+        ),
     ),
     SurfaceContract(
         key="applications",
@@ -122,6 +157,10 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("member", "owner", "staff", "faceless", "cross_tenant"),
         dimensions=("page_list", "detail_view", "action_availability", "recovery"),
         privacy_matrix_label="/applications",
+        proof_references=(
+            "tests/test_forum_slice.py::test_applications_desk_tracks_character_statuses",
+            "tests/test_forum_slice.py::test_application_room_for_other_program_renders_realm_recovery",
+        ),
     ),
     SurfaceContract(
         key="notifications",
@@ -132,6 +171,11 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("member", "owner", "staff", "inactive", "faceless", "cross_tenant"),
         dimensions=("shell_count", "page_list", "detail_view", "notification_visibility"),
         privacy_matrix_label="/notifications",
+        proof_references=(
+            "tests/test_notification_contracts.py::test_notification_target_contracts_name_visibility_rules",
+            "tests/test_forum_slice.py::test_notifications_track_watched_thread_replies_and_open_read_state",
+            "tests/test_forum_slice.py::test_notification_inbox_limit_applies_after_visibility_filtering",
+        ),
     ),
     SurfaceContract(
         key="network_catalog",
@@ -142,6 +186,11 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("public", "account_visitor", "member", "staff", "cross_tenant"),
         dimensions=("page_list", "action_availability", "recovery"),
         privacy_matrix_label="/network",
+        proof_references=(
+            "tests/test_web_security.py::test_public_network_catalog_hides_membership_and_staff_signals",
+            "tests/test_web_security.py::test_network_read_models_split_public_cards_from_viewer_state",
+            "tests/test_forum_slice.py::test_network_directory_lists_programs_and_realm_entry_actions",
+        ),
     ),
     SurfaceContract(
         key="studio",
@@ -152,6 +201,11 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("member", "staff", "director", "inactive", "cross_tenant"),
         dimensions=("shell_count", "page_list", "detail_view", "action_availability", "recovery"),
         privacy_matrix_label="/studio",
+        proof_references=(
+            "tests/test_forum_slice.py::test_director_studio_surfaces_community_production_work",
+            "tests/test_forum_slice.py::test_studio_launch_moderates_access_requests",
+            "tests/test_forum_slice.py::test_realm_launch_room_requires_director_membership",
+        ),
     ),
     SurfaceContract(
         key="studio_operations",
@@ -162,9 +216,169 @@ SURFACE_CONTRACTS: tuple[SurfaceContract, ...] = (
         viewer_modes=("member", "staff", "director", "inactive", "cross_tenant"),
         dimensions=("page_list", "action_availability", "diagnostics"),
         privacy_matrix_label="/studio",
+        proof_references=(
+            "tests/test_forum_slice.py::test_studio_operations_tracks_writer_activation_oversight",
+            "tests/test_forum_slice.py::test_studio_operations_hides_review_queue_from_non_staff_members",
+        ),
     ),
 )
 
 
 def surface_contracts_by_key() -> dict[str, SurfaceContract]:
     return {contract.key: contract for contract in SURFACE_CONTRACTS}
+
+
+def validate_surface_contracts(
+    contracts: Iterable[SurfaceContract] = SURFACE_CONTRACTS,
+    *,
+    repo_root: Path | None = None,
+    privacy_matrix_text: str | None = None,
+) -> tuple[SurfaceContractValidationIssue, ...]:
+    """Validate the read-only surface registry against code, proof, and docs."""
+    root = repo_root
+    matrix = privacy_matrix_text
+    if matrix is None and root is not None:
+        matrix_path = root / "docs" / "architecture" / "rendered-route-privacy-matrix.md"
+        matrix = matrix_path.read_text(encoding="utf-8")
+
+    issues: list[SurfaceContractValidationIssue] = []
+    seen_keys: set[str] = set()
+    duplicate_keys: set[str] = set()
+    contract_tuple = tuple(contracts)
+
+    for contract in contract_tuple:
+        if contract.key in seen_keys:
+            duplicate_keys.add(contract.key)
+        seen_keys.add(contract.key)
+
+    issues.extend(
+        [
+            SurfaceContractValidationIssue(
+                code="duplicate_key",
+                contract_key=duplicate_key,
+                message=f"{duplicate_key} is registered more than once.",
+            )
+            for duplicate_key in sorted(duplicate_keys)
+        ]
+    )
+
+    for contract in contract_tuple:
+        issues.extend(_validate_required_fields(contract))
+
+        if matrix is not None and contract.privacy_matrix_label not in matrix:
+            issues.append(
+                SurfaceContractValidationIssue(
+                    code="missing_privacy_matrix_label",
+                    contract_key=contract.key,
+                    message=(
+                        f"{contract.key} references privacy matrix label "
+                        f"{contract.privacy_matrix_label!r}, but that label is absent from the "
+                        "rendered route privacy matrix."
+                    ),
+                )
+            )
+
+        if root is not None:
+            issues.extend(_validate_page_contract(root, contract))
+            issues.extend(_validate_proof_references(root, contract))
+
+    return tuple(issues)
+
+
+def _validate_required_fields(
+    contract: SurfaceContract,
+) -> tuple[SurfaceContractValidationIssue, ...]:
+    missing: list[str] = []
+    if not contract.key:
+        missing.append("key")
+    if not contract.route_family:
+        missing.append("route_family")
+    if not contract.page_path:
+        missing.append("page_path")
+    if not contract.service_calls:
+        missing.append("service_calls")
+    if not contract.read_models:
+        missing.append("read_models")
+    if not contract.viewer_modes:
+        missing.append("viewer_modes")
+    if not contract.dimensions:
+        missing.append("dimensions")
+    if not contract.privacy_matrix_label:
+        missing.append("privacy_matrix_label")
+    if not contract.proof_references:
+        missing.append("proof_references")
+
+    return tuple(
+        SurfaceContractValidationIssue(
+            code="missing_required_field",
+            contract_key=contract.key or "<empty>",
+            message=(
+                f"{contract.key or '<empty>'} is missing required surface contract field {field}."
+            ),
+        )
+        for field in missing
+    )
+
+
+def _validate_page_contract(
+    root: Path,
+    contract: SurfaceContract,
+) -> tuple[SurfaceContractValidationIssue, ...]:
+    page_path = root / contract.page_path
+    if not page_path.exists():
+        return (
+            SurfaceContractValidationIssue(
+                code="missing_page",
+                contract_key=contract.key,
+                message=f"{contract.key} page path does not exist: {contract.page_path}.",
+            ),
+        )
+
+    source = page_path.read_text(encoding="utf-8")
+    return tuple(
+        SurfaceContractValidationIssue(
+            code="missing_service_call",
+            contract_key=contract.key,
+            message=(
+                f"{contract.key} page {contract.page_path} does not call "
+                f"registered service contract {service_call!r}."
+            ),
+        )
+        for service_call in contract.service_calls
+        if service_call not in source
+    )
+
+
+def _validate_proof_references(
+    root: Path,
+    contract: SurfaceContract,
+) -> tuple[SurfaceContractValidationIssue, ...]:
+    issues: list[SurfaceContractValidationIssue] = []
+    for reference in contract.proof_references:
+        path_text, separator, symbol = reference.partition("::")
+        path = root / path_text
+        if not path.exists():
+            issues.append(
+                SurfaceContractValidationIssue(
+                    code="missing_proof_reference",
+                    contract_key=contract.key,
+                    message=f"{contract.key} proof reference does not exist: {reference}.",
+                )
+            )
+            continue
+
+        if separator and path_text.startswith("tests/"):
+            source = path.read_text(encoding="utf-8")
+            if f"def {symbol}(" not in source and f"class {symbol}" not in source:
+                issues.append(
+                    SurfaceContractValidationIssue(
+                        code="missing_proof_symbol",
+                        contract_key=contract.key,
+                        message=(
+                            f"{contract.key} proof reference {reference} names a test symbol "
+                            "that does not exist."
+                        ),
+                    )
+                )
+
+    return tuple(issues)

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -10,7 +11,7 @@ import pytest
 from elbysodic.db import ForumRepository, connect
 from elbysodic.services import create_services
 from elbysodic.web.state import close_request_services, configure_services, get_services
-from elbysodic.web.surface_contracts import SURFACE_CONTRACTS
+from elbysodic.web.surface_contracts import SURFACE_CONTRACTS, validate_surface_contracts
 
 REPO_ROOT = Path(__file__).parents[1]
 WEB_DIR = REPO_ROOT / "src" / "elbysodic" / "web"
@@ -211,35 +212,59 @@ def test_critical_rendered_pages_use_named_service_surface_contracts() -> None:
     assert missing == []
 
 
-def test_rendered_surface_contract_registry_is_complete_enough() -> None:
-    privacy_matrix = (REPO_ROOT / "docs/architecture/rendered-route-privacy-matrix.md").read_text(
-        encoding="utf-8"
-    )
+def test_rendered_surface_contract_registry_passes_drift_gate() -> None:
     keys = [contract.key for contract in SURFACE_CONTRACTS]
-    missing_paths = [
-        contract.page_path
-        for contract in SURFACE_CONTRACTS
-        if not (REPO_ROOT / contract.page_path).exists()
-    ]
-    incomplete = [
-        contract.key
-        for contract in SURFACE_CONTRACTS
-        if not contract.service_calls
-        or not contract.read_models
-        or not contract.viewer_modes
-        or not contract.dimensions
-    ]
-    missing_matrix_labels = [
-        contract.key
-        for contract in SURFACE_CONTRACTS
-        if contract.privacy_matrix_label not in privacy_matrix
-    ]
 
     assert len(keys) == len(set(keys))
     assert len(SURFACE_CONTRACTS) >= 10
-    assert missing_paths == []
-    assert incomplete == []
-    assert missing_matrix_labels == []
+    assert validate_surface_contracts(repo_root=REPO_ROOT) == ()
+
+
+@pytest.mark.parametrize(
+    ("broken_contract", "expected_code"),
+    [
+        (
+            replace(SURFACE_CONTRACTS[0], viewer_modes=()),
+            "missing_required_field",
+        ),
+        (
+            replace(SURFACE_CONTRACTS[0], dimensions=()),
+            "missing_required_field",
+        ),
+        (
+            replace(SURFACE_CONTRACTS[0], service_calls=("services.missing_surface()",)),
+            "missing_service_call",
+        ),
+        (
+            replace(SURFACE_CONTRACTS[0], privacy_matrix_label="/missing-surface"),
+            "missing_privacy_matrix_label",
+        ),
+        (
+            replace(SURFACE_CONTRACTS[0], proof_references=("tests/test_forum_slice.py::missing",)),
+            "missing_proof_symbol",
+        ),
+        (
+            replace(SURFACE_CONTRACTS[0], proof_references=("tests/test_missing_surface.py",)),
+            "missing_proof_reference",
+        ),
+    ],
+)
+def test_rendered_surface_contract_drift_gate_reports_missing_requirements(
+    broken_contract,
+    expected_code: str,
+) -> None:
+    issues = validate_surface_contracts((broken_contract,), repo_root=REPO_ROOT)
+
+    assert expected_code in {issue.code for issue in issues}
+
+
+def test_rendered_surface_contract_drift_gate_reports_duplicate_keys() -> None:
+    issues = validate_surface_contracts(
+        (SURFACE_CONTRACTS[0], SURFACE_CONTRACTS[0]),
+        repo_root=REPO_ROOT,
+    )
+
+    assert "duplicate_key" in {issue.code for issue in issues}
 
 
 def test_service_raw_sql_stays_limited_to_lifecycle_and_operations_diagnostics() -> None:


### PR DESCRIPTION
Closes #102

## Summary
- Add proof references to the rendered surface registry.
- Add a reusable registry validator for page, service, matrix, and proof drift.
- Update backend contract tests and architecture docs for the drift gate.

## Steward Notes
- Consulted Surface Contract, Web, Test, and Docs stewards.
- Accepted: checker is read-only and complements rendered privacy tests.
- Proof: focused backend contract tests, full pytest, ruff, ty, app check.
- Collateral: surface contract architecture and rendered privacy matrix docs updated.
- Remaining risk: no CLI exposure yet, per issue scope.

## Verification
- uv run pytest tests/test_backend_contracts.py -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
- uv run pytest -q --tb=short