### PR TITLE
Add onboarding QA regression pack

### DIFF
--- a/docs/operations/onboarding-browser-qa.md
+++ b/docs/operations/onboarding-browser-qa.md
@@ -1,0 +1,104 @@
+# Onboarding Browser QA
+
+Use this checklist when a PR touches auth entry, public preview, request
+access, invite acceptance, first-face work, applicant state, director launch, or
+first writing move handoffs. Rendered tests prove behavior; this pass catches
+viewport, focus, overflow, copy, and state-language regressions.
+
+## Required Viewports
+
+- Desktop: 1440 x 1200.
+- Tablet: 900 x 1100.
+- Mobile: 390 x 844.
+
+## Required States
+
+- Signed-out visitor on `/network` and `/c/afterlight-accord`.
+- Signed-in account visitor on `/c/afterlight-accord`.
+- Request-access form and confirmation posture.
+- Valid invitation acceptance into a faceless member state.
+- Faceless member on Desk and first-face application start.
+- Applicant with draft or accepted application room.
+- Member with accepted active face on Desk, wanted, plotting, and first-scene
+  paths.
+- Director on Studio Launch, access requests, invitation management, and Studio
+  Operations.
+- Inactive or cross-community recovery state when the changed surface can
+  expose membership-local data.
+
+## Community Landing Profile
+
+Start an isolated seeded development server:
+
+```bash
+ELBYSODIC_ENV=development uv run elbysodic \
+  --db-path /private/tmp/elbysodic-onboarding-qa.sqlite3 \
+  --port 8007 \
+  --seed-demo \
+  serve
+```
+
+Run the existing public-preview and first-face surface profile:
+
+```bash
+ELBYSODIC_ENV=development uv run python scripts/browser_qa.py \
+  --base-url http://127.0.0.1:8007 \
+  --profile community-landing \
+  --artifact-dir /private/tmp/elbysodic-onboarding-community-landing-qa
+```
+
+## Writer Activation Script
+
+Run the invite-to-first-face smoke path against the same seeded server:
+
+```bash
+ELBYSODIC_ENV=development uv run python scripts/writer_activation_qa.py \
+  --base-url http://127.0.0.1:8007
+```
+
+The script creates a copy-only invitation, accepts it as a new writer, verifies
+faceless continuation, creates a first-face draft, and checks wanted/plotting
+entry for an accepted writer.
+
+## Manual Inspection
+
+For each screenshot set or browser pass, record:
+
+- base URL, database path, command, date, and artifact directory
+- route and seed persona or login state
+- first viewport identity signal and primary action
+- whether public/account visitors see only public-safe realm, wanted,
+  guidebook, request-access, and application posture
+- whether faceless members and applicants can find first-face work without
+  seeing other writers' applications, staff notes, private queues, active-face
+  controls, or staff controls
+- whether director-only launch blockers, access-request notes, invite links,
+  and review state remain private
+- keyboard focus order through login, request access, application, invite,
+  and Studio queue controls where present
+- text overlap, clipped buttons, horizontal scroll, console errors, missing
+  media, or awkward mobile truncation
+
+## Pass Criteria
+
+- Public and account visitor states do not render Desk, active face, unread
+  counts, staff controls, private notes, invite links, application review state,
+  plotting rooms, or reserves.
+- Applicants and faceless members see a next action toward first-face work.
+- Directors can find launch blockers and request/invite work without exposing
+  that state to ordinary members or visitors.
+- Auth and recovery copy distinguishes account, membership, face, application,
+  claims, reserves, wanted, plotting, scene, and thread state.
+- Screenshots or artifact paths are recorded in the PR, release note, or
+  operations note.
+
+## Current Status
+
+Passed locally on June 3, 2026 against an isolated seeded development server on
+`http://127.0.0.1:8007` with database
+`/private/tmp/elbysodic-onboarding-qa.sqlite3`.
+
+- Community landing profile passed. Screenshot artifacts:
+  `/private/tmp/elbysodic-onboarding-community-landing-qa-2026-06-03`.
+- Writer activation QA passed after refreshing the script to wait for the
+  current first-face action label, `Create draft face`.

--- a/research/uat/README.md
+++ b/research/uat/README.md
@@ -22,6 +22,13 @@ research/uat/
   observed/
 ```
 
+Reusable onboarding protocols:
+
+- `protocols/public-realm-preview.md`
+- `protocols/first-face-onboarding.md`
+- `protocols/wanted-to-plotting-handoff.md`
+- `protocols/onboarding-regression-pack.md`
+
 ## What Counts As A Task
 
 Good UAT tasks are concrete:

--- a/research/uat/protocols/onboarding-regression-pack.md
+++ b/research/uat/protocols/onboarding-regression-pack.md
@@ -1,0 +1,149 @@
+# UAT Protocol: Onboarding Regression Pack
+
+Status: reusable UAT protocol
+Flow: auth entry, request access, invite acceptance, first face, applicant
+state, director launch, and public preview handoff
+Primary users: Active Scene Writer, Invited/New Face Applicant, Hook Hunter,
+Community Director, Staff Moderator, Safety-Boundary Writer, Returning Regular
+Last updated: 2026-06-03
+
+## Evidence Mode
+
+Use this protocol for simulated UAT, browser QA, or observed UAT against
+implemented routes, screenshots, or a deployed preview. Simulated findings must
+stay labeled as synthetic until real PBP writers or directors perform the task.
+
+## Research Question
+
+Can a writer or director move through the entry and onboarding states without
+confusing account, membership, face, application, staff review, request-access,
+or public-preview boundaries?
+
+## Artifact Options
+
+- `/login`, `/logout`, stale-session recovery, and account-visitor posture
+- `/network` and public catalog cards
+- `/c/{community}` public realm previews and request-access entry
+- `/invite/{token}` acceptance states
+- `/applications/new` and `/applications/{character}` first-face work
+- `/claims`, `/wanted`, `/plotting`, and first-scene handoff surfaces
+- `/studio/launch`, `/studio/access-requests`, and invitation management
+- screenshots, browser QA artifacts, local preview URLs, or PR diffs
+
+## Starting States
+
+Run the smallest set that matches the surface under test:
+
+- Signed-out public visitor.
+- Signed-in account visitor with no local membership.
+- Pending access requester.
+- Invited writer with valid, accepted, revoked, expired, malformed, or
+  cross-community token.
+- Faceless member with no public posting identity.
+- Applicant with draft, submitted, revision-requested, accepted, or declined
+  application.
+- Member with accepted active face.
+- Staff or director with current-community capability.
+- Inactive membership.
+- Same global account or route target in another community.
+
+## Tasks
+
+1. Auth entry and recovery: sign in, sign out, recover from stale or inactive
+   selected membership, and confirm the page explains account versus realm
+   membership without granting member shell state.
+2. Public preview handoff: inspect a realm preview or catalog card, identify
+   whether access is invite-only, request-access, closed, or application-ready,
+   and choose the next safe action.
+3. Request access: submit or revisit a request-access posture and confirm the
+   user understands it is interest, not membership or permission.
+4. Invite acceptance: accept or inspect valid, accepted, revoked, expired,
+   malformed, and cross-community invite states without exposing raw tokens,
+   launch-room details, or private staff context.
+5. First-face onboarding: start or continue first-face work, then distinguish
+   account, membership, public face, application, claims, reserves, wanted, and
+   scene handoff.
+6. Applicant state: inspect draft, submitted, revision-requested, accepted, and
+   declined application states and explain what staff can see versus what other
+   writers can see.
+7. Director launch: open Studio Launch, access requests, and invitation
+   management, then identify private blockers without showing them to ordinary
+   members or public visitors.
+8. First writing move: from an accepted face, find one concrete next move:
+   claim/reserve cleanup, wanted hook, plotting room, location, open scene, or
+   thread.
+
+## Success Criteria
+
+- The participant can name their state: public visitor, account visitor,
+  pending requester, invited writer, faceless member, applicant, member with
+  face, staff, director, inactive member, or cross-community visitor.
+- Every state has a concrete next action or a clear no-action recovery state.
+- Public and account-visitor surfaces never render Desk, active face, unread
+  counts, staff controls, private notes, invite links, application review state,
+  plotting rooms, or reserves unless authorized.
+- Applicant and faceless-member flows point to first-face work without showing
+  another writer's applications, staff notes, or private queues.
+- Director launch and request-access review surfaces use current-community
+  state and do not imply public self-serve registration.
+- Copy uses realm, writer, face, roster, application, claims, reserves, wanted,
+  plotting, scene, thread, needs reply, waiting, caught up, and watching.
+- Desktop and mobile first view preserve current identity, privacy state, and
+  primary action without overlap, truncation, or horizontal scroll.
+
+## Browser QA Checklist
+
+Use `docs/operations/onboarding-browser-qa.md` for local commands. Record:
+
+- base URL and database path
+- browser QA profile or script name
+- desktop/tablet/mobile screenshots or artifact directory
+- seed persona or login state for each pass
+- pass/fail notes for first viewport, primary action, copy clarity, privacy
+  state, focus order, text overflow, horizontal overflow, and console errors
+
+## Synthetic Panelists
+
+Use these lenses for simulated panel passes:
+
+- Active Scene Writer: wrong-face prevention, obligations, and first writing
+  move.
+- Invited/New Face Applicant: public trust, application state, and staff
+  visibility.
+- Hook Hunter: wanted-to-application and wanted-to-request-access handoff.
+- Community Director: launch blockers, invitations, access requests, and
+  staff workload.
+- Staff Moderator and Safety-Boundary Writer: private notes, review state, and
+  applicant confidence.
+- Returning Regular: stale session recovery, membership switching, and account
+  posture.
+
+## Required Proof Candidates
+
+- Rendered tests: public visitor, account visitor, pending requester, invited
+  writer, faceless member, applicant, member, staff/director, inactive, and
+  cross-community states.
+- Negative assertions: Desk, active face, unread counts, staff controls,
+  private notes, invite links, application review state, plotting rooms, and
+  reserves where unauthorized.
+- Browser QA: community landing profile plus writer activation QA across
+  desktop/tablet/mobile where the script supports it.
+- Copy check: account, membership, face, application, claims, reserves, wanted,
+  plotting, scene, and thread vocabulary.
+- Accessibility check: labels, focus order, keyboard reachability, alert roles,
+  and mobile tap targets.
+- Real UAT: repeat the highest-risk tasks with 2 to 3 PBP writers or directors
+  after the route is reachable in a shared preview.
+
+## Decision Ledger
+
+Record findings as:
+
+- Accepted: update tests, docs, product docs, component changes, or existing
+  issue links in the same PR.
+- Proposed: useful but needs more evidence or route implementation.
+- Deferred: likely correct but blocked by another issue or release gate.
+- Rejected: conflicts with Elbysodic standards or evidence is too weak.
+- Not-now: valid later work outside the onboarding backbone.
+
+Never promote synthetic-only findings as real UXR.

--- a/research/uat/simulated/2026-06-03-onboarding-regression-pack-simulated-panel.md
+++ b/research/uat/simulated/2026-06-03-onboarding-regression-pack-simulated-panel.md
@@ -1,0 +1,206 @@
+# Synthetic Panel Run: Onboarding Regression Pack
+
+Status: synthetic panel
+Date: 2026-06-03
+Researcher: Codex
+Artifact evaluated: issue #118 scope, existing UAT protocols, browser QA
+scripts, community landing browser QA, rendered privacy matrix, and current
+onboarding route contracts
+Seed docs: `docs/product/user-personas-panel.md`,
+`docs/architecture/rendered-route-privacy-matrix.md`,
+`docs/architecture/seed-personas.md`,
+`research/uat/protocols/public-realm-preview.md`,
+`research/uat/protocols/first-face-onboarding.md`,
+`research/uat/protocols/wanted-to-plotting-handoff.md`
+Panelists used: Active Scene Writer, Invited/New Face Applicant, Hook Hunter,
+Community Director, Staff Moderator and Safety-Boundary Writer, Returning
+Regular
+Confidence: medium for synthetic convergence, low for observed usability
+
+This is simulated research. It is useful for critique and hypothesis
+generation, but it is not real interview evidence.
+
+## Task Prompt
+
+```text
+Evaluate the repeatable onboarding QA pack for auth entry, request access,
+invite acceptance, first face, applicant flow, director launch, and public
+preview handoffs. Focus on whether the tasks prove public privacy, account
+visitor posture, first-face clarity, staff/director privacy, mobile composition,
+and PBP-native vocabulary without turning synthetic findings into doctrine.
+```
+
+## Panel Findings
+
+### Active Scene Writer
+
+- Flow: accepted face and first writing move
+- Severity: P1
+- User Job: know who I am wearing and what I owe next before posting
+- Evidence: persona guide prioritizes active face, obligations, and wrong-face
+  prevention; existing browser QA covers Desk, wanted, and plotting entry
+- User Impact: accepted writers can still stall if "accepted" is a status
+  rather than a path into wanted, plotting, locations, or scenes
+- Expected Experience: accepted application and Desk state should keep face,
+  claims/reserves, wanted, plotting, and first-scene paths close together
+- Recommended Change: keep first writing move as a required UAT task and proof
+  candidate
+- Required Proof: rendered tests for accepted applicant handoff plus browser QA
+  first viewport on Desk/application
+- Collateral: `research/uat/protocols/onboarding-regression-pack.md`
+- Confidence: medium
+
+### Invited Or New Face Applicant
+
+- Flow: public preview, request access, and first-face work
+- Severity: P1
+- User Job: decide whether the realm is safe and worth bringing a face into
+- Evidence: public preview and first-face protocols both flag public/private
+  audience confusion and staff-note anxiety
+- User Impact: a polished public preview can still lose trust if request access
+  reads as membership or if application visibility is ambiguous
+- Expected Experience: every entry state names what happens next and who can
+  see notes, applications, claims, and reserves
+- Recommended Change: require public/account/applicant negative assertions and
+  copy checks in the onboarding protocol
+- Required Proof: public visitor, account visitor, pending requester, faceless
+  member, applicant, member, staff/director, inactive, and cross-community
+  rendered states
+- Collateral: `docs/operations/onboarding-browser-qa.md`
+- Confidence: medium
+
+### Hook Hunter
+
+- Flow: wanted hook to application or request access
+- Severity: P2
+- User Job: follow a playable opening without exposing private pitch notes
+- Evidence: wanted handoff protocol identifies open/raised-hand/private-note
+  leakage risks; issue #119 covers public wanted handoff work
+- User Impact: hook hunters can misread a public wanted hook as an application
+  grant or expose a concept before they understand staff visibility
+- Expected Experience: public wanted actions should say request access or
+  start application without implying membership
+- Recommended Change: keep wanted-to-request-access and wanted-to-application
+  as explicit UAT tasks, but defer UI changes to #119 and #116
+- Required Proof: rendered wanted public/privacy assertions and browser QA on
+  wanted detail mobile/desktop
+- Collateral: existing issues #119 and #116
+- Confidence: medium
+
+### Community Director
+
+- Flow: Studio Launch, access requests, and invitations
+- Severity: P1
+- User Job: open a realm and manage invitations without leaking launch blockers
+- Evidence: community landing browser QA already includes Studio Launch and
+  Operations; issue #115 tracks director realm-opening front-end
+- User Impact: directors need repeatable proof that launch blockers and invite
+  links are private while public preview remains safe
+- Expected Experience: QA should inspect director state and public/account
+  visitor state in the same pass
+- Recommended Change: add director launch and invitation management states to
+  the onboarding browser QA checklist
+- Required Proof: browser QA artifacts and rendered tests for director,
+  ordinary member, account visitor, public visitor, inactive, and
+  cross-community states
+- Collateral: `docs/operations/onboarding-browser-qa.md`
+- Confidence: medium
+
+### Staff Moderator And Safety-Boundary Writer
+
+- Flow: application review, request access, and private notes
+- Severity: P1
+- User Job: protect applicant and staff context from leaking through public or
+  member surfaces
+- Evidence: research steward requires synthetic notes to label evidence; privacy
+  matrix lists request notes, staff notes, invite links, review state, and
+  private queues as sensitive
+- User Impact: one leaked applicant note can break trust in a pseudonymous
+  writing space
+- Expected Experience: public, member, applicant, and staff surfaces have
+  visibly different audience states and negative privacy proof
+- Recommended Change: make negative assertions and evidence labeling required
+  in every onboarding UAT note
+- Required Proof: negative rendered assertions plus browser QA copy/privacy
+  checklist
+- Collateral: protocol decision ledger and operations checklist
+- Confidence: medium
+
+### Returning Regular
+
+- Flow: auth entry, logout, stale session recovery, and membership switching
+- Severity: P2
+- User Job: return to the correct realm and face without stale session surprises
+- Evidence: issue #114 tracks auth UX; production auth issue #54 tracks backend
+  trust; QA currently needs a protocol that routes findings into those issues
+- User Impact: returning users may mistake account visitor posture or stale
+  membership recovery for lost access
+- Expected Experience: login, logout, account visitor, inactive, and
+  cross-community recovery copy should be tested as trust surfaces
+- Recommended Change: add auth entry/session recovery tasks without changing
+  auth behavior in this PR
+- Required Proof: rendered auth/session states and browser QA where UI changes
+  land
+- Collateral: existing issue #114
+- Confidence: medium-low until auth UX surfaces are implemented
+
+## Convergence
+
+- Public visitor, account visitor, faceless member, applicant, accepted member,
+  staff/director, inactive, and cross-community states need to be tested as
+  distinct states.
+- Browser QA must check identity signal, primary action, mobile composition,
+  privacy state, focus order, overflow, and console errors.
+- Synthetic panel and simulated UAT outputs must stay labeled as synthetic
+  until real PBP writers or directors perform the tasks.
+- Accepted findings should route to existing implementation issues rather than
+  expanding this QA-pack PR into route, auth, schema, or privacy changes.
+
+## Tensions And Minority Reports
+
+- The Hook Hunter wants richer wanted-to-application paths now; the safety lens
+  prefers deferring UI changes until public-preview privacy and request-access
+  posture are proven.
+- The Returning Regular lens wants stale-session recovery covered, but auth UX
+  implementation belongs to #114 and backend trust gates belong to #54.
+- The Director lens wants launch-room QA in the pack, while the applicant lens
+  warns that public preview should not expose director blockers as proof that
+  the realm is alive.
+
+## Decisions
+
+- Accepted: create one reusable onboarding regression protocol that stitches
+  public preview, auth entry, request access, invite acceptance, first face,
+  applicant state, director launch, and first writing move tasks together.
+- Accepted: add an operations browser QA checklist that reuses the existing
+  community landing browser profile and writer activation script.
+- Accepted: record this panel run as synthetic-only evidence with confidence
+  labels and promotion boundaries.
+- Proposed: when #114, #116, #119, or #115 change surfaces, use this pack to
+  produce fresh screenshots and rendered privacy proof.
+- Deferred: real UAT until a shared preview is stable and participant consent
+  is planned.
+- Rejected: treating synthetic panel convergence as validated user research.
+- Not-now: broad analytics, new public registration, or a new browser QA CLI
+  profile before the existing scripts are exhausted.
+
+## Proof Needed
+
+- Rendered test: implementation issues should add state-specific privacy tests
+  when surfaces change.
+- Service test: only when accepted findings change service read models.
+- Browser QA: run `scripts/browser_qa.py --profile community-landing` and
+  `scripts/writer_activation_qa.py` for onboarding-affecting PRs.
+- Copy check: use PBP-native account, membership, face, application, claims,
+  reserves, wanted, plotting, scene, and thread language.
+- Accessibility check: labels, focus order, tap targets, and mobile overflow
+  for login, request access, application, invite, and Studio controls.
+- Real interview: after live preview and consent planning.
+- Real UAT: after live preview and consent planning.
+- No collateral: this PR changes QA/research artifacts only; no route, schema,
+  auth, permission, or privacy behavior changes.
+
+## Promotion Target
+
+- `research/uat/protocols/onboarding-regression-pack.md`
+- `docs/operations/onboarding-browser-qa.md`

--- a/scripts/writer_activation_qa.py
+++ b/scripts/writer_activation_qa.py
@@ -46,7 +46,7 @@ async def _accept_invitation_without_face(page: Page, base_url: str, invite_path
     await page.get_by_label("Password").fill("activation-password")
     await page.get_by_role("button", name="Enter realm").click()
     await page.wait_for_url(f"**{COMMUNITY_PATH}/applications/new")
-    await page.get_by_text("Start Application").wait_for()
+    await page.get_by_role("button", name="Create draft face").wait_for()
     await page.goto(urljoin(base_url, f"{COMMUNITY_PATH}/desk"), wait_until="domcontentloaded")
     await page.get_by_text("Start with a first face").wait_for()
 


### PR DESCRIPTION
Closes #118

## Summary
- Add a reusable onboarding regression UAT protocol covering auth entry, request access, invite acceptance, first face, applicant state, director launch, and public preview handoffs.
- Add a synthetic panel run for the onboarding pack with accepted/deferred/not-now decisions and evidence labels.
- Add an operations browser QA checklist that reuses the existing community-landing profile and writer activation script.
- Refresh writer activation QA to wait for the current first-face action label.

## Steward Notes
- Consulted Research, Product/User Panel, Web/Design, Planning, Docs, and Test stewardship.
- Accepted: keep this PR to repeatable proof artifacts and a stale QA-script fix; route/auth/schema/privacy behavior remains unchanged.
- Deferred: implementation findings route to existing #114, #115, #116, and #119.
- Proof: browser QA profile and writer activation QA run locally; lint/format/app/route-smoke gates passed.
- Collateral: UAT protocol index and operations QA documentation updated.
- Remaining risk: synthetic panel output is not real UXR; real UAT remains deferred until a shared preview and consent plan exist.

## Browser QA
- Community landing profile passed against http://127.0.0.1:8007.
- Screenshot artifacts: /private/tmp/elbysodic-onboarding-community-landing-qa-2026-06-03.
- Writer activation QA passed against the same server.

## Verification
- ELBYSODIC_ENV=development uv run python scripts/browser_qa.py --base-url http://127.0.0.1:8007 --profile community-landing --artifact-dir /private/tmp/elbysodic-onboarding-community-landing-qa-2026-06-03
- ELBYSODIC_ENV=development uv run python scripts/writer_activation_qa.py --base-url http://127.0.0.1:8007
- uv run ruff check .
- uv run ruff format . --check
- uv run python -m py_compile scripts/writer_activation_qa.py
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
- uv run pytest tests/test_route_smoke.py -q --tb=short