### PR TITLE
Map backend steward regression gates

### DIFF
--- a/docs/architecture/steward-regression-pack.md
+++ b/docs/architecture/steward-regression-pack.md
@@ -1,0 +1,264 @@
+# Steward Regression Pack
+
+Status: architecture test map
+Last updated: 2026-06-03
+
+This map turns repeated steward concerns into durable regression entry points.
+It does not replace local steward files or full CI. It gives future agents a
+fast way to find which tests prove tenant, identity, rendered privacy,
+notification, transaction, export/restore, auth posture, and continuity
+contracts.
+
+## How To Use This Map
+
+1. Identify the steward concern touched by the change.
+2. Run the primary focused gate for that concern before broader CI.
+3. Add new focused regression cases near the existing module when a bug escapes
+   a steward or a new invariant becomes product doctrine.
+4. Update this map when a test file is renamed, split, or becomes the primary
+   gate for a concern.
+
+## Tenancy And Data Integrity
+
+Point of view: community-local ownership is the storage backstop for every
+service and rendered surface.
+
+Primary tests:
+
+- `tests/test_tenant_repository.py`
+- `tests/test_backend_contracts.py`
+
+Focused gate:
+
+```bash
+uv run pytest tests/test_tenant_repository.py tests/test_backend_contracts.py -q --tb=short
+```
+
+What this catches:
+
+- cross-community row joins
+- wrong-membership character ownership
+- inactive or malformed selected identity state
+- repository transaction rollback recovery
+- page-handler raw SQL drift
+
+Extend this section when new row families become tenant-paired, such as future
+continuity proposal source links or audit-event targets.
+
+## Identity And Auth Posture
+
+Point of view: global users, community memberships, roles, sessions, and public
+faces remain separate, even when a single login can enter several realms.
+
+Primary tests:
+
+- `tests/test_auth_contracts.py`
+- `tests/test_web_security.py`
+- `tests/test_forum_slice.py`
+
+Focused gate:
+
+```bash
+uv run pytest tests/test_auth_contracts.py tests/test_web_security.py -q --tb=short
+```
+
+What this catches:
+
+- production auth trust posture drift
+- seed password and demo-mode posture
+- signed-out and signed-in account visitor privacy
+- CSRF coverage on sensitive forms
+- stale, inactive, or cross-user membership recovery
+
+Do not use this map to approve auth enforcement changes by itself. Auth,
+session, CSRF, or security behavior changes still require the root stop-and-ask
+review posture.
+
+## Rendered Surface Contracts
+
+Point of view: page handlers call named services, templates render read models,
+and privacy/ranking/lifecycle decisions stay out of markup.
+
+Primary tests:
+
+- `tests/test_backend_contracts.py`
+- `tests/test_forum_slice.py`
+- `tests/test_web_security.py`
+- `tests/test_shell_navigation.py`
+
+Focused gate:
+
+```bash
+uv run pytest tests/test_backend_contracts.py tests/test_shell_navigation.py -q --tb=short
+```
+
+What this catches:
+
+- surface registry and privacy matrix drift
+- page handlers bypassing service contracts
+- shell/sidebar count and navigation privacy regressions
+- public preview, account visitor, inactive, faceless, staff, and
+  cross-community rendered privacy errors
+
+Add browser QA when layout, focus, responsive behavior, or visual trust is part
+of the accepted finding.
+
+## Notification Target Visibility
+
+Point of view: an inbox row delivered to the right membership is still hidden
+when its target is malformed, inaccessible, private, or cross-community.
+
+Primary tests:
+
+- `tests/test_notification_contracts.py`
+- `tests/test_forum_slice.py`
+
+Focused gate:
+
+```bash
+uv run pytest tests/test_notification_contracts.py -q --tb=short
+```
+
+What this catches:
+
+- notification target contract registration drift
+- missing required target fields
+- private plotting-room and wanted-interest leakage
+- inbox-window parity after hidden rows are filtered
+- unread count and mark-read visibility errors
+
+Add target-family tests before a new notification kind can affect shell counts,
+inbox rows, redirects, or mark-read behavior.
+
+## Transactional Workflows
+
+Point of view: multi-write workflows should not strand scenes, posts,
+notifications, applications, claims, reserves, plotting rooms, or Blueprint
+rows after a late failure.
+
+Primary tests:
+
+- `tests/test_forum_slice.py`
+- `tests/test_program_blueprints.py`
+- `tests/test_backend_contracts.py`
+
+Focused gate:
+
+```bash
+uv run pytest tests/test_forum_slice.py tests/test_program_blueprints.py -q --tb=short
+```
+
+What this catches:
+
+- thread start and reply rollback failures
+- application start rollback failures
+- plotting-room scene handoff rollback failures
+- Blueprint apply transaction proof
+- repository commit-failure recovery
+
+Prefer failure-injection helpers that fail at the service/repository seam and
+then assert no partial rows survived.
+
+## Export, Restore, And Operations
+
+Point of view: operator diagnostics and exports should be useful during
+incidents without leaking global accounts, passwords, token hashes, raw invite
+tokens, or private cross-community details.
+
+Primary tests:
+
+- `tests/test_community_exports.py`
+- `tests/test_forum_slice.py`
+- `tests/test_cli.py`
+
+Focused gate:
+
+```bash
+uv run pytest tests/test_community_exports.py tests/test_cli.py -q --tb=short
+```
+
+What this catches:
+
+- export manifest privacy drift
+- operations inspection and integrity output regressions
+- CLI smoke and command contract drift
+- restore-check and future restore-plan output shape changes
+
+Human-confirmation, destructive recovery, schema repair, and deployment changes
+remain outside this regression pack unless a separate issue approves them.
+
+## Continuity Readiness
+
+Point of view: Continuity Graph work stays gated until source-linked memory,
+canon review, privacy, notification, and export boundaries are proven.
+
+Primary tests:
+
+- `tests/test_continuity_domain.py`
+- `tests/test_continuity_readiness.py`
+
+Focused gate:
+
+```bash
+uv run pytest tests/test_continuity_domain.py tests/test_continuity_readiness.py -q --tb=short
+```
+
+What this catches:
+
+- continuity primitive invariants
+- readiness gate drift
+- source visibility expectations before public route families exist
+- docs/test disagreement around future canon review boundaries
+
+Future rendered continuity routes need Surface Contract, Notification, Export,
+Auth, and Tenancy proof before this section can become implementation coverage.
+
+## Blueprint Import And Apply
+
+Point of view: director-authored Program Blueprints can create setup material
+only through the validated, tenant-scoped, rollback-proven import contract.
+
+Primary tests:
+
+- `tests/test_program_blueprints.py`
+- `tests/test_forum_slice.py`
+
+Focused gate:
+
+```bash
+uv run pytest tests/test_program_blueprints.py -q --tb=short
+```
+
+What this catches:
+
+- parser and validation diagnostics
+- unknown-key and vocabulary validation drift
+- tenant-scoped hydration behavior
+- apply transaction and rollback proof
+
+Keep Blueprint behavior out of generic plugin language. The current extension
+contract is Program Blueprints, not a general plugin system.
+
+## Not-Now Gaps
+
+- Performance budgets are covered only where focused query-budget tests already
+  exist; broader benchmark gates are still not part of the pack.
+- Live Railway production smoke remains an operations record, not a local test.
+- Browser-only findings belong in operations QA notes and should be promoted
+  into rendered tests only when behavior can be proven semantically.
+- Partial staff capability storage and audit-event rows are future work; this
+  pack maps the V1 policy helper contract.
+- Real UXR and observed UAT are outside this test pack and must keep consent
+  and evidence labels in `research/`.
+
+## Standard Broad Gate
+
+Run the broad local gate before merging high-risk or cross-steward changes:
+
+```bash
+uv run ruff check .
+uv run ruff format . --check
+uv run ty check src/elbysodic/ tests/
+uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
+uv run pytest -q --tb=short
+```

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -198,6 +198,32 @@ def test_web_page_handlers_do_not_make_policy_decisions_directly() -> None:
     assert offenders == []
 
 
+def test_steward_regression_pack_maps_concerns_to_existing_gates() -> None:
+    regression_map = (REPO_ROOT / "docs" / "architecture" / "steward-regression-pack.md").read_text(
+        encoding="utf-8"
+    )
+    required_sections = (
+        "## Tenancy And Data Integrity",
+        "## Identity And Auth Posture",
+        "## Rendered Surface Contracts",
+        "## Notification Target Visibility",
+        "## Transactional Workflows",
+        "## Export, Restore, And Operations",
+        "## Continuity Readiness",
+        "## Blueprint Import And Apply",
+        "## Not-Now Gaps",
+    )
+    referenced_test_files = set(re.findall(r"`(tests/[^`]+\.py)`", regression_map))
+
+    for section in required_sections:
+        assert section in regression_map
+    assert len(referenced_test_files) >= 10
+    assert all((REPO_ROOT / path).exists() for path in referenced_test_files)
+    assert "uv run pytest" in regression_map
+    assert "uv run ruff check ." in regression_map
+    assert "uv run ty check src/elbysodic/ tests/" in regression_map
+
+
 def test_critical_rendered_pages_use_named_service_surface_contracts() -> None:
     missing: list[str] = []
     for contract in SURFACE_CONTRACTS:


### PR DESCRIPTION
Closes #113

## Summary
- Add a steward-facing backend regression pack map for tenancy, identity/auth, rendered surface contracts, notifications, transactionality, export/restore, continuity, and Blueprints.
- Document focused gates, what each gate catches, extension guidance, and not-now gaps.
- Add a backend contract test that verifies the map keeps required concern sections and references existing test files.

## Steward Notes
- Consulted Test, Surface Contract, Docs, Service, Security/Auth, Data, Operations, Continuity, and Blueprint stewardship through the existing scoped docs.
- Accepted: this PR creates durable mapping/proof for existing regression concerns without product behavior changes.
- Proof: backend contract test plus full local pytest suite, ruff, format, ty, and app check.
- Collateral: new architecture regression-pack map.
- Remaining risk: browser-only, live Railway smoke, performance benchmark, partial capability storage, and real UXR gaps remain explicitly not-now.

## Verification
- uv run pytest tests/test_backend_contracts.py -q --tb=short
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"
- uv run pytest -q --tb=short