### PR TITLE
Add read-only restore plan

### DIFF
--- a/docs/operations/sqlite-production.md
+++ b/docs/operations/sqlite-production.md
@@ -117,6 +117,22 @@ threads/posts, sessions, and workflow rows. The formatted report is redacted:
 record counts and statuses only, not emails, token hashes, session tokens,
 private notes, post bodies, application answers, or credentials.
 
+For an ordered non-mutating restore plan, derive the plan from the same
+restore-check result:
+
+```bash
+uv run python -c "from pathlib import Path; from elbysodic.services.operations import format_restore_plan_report, restore_check_database, restore_plan_from_check; result = restore_check_database(Path('/app/var/elbysodic-backup.sqlite3')); print(format_restore_plan_report(restore_plan_from_check(result)))"
+```
+
+The restore plan is also read-only. It separates safe checks from steps that
+require human confirmation before any repair, import, destructive restore, or
+cutover. It covers tenant roots, membership and character readback, workflow
+rows such as sessions, invitations, access requests, plotting rooms, and
+notifications, plus explicit review steps for claims/reserves, wanted hooks,
+continuity source links, export privacy, and auth/session posture. A blocked
+plan means operators should not mutate or restore the candidate until the named
+failure is understood.
+
 ## Backup/Restore Drill Record
 
 Latest known staging drill:

--- a/src/elbysodic/services/operations.py
+++ b/src/elbysodic/services/operations.py
@@ -198,6 +198,33 @@ class RestoreCheckResult:
 
 
 @dataclass(frozen=True, slots=True)
+class RestorePlanStep:
+    order: int
+    severity: str
+    domain: str
+    title: str
+    detail: str
+    risk: str
+    human_confirmation_required: bool
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class RestorePlan:
+    database_path: str
+    status: str
+    steps: tuple[RestorePlanStep, ...]
+
+    @property
+    def blockers(self) -> tuple[RestorePlanStep, ...]:
+        return tuple(step for step in self.steps if step.severity == "blocker")
+
+    @property
+    def human_confirmation_steps(self) -> tuple[RestorePlanStep, ...]:
+        return tuple(step for step in self.steps if step.human_confirmation_required)
+
+
+@dataclass(frozen=True, slots=True)
 class DirectorOperations:
     cards: list[OperationsCard]
     lanes: list[OperationsLane]
@@ -638,6 +665,43 @@ def format_restore_check_report(result: RestoreCheckResult) -> str:
     return "\n".join(lines) + "\n"
 
 
+def restore_plan_from_check(result: RestoreCheckResult) -> RestorePlan:
+    """Build a deterministic, read-only operator plan from restore-check output."""
+
+    steps: list[RestorePlanStep] = []
+    _append_restore_plan_preflight_steps(steps, result)
+    _append_restore_plan_readback_steps(steps, result)
+    _append_restore_plan_workflow_steps(steps, result)
+    _append_restore_plan_failure_steps(steps, result)
+    _append_restore_plan_confirmation_steps(steps, result)
+    blockers = [step for step in steps if step.severity == "blocker"]
+    status = "ready" if result.ok and not blockers else "blocked" if blockers else "review"
+    return RestorePlan(
+        database_path=result.database_path,
+        status=status,
+        steps=tuple(sorted(steps, key=lambda step: (step.order, step.domain, step.title))),
+    )
+
+
+def format_restore_plan_report(plan: RestorePlan) -> str:
+    lines = [
+        f"restore-plan {plan.status}",
+        f"database: {plan.database_path}",
+        f"steps: {len(plan.steps)}",
+        f"blockers: {len(plan.blockers)}",
+        f"human_confirmation: {len(plan.human_confirmation_steps)}",
+    ]
+    for step in plan.steps:
+        confirmation = "human-confirmation" if step.human_confirmation_required else "read-only"
+        lines.append(
+            f"- [{step.severity}] {step.order} {step.domain}: {step.title} ({confirmation})"
+        )
+        lines.append(f"  detail: {step.detail}")
+        lines.append(f"  risk: {step.risk}")
+        lines.append(f"  source: {step.source}")
+    return "\n".join(lines) + "\n"
+
+
 def _restore_check_connection(
     connection: sqlite3.Connection,
     path: Path,
@@ -688,6 +752,243 @@ def _restore_check_connection(
         readback_checks=tuple(readback_checks),
         failures=tuple(failures),
     )
+
+
+def _append_restore_plan_preflight_steps(
+    steps: list[RestorePlanStep],
+    result: RestoreCheckResult,
+) -> None:
+    _append_step(
+        steps,
+        10,
+        "ok" if result.opened_read_only else "blocker",
+        "operations",
+        "Open candidate database read-only",
+        "Restore planning must inspect the backup without changing it.",
+        "A writable inspection can mutate or lock a candidate backup during an incident.",
+        not result.opened_read_only,
+        "restore_check.opened_read_only",
+    )
+    _append_step(
+        steps,
+        20,
+        "ok" if result.integrity_check == "ok" else "blocker",
+        "storage",
+        "Verify SQLite integrity",
+        f"PRAGMA integrity_check returned {result.integrity_check}.",
+        "A failed integrity check can make later row-level conclusions unreliable.",
+        result.integrity_check != "ok",
+        "restore_check.integrity_check",
+    )
+    _append_step(
+        steps,
+        30,
+        "ok" if result.foreign_key_violations == 0 else "blocker",
+        "storage",
+        "Verify foreign-key integrity",
+        f"PRAGMA foreign_key_check reported {result.foreign_key_violations} violation(s).",
+        "Foreign-key violations can attach objects to missing or wrong tenant roots.",
+        result.foreign_key_violations != 0,
+        "restore_check.foreign_key_violations",
+    )
+    schema_ok = (
+        result.sqlite_user_version == result.current_schema_version
+        and result.latest_migration_version == result.current_schema_version
+    )
+    _append_step(
+        steps,
+        40,
+        "ok" if schema_ok else "blocker",
+        "schema",
+        "Verify schema and migration ledger",
+        (
+            f"user_version={result.sqlite_user_version}; "
+            f"latest_migration={result.latest_migration_version}; "
+            f"current={result.current_schema_version}."
+        ),
+        "Schema drift can make restore checks read the wrong columns or miss repaired rows.",
+        not schema_ok,
+        "restore_check.schema_versions",
+    )
+    _append_step(
+        steps,
+        50,
+        "ok" if result.community_count > 0 else "blocker",
+        "community",
+        "Verify tenant roots",
+        f"Candidate contains {result.community_count} community row(s).",
+        "A restore without tenant roots cannot safely recover memberships, faces, or story rows.",
+        result.community_count == 0,
+        "restore_check.community_count",
+    )
+
+
+def _append_restore_plan_readback_steps(
+    steps: list[RestorePlanStep],
+    result: RestoreCheckResult,
+) -> None:
+    for offset, check in enumerate(result.readback_checks, start=1):
+        _append_step(
+            steps,
+            60 + offset,
+            "ok" if check.status == "ok" else "blocker",
+            _restore_plan_domain_for_text(check.label),
+            f"Read back {check.label}",
+            check.detail,
+            "Service readback failure means operators should not trust raw table counts alone.",
+            check.status != "ok",
+            f"restore_check.readback.{check.label}",
+        )
+
+
+def _append_restore_plan_workflow_steps(
+    steps: list[RestorePlanStep],
+    result: RestoreCheckResult,
+) -> None:
+    counts = {count.table_name: count.count for count in result.core_counts}
+    workflow_domains = (
+        ("auth posture", "user_sessions", "Review session rows before reuse"),
+        ("commands", "command_submissions", "Review command submission reservations"),
+        ("invitations", "community_invitations", "Review invitation token posture"),
+        ("access requests", "community_access_requests", "Review access-request staff context"),
+        ("plotting", "plotting_rooms", "Review plotting room continuity"),
+        ("notification", "notifications", "Review notification targets"),
+    )
+    for offset, (domain, table_name, title) in enumerate(workflow_domains, start=1):
+        count = counts.get(table_name)
+        severity = "info" if count is not None else "warning"
+        detail = (
+            f"{table_name} has {count} row(s) in the candidate."
+            if count is not None
+            else f"{table_name} was not counted by restore-check."
+        )
+        _append_step(
+            steps,
+            80 + offset,
+            severity,
+            domain,
+            title,
+            detail,
+            "Workflow rows can carry private notes, tokens, redirects, or stale command state.",
+            False,
+            f"restore_check.counts.{table_name}",
+        )
+
+
+def _append_restore_plan_failure_steps(
+    steps: list[RestorePlanStep],
+    result: RestoreCheckResult,
+) -> None:
+    for offset, failure in enumerate(result.failures, start=1):
+        _append_step(
+            steps,
+            120 + offset,
+            "blocker",
+            _restore_plan_domain_for_text(failure),
+            "Resolve restore-check failure",
+            failure,
+            "Restore-check failures must be understood before any import, repair, or cutover.",
+            True,
+            "restore_check.failures",
+        )
+
+
+def _append_restore_plan_confirmation_steps(
+    steps: list[RestorePlanStep],
+    result: RestoreCheckResult,
+) -> None:
+    dependency_steps = (
+        (
+            "claims/reserves",
+            "Plan claim and reserve ownership review",
+            "Check claim and reserve ownership before any repair that touches first-face or casting state.",
+        ),
+        (
+            "wanted",
+            "Plan wanted hook and interest review",
+            "Check wanted availability, private interest notes, and plotting handoffs before repair.",
+        ),
+        (
+            "continuity",
+            "Plan continuity source review",
+            "Continuity source links are not a public restore surface yet; inspect source visibility before repair.",
+        ),
+        (
+            "export",
+            "Plan export privacy review",
+            "Compare export expectations before restoring data that may omit sessions, token hashes, or private notes.",
+        ),
+        (
+            "auth posture",
+            "Plan auth and session cutover review",
+            "Decide whether sessions, demo-mode posture, and invite-only access should survive the restore.",
+        ),
+    )
+    severity = "warning" if result.ok else "blocker"
+    for offset, (domain, title, detail) in enumerate(dependency_steps, start=1):
+        _append_step(
+            steps,
+            200 + offset,
+            severity,
+            domain,
+            title,
+            detail,
+            "These domains can expose private, staff, token, or cross-community state after cutover.",
+            True,
+            "restore_plan.human_confirmation",
+        )
+
+
+def _append_step(
+    steps: list[RestorePlanStep],
+    order: int,
+    severity: str,
+    domain: str,
+    title: str,
+    detail: str,
+    risk: str,
+    human_confirmation_required: bool,
+    source: str,
+) -> None:
+    steps.append(
+        RestorePlanStep(
+            order=order,
+            severity=severity,
+            domain=domain,
+            title=title,
+            detail=detail,
+            risk=risk,
+            human_confirmation_required=human_confirmation_required,
+            source=source,
+        )
+    )
+
+
+def _restore_plan_domain_for_text(text: str) -> str:
+    normalized = text.lower()
+    if "communit" in normalized:
+        return "community"
+    if "membership" in normalized or "member" in normalized:
+        return "membership"
+    if "character" in normalized or "face" in normalized:
+        return "character"
+    if "claim" in normalized or "reserve" in normalized:
+        return "claims/reserves"
+    if "wanted" in normalized:
+        return "wanted"
+    if "notification" in normalized:
+        return "notification"
+    if "continuity" in normalized or "source" in normalized:
+        return "continuity"
+    if "export" in normalized:
+        return "export"
+    if "session" in normalized or "auth" in normalized or "user" in normalized:
+        return "auth posture"
+    if "schema" in normalized or "migration" in normalized or "table" in normalized:
+        return "schema"
+    if "foreign" in normalized or "integrity" in normalized:
+        return "storage"
+    return "operations"
 
 
 def _restore_check_table_names(connection: sqlite3.Connection) -> set[str]:

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -30,9 +30,14 @@ from elbysodic.services.notifications import (
 )
 from elbysodic.services.operations import (
     OperationsInspectionConfig,
+    RestoreCheckCount,
+    RestoreCheckReadback,
+    RestoreCheckResult,
     format_restore_check_report,
+    format_restore_plan_report,
     operations_inspection,
     restore_check_database,
+    restore_plan_from_check,
 )
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
@@ -12522,6 +12527,92 @@ def test_restore_check_database_reports_redacted_service_readback(tmp_path: Path
     assert "Do not emit this summary." not in report
     assert "Do not emit this material body." not in report
     assert "Do not emit this post body." not in report
+
+
+def test_restore_plan_from_check_orders_read_only_operator_steps(tmp_path: Path) -> None:
+    db_path = tmp_path / "restore-plan.sqlite3"
+    services = create_services(path=db_path)
+    repo = services.repo
+    viewer = services.viewer()
+    assert viewer.current_character is not None
+    secret_user = repo.create_user("secret-plan@example.com", "secret-password-hash")
+    repo.create_user_session(secret_user.id, "secret-plan-token")
+    services.start_thread(
+        board_slug="danger-room",
+        character_id=viewer.current_character.id,
+        title="Restore Plan Scene",
+        body="Do not emit this restore plan body.",
+    )
+    services.close()
+
+    result = restore_check_database(db_path)
+    plan = restore_plan_from_check(result)
+    report = format_restore_plan_report(plan)
+
+    assert plan.status == "ready"
+    assert plan.blockers == ()
+    assert plan.steps == tuple(
+        sorted(plan.steps, key=lambda step: (step.order, step.domain, step.title))
+    )
+    assert plan.human_confirmation_steps
+    assert {step.domain for step in plan.human_confirmation_steps} >= {
+        "auth posture",
+        "claims/reserves",
+        "continuity",
+        "export",
+        "wanted",
+    }
+    assert "restore-plan ready" in report
+    assert "secret-plan@example.com" not in report
+    assert "secret-password-hash" not in report
+    assert "secret-plan-token" not in report
+    assert "Do not emit this restore plan body." not in report
+
+
+def test_restore_plan_from_check_maps_blockers_to_sensitive_domains() -> None:
+    result = RestoreCheckResult(
+        database_path="/private/tmp/candidate.sqlite3",
+        opened_read_only=True,
+        integrity_check="ok",
+        foreign_key_violations=0,
+        journal_mode="wal",
+        sqlite_user_version=1,
+        current_schema_version=2,
+        latest_migration_version=1,
+        community_count=0,
+        core_counts=(
+            RestoreCheckCount("notifications", "notifications", 2),
+            RestoreCheckCount("sessions", "user_sessions", 1),
+        ),
+        readback_checks=(
+            RestoreCheckReadback("memberships", "failed", "membership ownership missing"),
+            RestoreCheckReadback("characters", "failed", "character ownership drift detected"),
+        ),
+        failures=(
+            "no communities found",
+            "orphaned notification target found",
+            "continuity source gap detected",
+            "export manifest unavailable",
+            "auth session posture needs review",
+        ),
+    )
+
+    plan = restore_plan_from_check(result)
+    blockers_by_domain = {step.domain for step in plan.blockers}
+
+    assert plan.status == "blocked"
+    assert blockers_by_domain >= {
+        "auth posture",
+        "character",
+        "community",
+        "continuity",
+        "export",
+        "membership",
+        "notification",
+        "schema",
+    }
+    assert all(step.human_confirmation_required for step in plan.blockers)
+    assert "restore-plan blocked" in format_restore_plan_report(plan)
 
 
 def test_restore_check_database_reports_wrong_database_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #105

## Summary
- Add `RestorePlan` and `RestorePlanStep` read models derived from restore-check output.
- Add human-readable restore-plan formatting with ordered safe checks, blockers, and human-confirmation steps.
- Cover tenant roots, membership, character, notification, continuity, export, and auth-posture dependencies without performing repair or mutation.
- Document the operator command in the SQLite production runbook.

## Steward Notes
- Consulted Operations, Data, Security/Auth, Service, Docs, and Test stewardship.
- Accepted: restore planning is read-only and derived from existing restore-check diagnostics.
- Proof: restore-focused tests cover read-only plan ordering, redaction, and blocker domain mapping.
- Collateral: SQLite production runbook updated.
- Remaining risk: this does not repair, import, restore, migrate, or mutate any candidate database; destructive recovery remains behind separate approval.

## Verification
- `uv run pytest tests/test_forum_slice.py -q --tb=short -k "restore_check or restore_plan"`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
