### PR TITLE
Define community export privacy tiers

### DIFF
--- a/docs/architecture/primitives.md
+++ b/docs/architecture/primitives.md
@@ -280,6 +280,16 @@ sessions, token hashes, raw invite tokens, and private access-request notes from
 the general community archive manifest. Director-only detail export can be
 designed later if those private workflow records need a separate archive path.
 
+Export privacy profiles live with the service manifest. They define the allowed
+domain lists for public export, member export, staff operations export, and
+director archive export before any binary/archive artifact exists. Every profile
+and manifest section carries `community_id`, and every tier explicitly excludes
+cross-community records. Lower tiers keep private notes, staff queues, inactive
+identities, draft materials, notification rows, and other writers' private
+records out of export scope. The director archive profile names sensitive
+domains so operators can see which PBP workflow records require privacy review
+before preservation.
+
 ## Continuity Graph
 
 Continuity Graph is not yet a persistence primitive in this repo. Existing

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -159,6 +159,21 @@ access-request notes. A future detail export for staff workflow records needs a
 separate privacy review before it can include applicant emails, notes, or
 invitation audit material.
 
+The export service also owns privacy profiles for four archive tiers. A public
+export profile is limited to public-safe realm identity, approved roster,
+non-archived wanted hooks, claimed public casting values, and published material
+metadata. A member profile may add member-visible threads and posts, but not
+staff queues, private notes, another writer's private records, draft materials,
+notification rows, inactive identities, or cross-community records. A staff
+profile may include current-community operational state only for workflows the
+staff capability covers; it still excludes global auth material, sessions, raw
+invite tokens, notification rows, and other communities. A director archive
+profile names sensitive domains such as membership state, roles, inactive
+identities, draft materials, private plotting rooms, invitation state,
+notification rows, and staff queues, while still excluding global users,
+password hashes, sessions, raw invite tokens, applicant private notes, and
+cross-community rows.
+
 First-realm creation is not a public web permission. The current setup path is
 the operator-only `bootstrap-first-realm` CLI command, which creates a global
 login user plus a community-local director membership in the same transaction.

--- a/src/elbysodic/services/exports.py
+++ b/src/elbysodic/services/exports.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Literal, Protocol
 
 from elbysodic.domain.models import (
     Board,
@@ -26,15 +26,38 @@ from elbysodic.domain.models import (
 from elbysodic.services import policies
 from elbysodic.services.read_models import ForumView
 
+type CommunityExportPrivacyTier = Literal["public", "member", "staff", "director_archive"]
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityExportDomain:
+    community_id: int
+    name: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityExportProfile:
+    community_id: int
+    community_slug: str
+    tier: CommunityExportPrivacyTier
+    label: str
+    audience: str
+    included_domains: tuple[CommunityExportDomain, ...]
+    excluded_domains: tuple[CommunityExportDomain, ...]
+    sensitive_domains: tuple[CommunityExportDomain, ...]
+
 
 @dataclass(frozen=True, slots=True)
 class CommunityExportCount:
+    community_id: int
     label: str
     count: int
 
 
 @dataclass(frozen=True, slots=True)
 class CommunityExportOwnership:
+    community_id: int
     kind: str
     record_id: int
     membership_id: int | None
@@ -44,6 +67,7 @@ class CommunityExportOwnership:
 
 @dataclass(frozen=True, slots=True)
 class CommunityExportSourceLink:
+    community_id: int
     kind: str
     record_id: int
     href: str
@@ -52,6 +76,7 @@ class CommunityExportSourceLink:
 
 @dataclass(frozen=True, slots=True)
 class CommunityExportRedaction:
+    community_id: int
     scope: str
     reason: str
 
@@ -65,6 +90,7 @@ class CommunityExportManifest:
     ownership: tuple[CommunityExportOwnership, ...]
     source_links: tuple[CommunityExportSourceLink, ...]
     redactions: tuple[CommunityExportRedaction, ...]
+    privacy_profiles: tuple[CommunityExportProfile, ...]
 
 
 class CommunityExportRepository(Protocol):
@@ -167,25 +193,26 @@ def community_export_manifest(
         community_slug=community.slug,
         community_name=community.name,
         counts=(
-            CommunityExportCount("memberships", len(memberships)),
-            CommunityExportCount("roles", len({role.id for role in roles.values()})),
-            CommunityExportCount("characters", len(characters)),
-            CommunityExportCount("boards", len(boards)),
-            CommunityExportCount("threads", len(threads)),
-            CommunityExportCount("posts", len(posts)),
-            CommunityExportCount("materials", len(materials)),
-            CommunityExportCount("claim_types", len(claim_types)),
-            CommunityExportCount("claims", len(claims)),
-            CommunityExportCount("reserves", len(reserves)),
-            CommunityExportCount("wanted_ads", len(wanted_ads)),
-            CommunityExportCount("plot_hooks", len(plot_hooks)),
-            CommunityExportCount("plotting_rooms", len(plotting_rooms)),
-            CommunityExportCount("access_requests", len(access_requests)),
-            CommunityExportCount("invitations", len(invitations)),
+            CommunityExportCount(community.id, "memberships", len(memberships)),
+            CommunityExportCount(community.id, "roles", len({role.id for role in roles.values()})),
+            CommunityExportCount(community.id, "characters", len(characters)),
+            CommunityExportCount(community.id, "boards", len(boards)),
+            CommunityExportCount(community.id, "threads", len(threads)),
+            CommunityExportCount(community.id, "posts", len(posts)),
+            CommunityExportCount(community.id, "materials", len(materials)),
+            CommunityExportCount(community.id, "claim_types", len(claim_types)),
+            CommunityExportCount(community.id, "claims", len(claims)),
+            CommunityExportCount(community.id, "reserves", len(reserves)),
+            CommunityExportCount(community.id, "wanted_ads", len(wanted_ads)),
+            CommunityExportCount(community.id, "plot_hooks", len(plot_hooks)),
+            CommunityExportCount(community.id, "plotting_rooms", len(plotting_rooms)),
+            CommunityExportCount(community.id, "access_requests", len(access_requests)),
+            CommunityExportCount(community.id, "invitations", len(invitations)),
         ),
         ownership=(
             *(
                 CommunityExportOwnership(
+                    community.id,
                     "character",
                     character.id,
                     character.membership_id,
@@ -196,6 +223,7 @@ def community_export_manifest(
             ),
             *(
                 CommunityExportOwnership(
+                    community.id,
                     "post",
                     post.id,
                     post.author_membership_id,
@@ -206,6 +234,7 @@ def community_export_manifest(
             ),
             *(
                 CommunityExportOwnership(
+                    community.id,
                     "wanted_ad",
                     wanted_ad.id,
                     wanted_ad.creator_membership_id,
@@ -216,6 +245,7 @@ def community_export_manifest(
             ),
             *(
                 CommunityExportOwnership(
+                    community.id,
                     "plot_hook",
                     plot_hook.id,
                     plot_hook.author_membership_id,
@@ -226,6 +256,7 @@ def community_export_manifest(
             ),
             *(
                 CommunityExportOwnership(
+                    community.id,
                     "plotting_room",
                     room.id,
                     room.owner_membership_id,
@@ -238,6 +269,7 @@ def community_export_manifest(
         source_links=(
             *(
                 CommunityExportSourceLink(
+                    community.id,
                     "board",
                     board.id,
                     f"/c/{community.slug}/boards/{board.slug}",
@@ -247,6 +279,7 @@ def community_export_manifest(
             ),
             *(
                 CommunityExportSourceLink(
+                    community.id,
                     "thread",
                     thread.id,
                     f"/c/{community.slug}/boards/{_board_slug(boards, thread.board_id)}/threads/{thread.slug}",
@@ -256,6 +289,7 @@ def community_export_manifest(
             ),
             *(
                 CommunityExportSourceLink(
+                    community.id,
                     "material",
                     material.id,
                     f"/c/{community.slug}/world/{material.slug}",
@@ -265,6 +299,7 @@ def community_export_manifest(
             ),
             *(
                 CommunityExportSourceLink(
+                    community.id,
                     "wanted_ad",
                     wanted_ad.id,
                     f"/c/{community.slug}/wanted/{wanted_ad.slug}",
@@ -275,22 +310,27 @@ def community_export_manifest(
         ),
         redactions=(
             CommunityExportRedaction(
+                community.id,
                 "global_users",
                 "global login accounts and password hashes are outside one community export",
             ),
             CommunityExportRedaction(
+                community.id,
                 "sessions",
                 "session cookies, token hashes, and selected identity state are never archived",
             ),
             CommunityExportRedaction(
+                community.id,
                 "invitations",
                 "raw invite tokens are unavailable after creation because only token hashes are stored",
             ),
             CommunityExportRedaction(
+                community.id,
                 "access_requests",
                 "private request notes and applicant emails require a director-only detail export",
             ),
         ),
+        privacy_profiles=_community_export_profiles(community),
     )
 
 
@@ -299,3 +339,235 @@ def _board_slug(boards: list[Board], board_id: int) -> str:
         if board.id == board_id:
             return board.slug
     return "missing-board"
+
+
+def _community_export_profiles(community: Community) -> tuple[CommunityExportProfile, ...]:
+    return (
+        CommunityExportProfile(
+            community.id,
+            community.slug,
+            "public",
+            "Public realm export",
+            "signed-out visitors and off-site public archive readers",
+            included_domains=_domains(
+                community.id,
+                (
+                    ("realm_profile", "public community name, slug, premise, and entry posture"),
+                    ("published_roster", "approved public faces and roster labels"),
+                    ("open_wanted_hooks", "public wanted hooks that are not archived"),
+                    (
+                        "claimed_claims",
+                        "claimed public casting values without private review notes",
+                    ),
+                    (
+                        "published_material_metadata",
+                        "published guidebook titles, slugs, and summaries",
+                    ),
+                ),
+            ),
+            excluded_domains=_domains(
+                community.id,
+                (
+                    ("member_identities", "membership names and active-face state are not public"),
+                    (
+                        "private_notes",
+                        "writer, applicant, and staff notes are not public archive data",
+                    ),
+                    ("staff_queues", "operations and review queues require staff capability"),
+                    (
+                        "inactive_identities",
+                        "inactive memberships and faces stay outside public export",
+                    ),
+                    ("draft_materials", "draft guidebook and event materials stay inside Studio"),
+                    ("notification_rows", "membership inbox rows are private operational state"),
+                    ("cross_community_records", "export rows must belong to this community only"),
+                ),
+            ),
+            sensitive_domains=(),
+        ),
+        CommunityExportProfile(
+            community.id,
+            community.slug,
+            "member",
+            "Member-visible realm export",
+            "active members inside this community",
+            included_domains=_domains(
+                community.id,
+                (
+                    ("realm_profile", "community identity and member navigation context"),
+                    ("published_roster", "approved public faces and roster labels"),
+                    (
+                        "member_visible_threads",
+                        "threads visible to the member's current membership",
+                    ),
+                    ("member_visible_posts", "posts visible to the member's current membership"),
+                    ("open_wanted_hooks", "member-visible wanted hooks and public hook context"),
+                    (
+                        "claimed_claims",
+                        "member-visible casting values without private review notes",
+                    ),
+                    (
+                        "published_material_metadata",
+                        "published guidebook titles, slugs, and summaries",
+                    ),
+                ),
+            ),
+            excluded_domains=_domains(
+                community.id,
+                (
+                    (
+                        "other_writer_private_records",
+                        "member exports cannot include another writer's drafts or notes",
+                    ),
+                    (
+                        "private_notes",
+                        "writer, applicant, and staff notes stay out of member exports",
+                    ),
+                    ("staff_queues", "operations and review queues require staff capability"),
+                    (
+                        "inactive_identities",
+                        "inactive memberships and faces are not member export data",
+                    ),
+                    ("draft_materials", "draft guidebook and event materials stay inside Studio"),
+                    ("notification_rows", "membership inbox rows need a separate privacy contract"),
+                    ("cross_community_records", "export rows must belong to this community only"),
+                ),
+            ),
+            sensitive_domains=(),
+        ),
+        CommunityExportProfile(
+            community.id,
+            community.slug,
+            "staff",
+            "Staff operations export",
+            "staff with current-community capability for the included workflow",
+            included_domains=_domains(
+                community.id,
+                (
+                    ("realm_profile", "community identity for the current realm only"),
+                    ("memberships", "community-local membership records for staff workflow review"),
+                    ("roles", "community-local role assignments used by staff workflows"),
+                    ("characters", "current-community faces and application posture"),
+                    ("boards_threads_posts", "community boards, threads, posts, and authorship"),
+                    ("materials", "published and draft director materials visible to staff"),
+                    ("claims_reserves_wanted", "claim, reserve, and wanted-hook workflow state"),
+                    ("plot_hooks_plotting_rooms", "plotting and handoff spaces visible to staff"),
+                    ("staff_queues", "operations queues visible to current-community staff"),
+                ),
+            ),
+            excluded_domains=_domains(
+                community.id,
+                (
+                    (
+                        "global_users",
+                        "global login accounts and password hashes are outside one community export",
+                    ),
+                    (
+                        "sessions",
+                        "session cookies, token hashes, and selected identity state are never archived",
+                    ),
+                    ("raw_invitation_tokens", "only token hashes are stored after creation"),
+                    ("notification_rows", "membership inbox rows require director archive review"),
+                    ("cross_community_records", "export rows must belong to this community only"),
+                ),
+            ),
+            sensitive_domains=_domains(
+                community.id,
+                (
+                    (
+                        "memberships",
+                        "membership state can reveal writer identity inside this community",
+                    ),
+                    ("roles", "role assignments expose current staff posture"),
+                    ("draft_materials", "draft guidebook and event materials are staff-only"),
+                    ("staff_queues", "operations queues can reveal private workflow state"),
+                ),
+            ),
+        ),
+        CommunityExportProfile(
+            community.id,
+            community.slug,
+            "director_archive",
+            "Director archive export",
+            "directors preserving one complete community archive",
+            included_domains=_domains(
+                community.id,
+                (
+                    ("realm_profile", "community identity for the current realm only"),
+                    ("memberships", "community-local writer identities and active state"),
+                    ("roles", "community-local staff role assignments"),
+                    ("characters", "public faces owned by memberships in this community"),
+                    (
+                        "boards_threads_posts",
+                        "community boards, scenes, threads, posts, and authorship",
+                    ),
+                    ("materials", "published and draft director materials"),
+                    ("claims_reserves_wanted", "claim, reserve, and wanted-hook workflow state"),
+                    ("plot_hooks_plotting_rooms", "plotter hooks and private handoff room state"),
+                    (
+                        "access_request_metadata",
+                        "request lifecycle records without applicant emails or private notes",
+                    ),
+                    ("invitations", "invitation state without raw invite tokens"),
+                    (
+                        "notification_rows",
+                        "community-scoped membership inbox rows after target visibility review",
+                    ),
+                    ("staff_queues", "operations, review, and continuation queues"),
+                ),
+            ),
+            excluded_domains=_domains(
+                community.id,
+                (
+                    (
+                        "global_users",
+                        "global login accounts and password hashes are outside one community export",
+                    ),
+                    (
+                        "sessions",
+                        "session cookies, token hashes, and selected identity state are never archived",
+                    ),
+                    (
+                        "password_hashes",
+                        "password hashes are global auth material, not realm archive material",
+                    ),
+                    ("raw_invitation_tokens", "only token hashes are stored after creation"),
+                    (
+                        "applicant_private_notes",
+                        "notes and applicant emails need a detail-export privacy review",
+                    ),
+                    ("cross_community_records", "export rows must belong to this community only"),
+                ),
+            ),
+            sensitive_domains=_domains(
+                community.id,
+                (
+                    (
+                        "memberships",
+                        "membership state can reveal writer identity inside this community",
+                    ),
+                    ("roles", "role assignments expose current staff posture"),
+                    (
+                        "inactive_identities",
+                        "inactive memberships and faces remain sensitive archive material",
+                    ),
+                    ("draft_materials", "draft guidebook and event materials are not public"),
+                    ("private_plotting_rooms", "handoff rooms can expose private plotting context"),
+                    ("access_request_metadata", "request lifecycle can expose applicant history"),
+                    ("invitations", "invitation state is staff workflow history"),
+                    (
+                        "notification_rows",
+                        "inbox rows can reveal private targets and counterparties",
+                    ),
+                    ("staff_queues", "operations queues can reveal private workflow state"),
+                ),
+            ),
+        ),
+    )
+
+
+def _domains(
+    community_id: int,
+    domains: tuple[tuple[str, str], ...],
+) -> tuple[CommunityExportDomain, ...]:
+    return tuple(CommunityExportDomain(community_id, name, reason) for name, reason in domains)

--- a/tests/test_community_exports.py
+++ b/tests/test_community_exports.py
@@ -4,6 +4,12 @@ import pytest
 
 from elbysodic.db.seed import DemoSeed, resolve_seed_persona
 from elbysodic.services import AppServices, create_services
+from elbysodic.services.exports import (
+    CommunityExportDomain,
+    CommunityExportManifest,
+    CommunityExportPrivacyTier,
+    CommunityExportProfile,
+)
 
 
 def test_director_export_manifest_is_tenant_scoped_and_redacted() -> None:
@@ -37,6 +43,10 @@ def test_director_export_manifest_is_tenant_scoped_and_redacted() -> None:
     rendered_manifest = repr(manifest)
 
     assert manifest.community_slug == "x-men-apocalypse"
+    assert all(item.community_id == manifest.community_id for item in manifest.counts)
+    assert all(item.community_id == manifest.community_id for item in manifest.ownership)
+    assert all(link.community_id == manifest.community_id for link in manifest.source_links)
+    assert all(redaction.community_id == manifest.community_id for redaction in manifest.redactions)
     assert counts["memberships"] > 0
     assert counts["characters"] > 0
     assert counts["threads"] > 0
@@ -61,8 +71,183 @@ def test_director_export_manifest_is_tenant_scoped_and_redacted() -> None:
     assert "dev-password-hash" not in rendered_manifest
 
 
+def test_export_privacy_profiles_are_tenant_scoped() -> None:
+    services = create_services(path=":memory:")
+    staff = resolve_seed_persona(services.repo, "xmen_staff")
+    staff_services = AppServices(
+        services.repo,
+        DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+    )
+
+    manifest = staff_services.community_export_manifest()
+    profiles = {profile.tier: profile for profile in manifest.privacy_profiles}
+
+    assert set(profiles) == {"public", "member", "staff", "director_archive"}
+    for profile in profiles.values():
+        assert profile.community_id == manifest.community_id
+        assert profile.community_slug == manifest.community_slug
+        profile_domains = (
+            *profile.included_domains,
+            *profile.excluded_domains,
+            *profile.sensitive_domains,
+        )
+        assert all(domain.community_id == manifest.community_id for domain in profile_domains)
+
+
+def test_public_export_profile_includes_only_public_safe_realm_domains() -> None:
+    manifest = _staff_export_manifest()
+    public = _profile(manifest.privacy_profiles, "public")
+
+    assert _domain_names(public.included_domains) == {
+        "realm_profile",
+        "published_roster",
+        "open_wanted_hooks",
+        "claimed_claims",
+        "published_material_metadata",
+    }
+    assert {
+        "member_identities",
+        "private_notes",
+        "staff_queues",
+        "inactive_identities",
+        "draft_materials",
+        "notification_rows",
+        "cross_community_records",
+    }.issubset(_domain_names(public.excluded_domains))
+    assert public.sensitive_domains == ()
+
+
+def test_member_export_profile_excludes_staff_and_other_writer_private_state() -> None:
+    manifest = _staff_export_manifest()
+    member = _profile(manifest.privacy_profiles, "member")
+
+    assert {
+        "realm_profile",
+        "published_roster",
+        "member_visible_threads",
+        "member_visible_posts",
+        "open_wanted_hooks",
+        "claimed_claims",
+        "published_material_metadata",
+    }.issubset(_domain_names(member.included_domains))
+    assert {
+        "other_writer_private_records",
+        "private_notes",
+        "staff_queues",
+        "inactive_identities",
+        "draft_materials",
+        "notification_rows",
+        "cross_community_records",
+    }.issubset(_domain_names(member.excluded_domains))
+    assert member.sensitive_domains == ()
+
+
+def test_staff_export_profile_is_current_community_operational_state() -> None:
+    manifest = _staff_export_manifest()
+    staff = _profile(manifest.privacy_profiles, "staff")
+
+    assert {
+        "memberships",
+        "roles",
+        "characters",
+        "boards_threads_posts",
+        "materials",
+        "claims_reserves_wanted",
+        "plot_hooks_plotting_rooms",
+        "staff_queues",
+    }.issubset(_domain_names(staff.included_domains))
+    assert {
+        "global_users",
+        "sessions",
+        "raw_invitation_tokens",
+        "notification_rows",
+        "cross_community_records",
+    }.issubset(_domain_names(staff.excluded_domains))
+    assert {
+        "memberships",
+        "roles",
+        "draft_materials",
+        "staff_queues",
+    }.issubset(_domain_names(staff.sensitive_domains))
+
+
+def test_director_archive_profile_names_sensitive_domains_and_cross_tenant_exclusions() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    staff = resolve_seed_persona(repo, "xmen_staff")
+    hp = repo.get_community_by_slug("hp-universe")
+    repo.create_community_access_request(
+        hp.id,
+        email="hp-archive-profile@example.com",
+        display_name="HP Archive Profile Prospect",
+        face_concept="HP profile face concept",
+        wanted_hook="HP profile wanted hook",
+        notes="HP profile private note",
+    )
+    staff_services = AppServices(
+        repo,
+        DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+    )
+
+    manifest = staff_services.community_export_manifest()
+    director = _profile(manifest.privacy_profiles, "director_archive")
+    rendered_director_profile = repr(director)
+
+    assert {
+        "access_request_metadata",
+        "invitations",
+        "notification_rows",
+        "staff_queues",
+    }.issubset(_domain_names(director.included_domains))
+    assert {
+        "memberships",
+        "roles",
+        "inactive_identities",
+        "draft_materials",
+        "private_plotting_rooms",
+        "access_request_metadata",
+        "invitations",
+        "notification_rows",
+        "staff_queues",
+    }.issubset(_domain_names(director.sensitive_domains))
+    assert {
+        "global_users",
+        "sessions",
+        "password_hashes",
+        "raw_invitation_tokens",
+        "applicant_private_notes",
+        "cross_community_records",
+    }.issubset(_domain_names(director.excluded_domains))
+    assert "HP Archive Profile Prospect" not in rendered_director_profile
+    assert "HP profile private note" not in rendered_director_profile
+
+
 def test_member_cannot_create_community_export_manifest() -> None:
     services = create_services(path=":memory:")
 
     with pytest.raises(PermissionError, match="director access is required"):
         services.community_export_manifest()
+
+
+def _staff_export_manifest() -> CommunityExportManifest:
+    services = create_services(path=":memory:")
+    staff = resolve_seed_persona(services.repo, "xmen_staff")
+    staff_services = AppServices(
+        services.repo,
+        DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+    )
+    return staff_services.community_export_manifest()
+
+
+def _profile(
+    profiles: tuple[CommunityExportProfile, ...],
+    tier: CommunityExportPrivacyTier,
+) -> CommunityExportProfile:
+    for profile in profiles:
+        if profile.tier == tier:
+            return profile
+    raise AssertionError(f"missing export privacy profile for tier: {tier}")
+
+
+def _domain_names(domains: tuple[CommunityExportDomain, ...]) -> set[str]:
+    return {domain.name for domain in domains}


### PR DESCRIPTION
## Summary

- Add service-owned community export privacy profiles for public, member, staff, and director archive tiers.
- Make every export manifest section carry `community_id`.
- Document export privacy tier expectations in architecture docs.

Closes #106

## Steward Notes

- Service Steward: export tier read models stay service-owned and tenant-aware; no routes, CLI, schema, or archive artifact generation added.
- Privacy Steward: lower tiers explicitly exclude private notes, staff queues, inactive identities, draft materials, notification rows, other writers' private records, and cross-community rows.
- Docs Steward: architecture docs describe the PBP archive contract without presenting it as a public download surface.

## Proof

- `uv run pytest tests/test_community_exports.py -q --tb=short`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`
