### PR TITLE
Add continuity source visibility gate

### DIFF
--- a/docs/architecture/continuity-graph-readiness.md
+++ b/docs/architecture/continuity-graph-readiness.md
@@ -18,6 +18,11 @@ it is not a schema design and it does not authorize automatic canon.
 - Program, plotting, claims, applications, and notifications already carry
   source links in specific workflows. They are examples to inspect, not a
   generic continuity primitive.
+- `src/elbysodic/services/continuity.py` owns a schema-neutral source
+  visibility gate for future continuity read models. It resolves board,
+  location, scene/thread, post, character, material, wanted-hook, claim, and
+  reserve references through tenant-aware repository methods and returns
+  redacted visible/hidden results before any route or stored proposal exists.
 
 ## First Implementable Slice
 
@@ -64,6 +69,17 @@ must include proof for:
   links from unauthorized memberships
 - export behavior that includes only one community's continuity rows and
   citations
+
+The source visibility gate is intentionally conservative. Public and member
+viewers may see only sources they can already read: public locations, visible
+scenes/posts, accepted faces, published materials, open wanted hooks, and
+public claimed claims. Private scene participants can see their own private
+scene/post references inside otherwise visible locations. Staff/director
+capabilities can reveal review-only source labels for current-community
+workflow records, but inactive viewers, cross-community viewers, malformed
+post/thread pairs, private boards, draft materials, private claims, reserves,
+and other writers' private records return redacted hidden statuses unless the
+viewer already owns or can review that source.
 
 ## Stop-And-Ask Points
 

--- a/src/elbysodic/services/continuity.py
+++ b/src/elbysodic/services/continuity.py
@@ -1,0 +1,360 @@
+"""Continuity Graph source visibility gates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from elbysodic.domain.models import (
+    Board,
+    Character,
+    CharacterClaim,
+    CharacterReserve,
+    ClaimType,
+    CommunityMembership,
+    Material,
+    Post,
+    Role,
+    Thread,
+    WantedAd,
+)
+from elbysodic.services import policies
+from elbysodic.services.read_models import ForumView
+
+type ContinuitySourceFamily = Literal[
+    "board",
+    "character",
+    "claim",
+    "location",
+    "material",
+    "post",
+    "reserve",
+    "scene",
+    "thread",
+    "wanted_ad",
+]
+
+type ContinuitySourceVisibilityStatus = Literal[
+    "visible",
+    "hidden",
+    "not_found",
+    "cross_community",
+    "inactive_viewer",
+    "malformed",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuitySourceReference:
+    community_id: int
+    source_family: ContinuitySourceFamily
+    source_id: int
+    source_thread_id: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.community_id <= 0:
+            raise ValueError("community_id must be a positive id")
+        if self.source_id <= 0:
+            raise ValueError("source_id must be a positive id")
+        if self.source_thread_id is not None and self.source_thread_id <= 0:
+            raise ValueError("source_thread_id must be a positive id")
+        if self.source_family == "post" and self.source_thread_id is None:
+            raise ValueError("post source references require source_thread_id")
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuitySourceViewer:
+    community_id: int
+    membership: CommunityMembership | None = None
+    role: Role | None = None
+
+    @classmethod
+    def from_forum_view(cls, viewer: ForumView) -> ContinuitySourceViewer:
+        return cls(
+            community_id=viewer.community.id,
+            membership=viewer.membership,
+            role=viewer.role,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuitySourceVisibility:
+    community_id: int
+    source_family: ContinuitySourceFamily
+    source_id: int
+    status: ContinuitySourceVisibilityStatus
+    label: str
+    reason: str
+
+    @property
+    def visible(self) -> bool:
+        return self.status == "visible"
+
+
+class ContinuitySourceVisibilityRepository(Protocol):
+    def get_board(self, community_id: int, board_id: int) -> Board: ...
+
+    def get_thread(self, community_id: int, thread_id: int) -> Thread: ...
+
+    def get_post(self, community_id: int, post_id: int) -> Post: ...
+
+    def get_character(self, community_id: int, character_id: int) -> Character: ...
+
+    def get_material(self, community_id: int, material_id: int) -> Material: ...
+
+    def get_wanted_ad(self, community_id: int, wanted_ad_id: int) -> WantedAd: ...
+
+    def get_claim_type(self, community_id: int, claim_type_id: int) -> ClaimType: ...
+
+    def get_character_claim(self, community_id: int, claim_id: int) -> CharacterClaim: ...
+
+    def get_character_reserve(self, community_id: int, reserve_id: int) -> CharacterReserve: ...
+
+    def list_thread_participants(self, community_id: int, thread_id: int) -> list[Character]: ...
+
+
+def public_continuity_source_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    community_id: int,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    return continuity_source_visibility(
+        repo,
+        ContinuitySourceViewer(community_id=community_id),
+        reference,
+    )
+
+
+def continuity_source_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ForumView | ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    source_viewer = _source_viewer(viewer)
+    if reference.community_id != source_viewer.community_id:
+        return _hidden(reference, "cross_community", "source belongs to another community")
+    if source_viewer.membership is not None and not source_viewer.membership.is_active:
+        return _hidden(reference, "inactive_viewer", "viewer is inactive in this community")
+    try:
+        match reference.source_family:
+            case "board":
+                return _board_visibility(repo, source_viewer, reference)
+            case "location":
+                return _location_visibility(repo, source_viewer, reference)
+            case "thread" | "scene":
+                return _thread_visibility(repo, source_viewer, reference)
+            case "post":
+                return _post_visibility(repo, source_viewer, reference)
+            case "character":
+                return _character_visibility(repo, source_viewer, reference)
+            case "material":
+                return _material_visibility(repo, source_viewer, reference)
+            case "wanted_ad":
+                return _wanted_visibility(repo, source_viewer, reference)
+            case "claim":
+                return _claim_visibility(repo, source_viewer, reference)
+            case "reserve":
+                return _reserve_visibility(repo, source_viewer, reference)
+    except LookupError:
+        return _hidden(reference, "not_found", "source is not visible in this community")
+
+
+def _board_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    board = repo.get_board(reference.community_id, reference.source_id)
+    if _can_view_board(viewer, board):
+        return _visible(reference, board.name, "viewer can read this board")
+    return _hidden(reference, "hidden", "viewer cannot read this board")
+
+
+def _location_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    board = repo.get_board(reference.community_id, reference.source_id)
+    if board.board_kind not in {"location", "sublocation"}:
+        return _hidden(reference, "malformed", "location sources must target location boards")
+    if _can_view_board(viewer, board):
+        return _visible(reference, board.name, "viewer can read this location")
+    return _hidden(reference, "hidden", "viewer cannot read this location")
+
+
+def _thread_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    thread = repo.get_thread(reference.community_id, reference.source_id)
+    board = repo.get_board(reference.community_id, thread.board_id)
+    if _can_view_thread(repo, viewer, board, thread):
+        return _visible(reference, thread.title, "viewer can read this scene")
+    return _hidden(reference, "hidden", "viewer cannot read this scene")
+
+
+def _post_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    post = repo.get_post(reference.community_id, reference.source_id)
+    if post.thread_id != reference.source_thread_id:
+        return _hidden(reference, "malformed", "post source_thread_id does not match source_id")
+    thread = repo.get_thread(reference.community_id, post.thread_id)
+    board = repo.get_board(reference.community_id, thread.board_id)
+    if _can_view_thread(repo, viewer, board, thread):
+        return _visible(reference, f"post #{post.post_number}", "viewer can read this post")
+    return _hidden(reference, "hidden", "viewer cannot read this post")
+
+
+def _character_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    character = repo.get_character(reference.community_id, reference.source_id)
+    if character.application_status == "accepted" or _can_manage_casting(viewer):
+        return _visible(reference, character.name, "viewer can read this face")
+    if viewer.membership is not None and character.membership_id == viewer.membership.id:
+        return _visible(reference, character.name, "viewer owns this face")
+    return _hidden(reference, "hidden", "viewer cannot read this face")
+
+
+def _material_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    material = repo.get_material(reference.community_id, reference.source_id)
+    if material.status == "published" or _can_manage_world(viewer):
+        return _visible(reference, material.title, "viewer can read this material")
+    return _hidden(reference, "hidden", "viewer cannot read this material")
+
+
+def _wanted_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    wanted = repo.get_wanted_ad(reference.community_id, reference.source_id)
+    if wanted.status == "open" or _can_manage_casting(viewer):
+        return _visible(reference, wanted.title, "viewer can read this wanted hook")
+    if viewer.membership is not None and wanted.creator_membership_id == viewer.membership.id:
+        return _visible(reference, wanted.title, "viewer owns this wanted hook")
+    return _hidden(reference, "hidden", "viewer cannot read this wanted hook")
+
+
+def _claim_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    claim = repo.get_character_claim(reference.community_id, reference.source_id)
+    claim_type = repo.get_claim_type(reference.community_id, claim.claim_type_id)
+    if claim.status == "claimed" and claim_type.visibility == "public":
+        return _visible(reference, claim.label, "viewer can read this public claim")
+    if _can_manage_casting(viewer) or _can_manage_applications(viewer):
+        return _visible(reference, claim.label, "viewer can review this claim")
+    return _hidden(reference, "hidden", "viewer cannot read this claim")
+
+
+def _reserve_visibility(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    reference: ContinuitySourceReference,
+) -> ContinuitySourceVisibility:
+    reserve = repo.get_character_reserve(reference.community_id, reference.source_id)
+    if _can_manage_casting(viewer):
+        return _visible(reference, reserve.title, "viewer can review this reserve")
+    if viewer.membership is not None and reserve.membership_id == viewer.membership.id:
+        return _visible(reference, reserve.title, "viewer owns this reserve")
+    return _hidden(reference, "hidden", "viewer cannot read this reserve")
+
+
+def _can_view_board(viewer: ContinuitySourceViewer, board: Board) -> bool:
+    if viewer.membership is None:
+        return not board.is_private
+    return policies.can_view_board(viewer.membership, board, viewer.role)
+
+
+def _can_view_thread(
+    repo: ContinuitySourceVisibilityRepository,
+    viewer: ContinuitySourceViewer,
+    board: Board,
+    thread: Thread,
+) -> bool:
+    if not _can_view_board(viewer, board):
+        return False
+    if thread.status != "private":
+        return True
+    if _can_moderate_thread(viewer, thread):
+        return True
+    if viewer.membership is None:
+        return False
+    if thread.author_membership_id == viewer.membership.id:
+        return True
+    participants = repo.list_thread_participants(thread.community_id, thread.id)
+    return any(character.membership_id == viewer.membership.id for character in participants)
+
+
+def _can_manage_world(viewer: ContinuitySourceViewer) -> bool:
+    if viewer.membership is None:
+        return False
+    return policies.can_manage_world(viewer.membership, viewer.role)
+
+
+def _can_manage_casting(viewer: ContinuitySourceViewer) -> bool:
+    if viewer.membership is None:
+        return False
+    return policies.can_manage_casting(viewer.membership, viewer.role)
+
+
+def _can_manage_applications(viewer: ContinuitySourceViewer) -> bool:
+    if viewer.membership is None:
+        return False
+    return policies.can_manage_applications(viewer.membership, viewer.role)
+
+
+def _can_moderate_thread(viewer: ContinuitySourceViewer, thread: Thread) -> bool:
+    if viewer.membership is None:
+        return False
+    return policies.can_moderate_thread(viewer.membership, thread, viewer.role)
+
+
+def _source_viewer(viewer: ForumView | ContinuitySourceViewer) -> ContinuitySourceViewer:
+    if isinstance(viewer, ContinuitySourceViewer):
+        return viewer
+    return ContinuitySourceViewer.from_forum_view(viewer)
+
+
+def _visible(
+    reference: ContinuitySourceReference,
+    label: str,
+    reason: str,
+) -> ContinuitySourceVisibility:
+    return ContinuitySourceVisibility(
+        community_id=reference.community_id,
+        source_family=reference.source_family,
+        source_id=reference.source_id,
+        status="visible",
+        label=label,
+        reason=reason,
+    )
+
+
+def _hidden(
+    reference: ContinuitySourceReference,
+    status: ContinuitySourceVisibilityStatus,
+    reason: str,
+) -> ContinuitySourceVisibility:
+    return ContinuitySourceVisibility(
+        community_id=reference.community_id,
+        source_family=reference.source_family,
+        source_id=reference.source_id,
+        status=status,
+        label="",
+        reason=reason,
+    )

--- a/tests/test_continuity_source_visibility.py
+++ b/tests/test_continuity_source_visibility.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from elbysodic.db.seed import SeedPersonaContext, resolve_seed_persona
+from elbysodic.services import create_services
+from elbysodic.services.continuity import (
+    ContinuitySourceReference,
+    ContinuitySourceViewer,
+    continuity_source_visibility,
+    public_continuity_source_visibility,
+)
+
+
+def test_public_continuity_sources_hide_private_scenes_posts_and_drafts() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    writer = resolve_seed_persona(repo, "xmen_writer")
+    community_id = writer.community.id
+    assert writer.character is not None
+    public_location = repo.get_board_by_slug(community_id, "new-york-city")
+    private_board = repo.create_board(
+        community_id,
+        "continuity-private-lab",
+        "Continuity Private Lab",
+        is_private=True,
+    )
+    public_thread = repo.create_thread(
+        community_id,
+        public_location.id,
+        writer.character.id,
+        "continuity-public-scene",
+        "Continuity public scene",
+    )
+    public_post = repo.create_post(
+        community_id,
+        public_thread.id,
+        writer.character.id,
+        "A public scene beat eligible for citation.",
+    )
+    private_thread = repo.create_thread(
+        community_id,
+        private_board.id,
+        writer.character.id,
+        "continuity-private-scene",
+        "Continuity private scene",
+    )
+    private_post = repo.create_post(
+        community_id,
+        private_thread.id,
+        writer.character.id,
+        "A private scene beat that must not leak.",
+    )
+    draft_material = repo.create_material(
+        community_id,
+        "continuity-draft-material",
+        "Continuity Draft Material",
+        status="draft",
+    )
+
+    public_location_result = public_continuity_source_visibility(
+        repo,
+        community_id,
+        ContinuitySourceReference(community_id, "location", public_location.id),
+    )
+    public_post_result = public_continuity_source_visibility(
+        repo,
+        community_id,
+        ContinuitySourceReference(
+            community_id,
+            "post",
+            public_post.id,
+            source_thread_id=public_thread.id,
+        ),
+    )
+    private_thread_result = public_continuity_source_visibility(
+        repo,
+        community_id,
+        ContinuitySourceReference(community_id, "scene", private_thread.id),
+    )
+    private_post_result = public_continuity_source_visibility(
+        repo,
+        community_id,
+        ContinuitySourceReference(
+            community_id,
+            "post",
+            private_post.id,
+            source_thread_id=private_thread.id,
+        ),
+    )
+    draft_material_result = public_continuity_source_visibility(
+        repo,
+        community_id,
+        ContinuitySourceReference(community_id, "material", draft_material.id),
+    )
+
+    assert public_location_result.visible is True
+    assert public_location_result.label == "New York City"
+    assert public_post_result.visible is True
+    assert public_post_result.label == "post #1"
+    assert private_thread_result.status == "hidden"
+    assert private_thread_result.label == ""
+    assert private_post_result.status == "hidden"
+    assert private_post_result.label == ""
+    assert draft_material_result.status == "hidden"
+    assert draft_material_result.label == ""
+
+
+def test_private_scene_sources_are_visible_to_participants_and_staff_only() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    writer = resolve_seed_persona(repo, "xmen_writer")
+    outsider = resolve_seed_persona(repo, "xmen_outsider")
+    staff = resolve_seed_persona(repo, "xmen_staff")
+    community_id = writer.community.id
+    assert writer.character is not None
+    public_location = repo.get_board_by_slug(community_id, "new-york-city")
+    private_thread = repo.create_thread(
+        community_id,
+        public_location.id,
+        writer.character.id,
+        "continuity-participant-scene",
+        "Continuity participant scene",
+        status="private",
+    )
+    private_post = repo.create_post(
+        community_id,
+        private_thread.id,
+        writer.character.id,
+        "Participant-visible private source.",
+    )
+    thread_reference = ContinuitySourceReference(community_id, "scene", private_thread.id)
+    post_reference = ContinuitySourceReference(
+        community_id,
+        "post",
+        private_post.id,
+        source_thread_id=private_thread.id,
+    )
+
+    participant_result = continuity_source_visibility(repo, _viewer(writer), thread_reference)
+    outsider_result = continuity_source_visibility(repo, _viewer(outsider), thread_reference)
+    staff_result = continuity_source_visibility(repo, _viewer(staff), post_reference)
+
+    assert participant_result.visible is True
+    assert participant_result.label == "Continuity participant scene"
+    assert outsider_result.status == "hidden"
+    assert outsider_result.label == ""
+    assert staff_result.visible is True
+    assert staff_result.label == "post #1"
+
+
+def test_continuity_source_gate_hides_inactive_and_cross_community_viewers() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    writer = resolve_seed_persona(repo, "xmen_writer")
+    inactive = resolve_seed_persona(repo, "xmen_inactive")
+    hp = repo.get_community_by_slug("hp-universe")
+    assert writer.character is not None
+    location = repo.get_board_by_slug(writer.community.id, "new-york-city")
+
+    inactive_result = continuity_source_visibility(
+        repo,
+        _viewer(inactive),
+        ContinuitySourceReference(writer.community.id, "location", location.id),
+    )
+    cross_community_result = continuity_source_visibility(
+        repo,
+        ContinuitySourceViewer(community_id=hp.id),
+        ContinuitySourceReference(writer.community.id, "location", location.id),
+    )
+
+    assert inactive_result.status == "inactive_viewer"
+    assert inactive_result.label == ""
+    assert cross_community_result.status == "cross_community"
+    assert cross_community_result.label == ""
+
+
+def test_claim_and_reserve_sources_keep_private_review_state_out_of_lower_tiers() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    writer = resolve_seed_persona(repo, "xmen_writer")
+    outsider = resolve_seed_persona(repo, "xmen_outsider")
+    staff = resolve_seed_persona(repo, "xmen_staff")
+    community_id = writer.community.id
+    assert writer.character is not None
+    private_claim_type = repo.create_claim_type(
+        community_id,
+        "continuity-private-claim",
+        "Continuity Private Claim",
+        visibility="staff",
+    )
+    private_claim = repo.create_character_claim(
+        community_id,
+        private_claim_type.id,
+        "restricted-claim",
+        "Restricted Claim",
+        character_id=writer.character.id,
+        notes="Claim notes that must stay private.",
+    )
+    reserve = repo.create_character_reserve(
+        community_id,
+        writer.membership.id,
+        writer.character.id,
+        "Continuity private reserve",
+        notes="Reserve notes that must stay private.",
+    )
+
+    public_claim = public_continuity_source_visibility(
+        repo,
+        community_id,
+        ContinuitySourceReference(community_id, "claim", private_claim.id),
+    )
+    outsider_reserve = continuity_source_visibility(
+        repo,
+        _viewer(outsider),
+        ContinuitySourceReference(community_id, "reserve", reserve.id),
+    )
+    owner_reserve = continuity_source_visibility(
+        repo,
+        _viewer(writer),
+        ContinuitySourceReference(community_id, "reserve", reserve.id),
+    )
+    staff_claim = continuity_source_visibility(
+        repo,
+        _viewer(staff),
+        ContinuitySourceReference(community_id, "claim", private_claim.id),
+    )
+
+    assert public_claim.status == "hidden"
+    assert public_claim.label == ""
+    assert outsider_reserve.status == "hidden"
+    assert outsider_reserve.label == ""
+    assert owner_reserve.visible is True
+    assert owner_reserve.label == "Continuity private reserve"
+    assert staff_claim.visible is True
+    assert staff_claim.label == "Restricted Claim"
+
+
+def test_continuity_source_gate_rejects_malformed_location_and_post_references() -> None:
+    services = create_services(path=":memory:")
+    repo = services.repo
+    writer = resolve_seed_persona(repo, "xmen_writer")
+    community_id = writer.community.id
+    assert writer.character is not None
+    community_board = repo.get_board_by_slug(community_id, "announcements")
+    location = repo.get_board_by_slug(community_id, "new-york-city")
+    first_thread = repo.create_thread(
+        community_id,
+        location.id,
+        writer.character.id,
+        "continuity-first-thread",
+        "Continuity first thread",
+    )
+    second_thread = repo.create_thread(
+        community_id,
+        location.id,
+        writer.character.id,
+        "continuity-second-thread",
+        "Continuity second thread",
+    )
+    post = repo.create_post(
+        community_id,
+        first_thread.id,
+        writer.character.id,
+        "Post that belongs to the first thread.",
+    )
+
+    malformed_location = continuity_source_visibility(
+        repo,
+        _viewer(writer),
+        ContinuitySourceReference(community_id, "location", community_board.id),
+    )
+    malformed_post = continuity_source_visibility(
+        repo,
+        _viewer(writer),
+        ContinuitySourceReference(
+            community_id,
+            "post",
+            post.id,
+            source_thread_id=second_thread.id,
+        ),
+    )
+
+    assert malformed_location.status == "malformed"
+    assert malformed_location.label == ""
+    assert malformed_post.status == "malformed"
+    assert malformed_post.label == ""
+
+
+def _viewer(persona: SeedPersonaContext) -> ContinuitySourceViewer:
+    return ContinuitySourceViewer(
+        community_id=persona.community.id,
+        membership=persona.membership,
+        role=persona.role,
+    )


### PR DESCRIPTION
## Summary

- Add a schema-neutral continuity source visibility gate for board, location, scene/thread, post, face, material, wanted-hook, claim, and reserve references.
- Return redacted visibility results for hidden, inactive, malformed, missing, and cross-community sources so future canon surfaces cannot leak private labels.
- Document the source visibility gate in the Continuity Graph readiness contract.

Closes #109

## Steward Notes

- Continuity Graph Steward: source provenance now has a service-owned privacy gate before schema, routes, or review UI exist.
- Privacy Steward: private boards, draft materials, private claims, reserves, inactive viewers, malformed post/thread pairs, and cross-community references return hidden/redacted statuses unless the viewer already owns or can review the source.
- Data Steward: all source resolution uses tenant-aware repository methods with explicit `community_id`.
- No schema, route, repository API, notification, export artifact, or public continuity surface was added.

## Proof

- `uv run pytest tests/test_continuity_domain.py tests/test_continuity_source_visibility.py -q --tb=short`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`
