### PR TITLE
Document realm journey contract coverage

### DIFF
--- a/docs/architecture/realm-journey-contract-tests.md
+++ b/docs/architecture/realm-journey-contract-tests.md
@@ -1,0 +1,42 @@
+# Realm Journey Contract Tests
+
+Elbysodic's realm journey proof is a rendered and service contract pack, not a
+single browser scenario. The pack ties public discovery, account-visitor access,
+invite acceptance, first-face onboarding, application and claim review, scene
+posting, staff controls, notifications, inactive membership denial, and
+cross-community recovery into one regression surface.
+
+## Current Coverage Matrix
+
+| Journey leg | Audience | Primary proof |
+|---|---|---|
+| Public discovery and tenant preview | signed-out visitor | `test_production_routes_require_session`, `test_production_signed_out_public_realm_keeps_anonymous_posture`, `test_production_release_smoke_core_user_flow` |
+| Account visitor access request | signed-in account without membership | `test_production_signed_in_non_member_sees_account_posture_on_public_realm`, `test_production_signed_in_duplicate_access_request_links_existing_record` |
+| Invite acceptance and first face | director, invited writer, faceless member | `test_director_invites_writer_through_first_face_handoff`, `test_invited_writer_without_first_face_continues_to_application_form`, `test_invitation_acceptance_uses_writer_activation_handoff` |
+| Existing-account cross-realm invite | global account with another membership | `test_invitation_acceptance_keeps_existing_account_memberships_local` |
+| Applications and claims | member, applicant, staff | `test_applications_desk_tracks_character_statuses`, `test_rendered_surface_contract_parity_across_realm_viewers` |
+| Posting and active face | character-backed writer | `test_production_release_smoke_core_user_flow`, `test_tenant_prefixed_thread_routes_scope_composer_redirects` |
+| Notifications and continuation | member, faceless member, staff | `test_rendered_surface_contract_parity_across_realm_viewers`, `test_notifications_track_watched_thread_replies_and_open_read_state`, `test_faceless_writer_does_not_count_unowned_character_notifications` |
+| Staff/director controls | current-community staff and director | `test_rendered_surface_contract_parity_across_realm_viewers`, `test_director_studio_surfaces_community_production_work` |
+| Inactive and cross-community recovery | inactive member, cross-community viewer | `test_request_identity_rejects_inactive_membership_viewer`, `test_rendered_surface_contract_parity_across_realm_viewers`, `test_prefixed_cross_realm_recovery_switches_to_target_tenant` |
+
+## Required Assertions
+
+The pack should keep asserting all of these conditions:
+
+- public and account visitors see public-safe realm material without active
+  face, unread count, staff queue, private notes, or mutating controls
+- access requests do not grant membership, role, face, session, reserve, claim,
+  or invitation state
+- invite acceptance creates or reuses the global account while creating only
+  the invited community's membership and optional first face
+- faceless members are routed toward first-face/application work before posting
+  and notification continuation can expose character-backed state
+- posting, notifications, and shell counts stay tied to the selected
+  membership and active face in the current community
+- staff/director controls render only for current-community capability holders
+- inactive and cross-community viewers fail closed or enter recovery without
+  private rows, staff notes, or mutating controls
+
+When a journey leg changes, update the rendered test and this matrix in the
+same PR so the contract remains discoverable.

--- a/tests/test_realm_journey_contract_pack.py
+++ b/tests/test_realm_journey_contract_pack.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+JOURNEY_DOC = ROOT / "docs" / "architecture" / "realm-journey-contract-tests.md"
+FORUM_SLICE = ROOT / "tests" / "test_forum_slice.py"
+WEB_SECURITY = ROOT / "tests" / "test_web_security.py"
+
+
+REQUIRED_JOURNEY_TESTS = {
+    "test_production_routes_require_session": WEB_SECURITY,
+    "test_production_signed_in_non_member_sees_account_posture_on_public_realm": WEB_SECURITY,
+    "test_production_signed_in_duplicate_access_request_links_existing_record": WEB_SECURITY,
+    "test_production_release_smoke_core_user_flow": WEB_SECURITY,
+    "test_director_invites_writer_through_first_face_handoff": FORUM_SLICE,
+    "test_invited_writer_without_first_face_continues_to_application_form": FORUM_SLICE,
+    "test_invitation_acceptance_uses_writer_activation_handoff": FORUM_SLICE,
+    "test_invitation_acceptance_keeps_existing_account_memberships_local": FORUM_SLICE,
+    "test_applications_desk_tracks_character_statuses": FORUM_SLICE,
+    "test_rendered_surface_contract_parity_across_realm_viewers": FORUM_SLICE,
+    "test_tenant_prefixed_thread_routes_scope_composer_redirects": FORUM_SLICE,
+    "test_notifications_track_watched_thread_replies_and_open_read_state": FORUM_SLICE,
+    "test_faceless_writer_does_not_count_unowned_character_notifications": FORUM_SLICE,
+    "test_director_studio_surfaces_community_production_work": FORUM_SLICE,
+    "test_request_identity_rejects_inactive_membership_viewer": FORUM_SLICE,
+    "test_prefixed_cross_realm_recovery_switches_to_target_tenant": FORUM_SLICE,
+}
+
+REQUIRED_CONTRACT_PHRASES = {
+    "public and account visitors see public-safe realm material",
+    "access requests do not grant membership",
+    "invite acceptance creates or reuses the global account",
+    "faceless members are routed toward first-face/application work",
+    "posting, notifications, and shell counts stay tied",
+    "staff/director controls render only for current-community capability holders",
+    "inactive and cross-community viewers fail closed",
+}
+
+
+def test_realm_journey_contract_pack_names_rendered_regression_tests() -> None:
+    doc = JOURNEY_DOC.read_text()
+
+    for test_name in REQUIRED_JOURNEY_TESTS:
+        assert test_name in doc
+
+    for phrase in REQUIRED_CONTRACT_PHRASES:
+        assert phrase in doc
+
+
+def test_realm_journey_contract_pack_keeps_required_tests_present() -> None:
+    for test_name, path in REQUIRED_JOURNEY_TESTS.items():
+        source = path.read_text()
+        assert f"def {test_name}" in source


### PR DESCRIPTION
## Summary

- Add a realm journey contract matrix that maps public discovery, account visitor, invite, first-face, application/claim, posting, staff, notification, inactive, and cross-community coverage to concrete rendered/service tests.
- Add a guard test that pins the named journey regression tests and required privacy assertions so future cleanup cannot silently drop journey coverage.

Closes #112

## Steward Notes

- Surface Contract Steward: the matrix ties shell/page/detail/action/notification journey proof together across identity modes.
- Auth Steward: global account, community membership, inactive membership, and cross-community recovery coverage are named explicitly.
- Test Steward: this PR does not duplicate the large rendered flows; it makes the existing rendered journey pack discoverable and guarded.
- No route, schema, auth behavior, or UI behavior changes.

## Proof

- `uv run pytest tests/test_realm_journey_contract_pack.py -q --tb=short`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`
