### PR TITLE
Add front-end surface conversion contract pack

### DIFF
--- a/docs/product/front-end-surface-conversion-pack.md
+++ b/docs/product/front-end-surface-conversion-pack.md
@@ -1,0 +1,122 @@
+# Front-End Surface Conversion Pack
+
+Status: implementation audit pack for #117
+Owner: Web, product design, surface-contract, and test stewardship
+Last updated: 2026-06-04
+
+This pack turns the front-end debt epic into a repeatable audit. It does not
+change route, auth, privacy, schema, or service behavior. Use it when a PR
+touches rendered auth/access, onboarding, public preview, Writer Desk, Studio,
+applications, claims/reserves, wanted, composer, or shell-adjacent surfaces.
+
+## Audience And Risk
+
+The high-risk audiences are signed-out visitors, signed-in account visitors,
+faceless members, applicant writers, active-face writers, hook hunters,
+directors, staff, inactive members, and cross-community recovery visitors.
+
+The failure modes are:
+
+- public or account visitors seeing a community shell, unread counts, active
+  face controls, staff controls, private queues, application review state, or
+  invitation material
+- members and applicants losing the next first-face, application, claims,
+  reserve, reply, or plotting action behind generic setup language
+- staff and directors seeing Studio as a generic admin dashboard instead of a
+  realm production room
+- repeated PBP UI shapes drifting into page-local CSS or ad hoc templates
+- forms, filters, drawers, and action panels losing labels, focus visibility,
+  keyboard reachability, or mobile tap room
+
+## Shared Pattern Inventory
+
+| Pattern | Shared Owner | Current High-Risk Surfaces | Conversion Rule | Required Proof |
+|---|---|---|---|---|
+| Product/account access posture | `_components/access.html` | login, request access, invite acceptance, Network account return | Use `product_identity()` and `access_account_notice()` before page-local account panels. Account posture never grants a realm shell or membership affordance. | Rendered auth/access tests, negative shell/count assertions, labelled form checks |
+| Empty or caught-up policy block | `_components/ui.html` | Desk, applications, casting, claims, notifications, plotting, wanted | Use `empty_policy_block()` when the empty state reduces anxiety or points to the next PBP action. Hide optional empty lanes that only prove nothing exists. | Rendered page tests for the empty state and absent private/staff data |
+| Page section rhythm | `_components/ui.html` | Desk, applications, Studio, long workflow rooms | Use `page_section()` before inventing page-local section headers around repeated workflow regions. | Semantic heading/region assertions and app check |
+| Command/pulse/metric vocabulary | `_components/vocabulary.html` | Desk, applications, members, Network, notifications, Studio rooms | Use `page_pulse()`, `command_panel()`, `command_action()`, `lane_preview()`, and `metric_item()` for workflow signals. Counts must change confidence, urgency, privacy, availability, or next action. | Rendered tests for labels and available actions |
+| Thread and queue previews | `_components/thread_summary.html` | My Threads, board pages, character/member scenes, community activity | Use thread summary components for needs reply, waiting, watched, caught up, and activity rows before duplicating scene cards. | Rendered queue tests with face/writer distinction |
+| Wanted and plotting hook cards | `_components/wanted.html`, `_components/plot_hooks.html` | wanted index/detail, casting, character hooks | Use wanted/hook components for hook identity, relationship, reserve, interest, and plotting handoff. Do not stamp every child with `Wanted hook` when the parent section already says it. | Wanted/application/privacy tests with negative private-note assertions |
+| Realm gateway/public preview | `_components/realm_gateway.html`, `_components/network_catalog.html` | root community home, Network, public catalog, account visitor preview | Public surfaces sell premise, places, wanted, guidebook paths, activity, and access posture without launch blockers or staff setup state. | Public/account/member/staff rendered tests and browser QA |
+| Director controls and production rooms | `_components/director_controls.html`, `_components/vocabulary.html` | Studio, board/studio board pages, launch, operations, discovery | Director controls attach to the production object and stay visually behind story/writer context unless the director is in Studio. | Staff/director rendered tests and privacy matrix updates when behavior changes |
+| Composer controls and post style preview | `_components/composer.html`, `_components/post_style_preview.html` | new thread, reply, edit post, character/post style | Composer toolbar, preview, active face, draft state, and post style controls stay shared. | Markup safety tests, form tests, browser QA for desktop/mobile writing surfaces |
+| Facets and claims/intake context | `_components/facets.html`, claims/intake templates | claims, applications, characters, world, discover, wanted | Facets are not generic tags. Clickable filters must look distinct from descriptive chips, and claims/reserves must stay current-community scoped. | Rendered claims/application tests and tenant boundary tests |
+
+## CSS And Token Audit
+
+CSS movement uses `docs/architecture/theme-css-architecture.md` as the owner
+ledger. A PR that touches CSS should classify each touched selector as one of:
+
+- Chirp primitive adoption or narrow Chirp override
+- Elbysodic PBP component
+- product-family selector
+- temporary page composition
+- legacy ledger item with a replacement path
+
+Do not add a new page-local selector when a shared component or existing theme
+layer already owns the shape. Elbysodic-specific tokens belong in
+`src/elbysodic/web/static/elbysodic-theme.css` and
+`src/elbysodic/web/static/elbysodic-theme/00-tokens.css`; product-family files
+should reference tokens rather than inventing one-off color, spacing, border,
+or shadow systems.
+
+## Label And Typography Audit
+
+Every audited page should pass these checks before visual QA:
+
+- One dominant phrase in each heading cluster.
+- No child card repeats the parent section's object type unless the set mixes
+  object types or the state changes the next action.
+- Kicker, badge, metric label, helper line, and footer each add a distinct axis:
+  privacy, lifecycle, urgency, ownership, relationship, active-face relevance,
+  or action.
+- Counts appear only when they change confidence, urgency, privacy,
+  availability, or next action.
+- PBP vocabulary wins over generic labels: face, roster, thread, scene,
+  plotter, wanted, claims, reserves, needs reply, waiting, caught up, and
+  watching.
+
+## Accessibility Audit
+
+For form, filter, drawer, navigation, or command changes, prove:
+
+- visible controls have an accessible label or labelled control wrapper
+- hidden controls are limited to command context, CSRF, idempotency, selected
+  object ids, or return paths
+- submit buttons name the PBP action, not a generic `Continue`
+- alerts use `role="alert"` and passive confirmations use `role="status"`
+- keyboard focus is visible and remains near the object being changed
+- mobile tap targets do not overlap and preserve the next action plus privacy
+  state
+
+## Browser QA Profiles
+
+Run browser QA when layout, interaction, or responsive behavior changes. Keep a
+desktop and mobile capture for the changed surface family:
+
+| Profile | Routes/States |
+|---|---|
+| Auth/access | `/login`, `/request-access`, `/invite/{token}` valid/error/recovery |
+| Public preview | `/`, `/network`, public community home, wanted detail, guidebook material |
+| Account visitor | Network return panel and realm preview without member shell, Desk, active face, unread counts, or staff controls |
+| Writer onboarding | faceless Desk, application draft/revision, claims/reserves, first scene handoff |
+| Writer work | `/desk`, `/my/threads`, `/notifications`, thread reply composer |
+| Wanted/plotting | wanted index/detail, interest state, plotting room handoff |
+| Studio | `/studio`, `/studio/launch`, `/studio/operations`, `/studio/intake`, `/studio/discovery` |
+| Public catalog | `/network`, `/network?q=...`, catalog cards, request-access entry actions |
+
+Browser QA should check first viewport priority, text fit, focus/tap behavior,
+private/staff state absence, active-face or account posture, and whether the
+screen still reads as modern PBP software instead of a generic SaaS dashboard
+or old forum index.
+
+## Not Now
+
+- SPA conversion
+- raw CSS or external font inputs
+- self-serve public registration
+- auth/session enforcement changes
+- schema or migration work
+- email/push notification preferences
+- broad visual redesign without surface-specific proof

--- a/docs/product/information-hierarchy.md
+++ b/docs/product/information-hierarchy.md
@@ -24,6 +24,9 @@ current Jcink/PBP, layered-context, editorial-discovery, and technicolor
 futurism synthesis should shape a surface.
 Use `docs/product/surface-quality-bar.md` before turning product data into
 visible cards, badges, metrics, helper copy, or public/editorial page sections.
+Use `docs/product/front-end-surface-conversion-pack.md` when changing
+auth/access, onboarding, public preview, Desk, Studio, applications,
+claims/reserves, wanted, composer, or shell-adjacent surfaces.
 Use `design/composition-bible.md` when deciding whether the surface should be
 open layout, compact rows, story-object cards, or an elevated command panel.
 
@@ -246,6 +249,10 @@ names that describe the writer/director job they support.
 
 Current promoted component shapes:
 
+- `product_identity` and `access_account_notice`: account and realm-access
+  posture for login, request access, invite acceptance, and account visitors.
+  These components never imply a local membership, active face, unread count,
+  staff control, or community shell.
 - `local_rail`: in-page navigation for dense rooms such as Writer Desk, Studio,
   character hubs, and application/casting surfaces. It moves within the current
   route; it is not a sidebar substitute and should not carry global active

--- a/tests/test_frontend_surface_contracts.py
+++ b/tests/test_frontend_surface_contracts.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PAGES = REPO_ROOT / "src/elbysodic/web/pages"
+PACK_DOC = REPO_ROOT / "docs/product/front-end-surface-conversion-pack.md"
+
+
+SURFACE_COMPONENT_EXPECTATIONS = {
+    "login/page.html": [
+        'from "_components/access.html" import product_identity',
+        "product_identity()",
+        "Choose the account first",
+    ],
+    "request-access/page.html": [
+        'from "_components/access.html" import access_account_notice, product_identity',
+        "access_account_notice(",
+        "Request access",
+    ],
+    "desk/page.html": [
+        'from "_components/ui.html" import empty_policy_block, page_section',
+        'from "_components/vocabulary.html" import command_action, lane_preview, metric_item, page_pulse',
+        "needs_first_face",
+    ],
+    "applications/page.html": [
+        'from "_components/facets.html" import facet_pills',
+        'from "_components/ui.html" import empty_policy_block, page_section',
+        'from "_components/vocabulary.html" import command_panel, metric_item',
+    ],
+    "claims/page.html": [
+        'from "_components/ui.html" import empty_policy_block',
+        "Claims",
+        "reserved",
+    ],
+    "wanted/page.html": [
+        'from "_components/ui.html" import empty_policy_block',
+        'from "_components/wanted.html" import wanted_card',
+        "wanted hooks",
+    ],
+    "wanted/{wanted_slug}/page.html": [
+        'from "_components/facets.html" import facet_pills',
+        'from "_components/wanted.html" import thread_signal, wanted_card',
+        "plotting",
+    ],
+    "notifications/page.html": [
+        'from "_components/ui.html" import empty_policy_block',
+        'from "_components/vocabulary.html" import metric_item, page_pulse',
+        "Mark all read",
+    ],
+    "network/page.html": [
+        'from "_components/network_catalog.html" import program_card, program_summary',
+        'from "_components/vocabulary.html" import metric_item',
+        "network_access_posture",
+    ],
+    "page.html": [
+        'from "_components/realm_gateway.html" import realm_gateway_home',
+        'from "_components/director_controls.html" import director_context_panel',
+        "realm_gateway_home(",
+    ],
+    "studio/page.html": [
+        'from "_components/facets.html" import facet_pills',
+        'from "_components/ui.html" import empty_policy_block',
+        'from "_components/vocabulary.html" import room_header',
+    ],
+    "boards/{board_slug}/threads/new/page.html": [
+        'from "_components/composer.html" import composer_toolbar, composer_view_toggle',
+        "idempotency_key",
+        "Start scene",
+    ],
+    "boards/{board_slug}/threads/{thread_slug}/page.html": [
+        'from "_components/composer.html" import composer_toolbar, composer_view_toggle',
+        'from "_components/posts.html" import post_frame',
+        "reply-character",
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    ("template_path", "required_snippets"),
+    SURFACE_COMPONENT_EXPECTATIONS.items(),
+)
+def test_high_risk_templates_use_shared_frontend_surface_patterns(
+    template_path: str,
+    required_snippets: list[str],
+) -> None:
+    text = (PAGES / template_path).read_text(encoding="utf-8")
+
+    for snippet in required_snippets:
+        assert snippet in text, f"{template_path} is missing {snippet!r}"
+
+
+def test_frontend_surface_conversion_pack_names_required_audit_profiles() -> None:
+    text = PACK_DOC.read_text(encoding="utf-8")
+
+    for required in [
+        "Shared Pattern Inventory",
+        "CSS And Token Audit",
+        "Label And Typography Audit",
+        "Accessibility Audit",
+        "Browser QA Profiles",
+        "Auth/access",
+        "Public preview",
+        "Account visitor",
+        "Writer onboarding",
+        "Studio",
+        "Public catalog",
+    ]:
+        assert required in text
+
+
+def test_access_and_search_surfaces_keep_labelled_controls() -> None:
+    expectations = {
+        "login/page.html": [
+            "<span>Email</span>",
+            "<span>Password</span>",
+            'autocomplete="username"',
+            'autocomplete="current-password"',
+        ],
+        "request-access/page.html": [
+            "<span>Writer email</span>",
+            "<span>Writer name</span>",
+            "<span>Face concept</span>",
+            "<span>Wanted hook or way in</span>",
+            "<span>Notes for directors</span>",
+            'role="status"',
+            'role="alert"',
+        ],
+        "network/page.html": [
+            'role="search"',
+            'label for="network-search"',
+            'type="search"',
+        ],
+        "_layout.html": [
+            'role="search"',
+            'for="elbysodic-topbar-search-input"',
+            'aria-label="Search {{ scope_label }}"',
+        ],
+    }
+
+    for template_path, required_snippets in expectations.items():
+        text = (PAGES / template_path).read_text(encoding="utf-8")
+        for snippet in required_snippets:
+            assert snippet in text, f"{template_path} is missing {snippet!r}"


### PR DESCRIPTION
## Summary

- adds a front-end surface conversion pack for auth/access, onboarding, public preview, Desk, Studio, applications, claims/reserves, wanted, composer, and catalog surfaces
- documents shared component ownership, CSS/token audit rules, label/typography checks, accessibility checks, and browser QA profiles
- adds static regression tests tying high-risk templates to shared component patterns and labelled access/search controls

## Issue

Closes #117.

## Scope Notes

- No route, auth, privacy, schema, template rendering, or CSS behavior changes.
- Browser screenshots were not required because this PR only adds contract docs and static regression checks.

## Verification

- `uv run pytest tests/test_frontend_surface_contracts.py -q --tb=short`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`
