### PR TITLE
Add auth entry and recovery UX contract

### DIFF
--- a/docs/product/auth-entry-session-recovery-ux.md
+++ b/docs/product/auth-entry-session-recovery-ux.md
@@ -1,0 +1,88 @@
+# Auth Entry And Session Recovery UX
+
+Status: rendered UX contract for #114
+Owner: Web, auth/service, surface-contract, and product stewardship
+Last updated: 2026-06-04
+
+Auth entry is a trust surface for writers. It must explain the difference
+between a global Elbysodic account, a community-local membership, and an active
+face without leaking private realm state or implying global staff power.
+
+This guide does not define authentication mechanisms, password policy, session
+storage, or production enforcement. Those remain in the auth/security backend
+contracts. This guide defines the rendered posture that login, request access,
+account visitor previews, logout, identity switching, and recovery pages should
+preserve.
+
+## Viewer States
+
+| State | What The User Has | Rendered Posture | Must Not Render |
+|---|---|---|---|
+| Signed-out visitor | No active account session. | Public preview, login, and request-access actions. | Community shell, Desk, active face, unread counts, staff controls, private queues, member actions. |
+| Signed-in account visitor | Global login, no membership in the viewed community. | Signed-in account identity plus public-safe realm preview and request-access action. | Active face, local membership controls, unread counts, Desk, staff links, private forms, private queues. |
+| Member without face | Local membership but no posting identity. | First-face/application continuation before ordinary queue work. | Another writer's application, staff notes, active-face controls, private review state. |
+| Active-face writer | Membership plus current character. | Writer shell, active face, reply/plotting/application obligations, and local role controls. | Global character identity or staff power outside the current community. |
+| Staff/director | Membership with current-community capabilities. | Staff or Studio controls attached to current-community workflows. | Staff power in another realm or public/account visitor views. |
+| Inactive membership | Historical local identity that cannot enter. | Recovery or denial with generic posture and no private rows. | Inactive profile details, private queues, notifications, staff controls, switch options that cannot enter. |
+| Stale or cross-community selection | Account/session points at a missing, wrong, or different-community identity. | Recovery page names the safe target and offers a sanitized switch or public fallback. | Raw tokens, private target names the viewer cannot access, cross-realm private state, unsafe return URLs. |
+
+## Surface Contracts
+
+### Login
+
+Login names the account first. It can say that Elbysodic resolves community
+membership and active face after login, but it must not imply that logging in
+creates a realm membership or grants staff power. The request-access link stays
+available for writers who need a director-reviewed way in.
+
+### Request Access
+
+Request access is interest, not permission. Signed-out visitors provide writer
+email and first-face context. Signed-in account visitors reuse the account and
+do not need a separate email handoff. Confirmation copy can say the request was
+received, but it must not expose director review notes, invitation links, or
+staff queue details.
+
+### Account Visitor Preview
+
+An account visitor can browse public realm previews while signed in. The shell
+may show account identity and logout/theme tools, but it must not show the
+community shell, Desk, active face, unread counts, staff controls, private
+queues, or mutating member forms for the viewed realm.
+
+### Logout
+
+Logout clears account and development identity cookies and returns to login.
+Logout copy and links should avoid implying that writer names, memberships, or
+faces were deleted.
+
+### Recovery
+
+Recovery is service-owned. Templates render the safe `RecoveryView` only:
+kicker, title, summary, detail, sanitized switch action, and public fallback
+links. The switch form keeps `membership_id`, `character_id`, and `next`
+service-provided; templates do not infer cross-community destinations.
+
+## Copy Rules
+
+- Use account for global login identity.
+- Use membership for local realm identity and role/capability context.
+- Use face for public character/posting identity.
+- Use realm, writer, director, roster, request access, invitation, first face,
+  application, claims, reserves, wanted, scene, and Desk.
+- Avoid generic signup, workspace, project, team, organization, task, admin,
+  and dashboard language unless quoting technical configuration.
+
+## Required Proof
+
+Rendered auth-entry PRs should include focused proof for:
+
+- signed-out login/request-access pages without community shell or private state
+- signed-in account visitor preview without local membership affordances
+- request-access account reuse without exposing director review state
+- member/staff login preserving current-community membership and face context
+- inactive, stale, revoked, or cross-community recovery without private leakage
+- mobile/browser QA when layout, keyboard, drawer, or focus behavior changes
+
+Docs and tests can update this contract without browser screenshots when no
+rendered markup, layout, CSS, route, or auth behavior changes.

--- a/docs/product/information-hierarchy.md
+++ b/docs/product/information-hierarchy.md
@@ -10,6 +10,9 @@ This document explains what repeated concepts mean visually. Use
 compact, editable, or collapsed a control should be.
 Use `docs/product/navigation-menus.md` when deciding route placement, topbar
 realms, sidebar grouping, breadcrumbs, tabs, dropdowns, and active states.
+Use `docs/product/auth-entry-session-recovery-ux.md` before changing login,
+logout, request-access, account visitor, membership switching, stale session,
+inactive membership, or cross-community recovery surfaces.
 Use `docs/product/paragraph-rhythm.md` before adding or changing paragraph
 output; Elbysodic is a text-first app, so prose, summaries, helper copy, and
 metadata need distinct paragraph roles.

--- a/tests/test_auth_entry_surface_contracts.py
+++ b/tests/test_auth_entry_surface_contracts.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+from urllib.parse import urlencode
+
+from chirp.testing import TestClient
+
+from elbysodic.services import create_services
+from elbysodic.web import create_app
+from elbysodic.web.state import get_services
+
+_FORM = {"Content-Type": "application/x-www-form-urlencoded"}
+_CSRF_RE = re.compile(r'name="_csrf_token" value="([^"]+)"')
+_PAGES = Path(__file__).parents[1] / "src/elbysodic/web/pages"
+_DOC = Path(__file__).parents[1] / "docs/product/auth-entry-session-recovery-ux.md"
+
+
+def _response_headers(response, name: str) -> list[str]:
+    headers = response.headers
+    if isinstance(headers, dict):
+        value = headers.get(name)
+        return [] if value is None else [str(value)]
+    return [str(value) for key, value in headers if str(key).lower() == name.lower()]
+
+
+def _cookie_values(*responses) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for response in responses:
+        for cookie in _response_headers(response, "set-cookie"):
+            pair = cookie.split(";", 1)[0]
+            name, _, value = pair.partition("=")
+            values[name] = value
+    return values
+
+
+def _cookie_header(cookies: dict[str, str]) -> str:
+    return "; ".join(f"{name}={value}" for name, value in cookies.items())
+
+
+def _csrf_token(html: str) -> str:
+    match = _CSRF_RE.search(html)
+    assert match is not None
+    return match.group(1)
+
+
+def _set_production_env(monkeypatch) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "production")
+    monkeypatch.setenv("ELBYSODIC_SECRET_KEY", "x" * 32)
+    monkeypatch.setenv("ELBYSODIC_ALLOWED_HOSTS", "*")
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+
+
+async def _production_login(
+    client: TestClient,
+    *,
+    email: str,
+    next_url: str = "/network",
+) -> dict[str, str]:
+    page = await client.get(f"/login?next={next_url}")
+    cookies = _cookie_values(page)
+    response = await client.post(
+        "/login",
+        body=urlencode(
+            {
+                "email": email,
+                "password": "password",
+                "next": next_url,
+                "_csrf_token": _csrf_token(page.text),
+            }
+        ).encode(),
+        headers={**_FORM, "Cookie": _cookie_header(cookies)},
+    )
+    cookies.update(_cookie_values(response))
+    assert response.status == 302
+    return cookies
+
+
+def test_auth_entry_templates_preserve_account_membership_face_language() -> None:
+    login = (_PAGES / "login/page.html").read_text(encoding="utf-8")
+    access = (_PAGES / "_components/access.html").read_text(encoding="utf-8")
+    layout = (_PAGES / "_layout.html").read_text(encoding="utf-8")
+    recovery = (_PAGES / "recovery/_page.html").read_text(encoding="utf-8")
+    doc = _DOC.read_text(encoding="utf-8")
+
+    for snippet in [
+        "Choose the account first",
+        "community membership and active face",
+        "linked account request",
+    ]:
+        assert snippet in login
+    for snippet in [
+        "Existing Elbysodic account",
+        "Request access without a separate email handoff",
+        "first-face context",
+    ]:
+        assert snippet in access
+    for snippet in [
+        "Not a member of",
+        "Choose a realm or request access",
+        "playing as",
+        "clear session",
+    ]:
+        assert snippet in layout
+    for snippet in [
+        "recovery.kicker",
+        "recovery.summary",
+        'name="membership_id"',
+        'name="character_id"',
+        'name="next"',
+    ]:
+        assert snippet in recovery
+    for snippet in [
+        "Signed-out visitor",
+        "Signed-in account visitor",
+        "Member without face",
+        "Active-face writer",
+        "Inactive membership",
+        "Stale or cross-community selection",
+    ]:
+        assert snippet in doc
+
+
+def test_signed_out_auth_entry_stays_public_safe(monkeypatch) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+
+        async with TestClient(app) as client:
+            login = await client.get("/login")
+            request_access = await client.get("/c/afterlight-accord/request-access")
+            studio = await client.get("/studio")
+
+        assert login.status == 200
+        assert "Invite/demo accounts use password" in login.text
+        assert 'href="/request-access"' in login.text
+        assert "Request access" in login.text
+        assert "chirpui-sidebar__section-title" not in login.text
+        assert "Staff in X-Men Apocalypse" not in login.text
+        assert "playing as" not in login.text
+
+        assert request_access.status == 200
+        assert "Access opens through a director invitation." in request_access.text
+        assert "Writer email" in request_access.text
+        assert "Send access request" in request_access.text
+        assert "Account menu: signed in as" not in request_access.text
+        assert "playing as" not in request_access.text
+
+        assert studio.status == 302
+        assert dict(studio.headers)["location"] == "/login?next=/studio"
+
+    asyncio.run(run())
+
+
+def test_account_visitor_preview_stays_public_safe(monkeypatch) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+
+        async with TestClient(app) as client:
+            cookies = await _production_login(client, email="moira@example.com")
+            cookie = _cookie_header(cookies)
+            realm = await client.get("/c/afterlight-accord", headers={"Cookie": cookie})
+            request_access = await client.get(
+                "/c/afterlight-accord/request-access",
+                headers={"Cookie": cookie},
+            )
+
+        assert realm.status == 200
+        assert "Not a member of Afterlight Accord yet" in realm.text
+        assert "can browse the public preview, then request access" in realm.text
+        assert 'href="/c/afterlight-accord/request-access"' in realm.text
+        assert 'href="/c/afterlight-accord/desk"' not in realm.text
+        assert "playing as" not in realm.text
+        assert "Application Review Room" not in realm.text
+        assert "Staff in Afterlight Accord" not in realm.text
+
+        assert request_access.status == 200
+        assert "Existing Elbysodic account" in request_access.text
+        assert "Request access with this account" in request_access.text
+        assert "Writer email" not in request_access.text
+        assert "Director review" not in request_access.text
+        assert "Staff notes" not in request_access.text
+
+    asyncio.run(run())
+
+
+def test_cross_realm_recovery_renders_sanitized_switch_contract() -> None:
+    async def run() -> None:
+        app = create_app(debug=False, services=create_services(path=":memory:"), dev_tools=True)
+        services = get_services()
+        jurassic = services.repo.get_community_by_slug("jurassic-park-universe")
+        jurassic_membership = services.repo.get_membership_for_user(
+            jurassic.id,
+            services.seed.user.id,
+        )
+        cookie = (
+            f"elbysodic_dev_identity={jurassic.id}:{services.seed.user.id}:{jurassic_membership.id}"
+        )
+
+        async with TestClient(app) as client:
+            recovery = await client.get(
+                f"/c/{services.seed.community.slug}/world/paddock-twelve-incident",
+                headers={"Cookie": cookie},
+            )
+
+        assert recovery.status == 200
+        assert "/elbysodic-static/brand/elbysodic-mark.svg" in recovery.text
+        assert "That world material lives in Jurassic Park Universe." in recovery.text
+        assert (
+            'name="next" value="/c/jurassic-park-universe/world/paddock-twelve-incident"'
+            in recovery.text
+        )
+        assert 'name="membership_id"' in recovery.text
+        assert 'name="character_id"' in recovery.text
+        assert "Staff in X-Men Apocalypse" not in recovery.text
+        assert "Application Review Room" not in recovery.text
+        assert "elbysodic_session" not in recovery.text
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

- adds an auth entry and session recovery UX contract for login, request access, account visitors, logout, identity switching, inactive memberships, and cross-community recovery
- links the contract from the information hierarchy guide
- adds rendered/static tests for signed-out entry, account visitor public-safe previews, and sanitized cross-realm recovery

## Issue

Closes #114.

## Scope Notes

- No authentication, session, route, permission, schema, template rendering, or CSS behavior changes.
- Browser screenshots were not required because this PR adds contract docs and tests without changing layout or rendered markup.

## Verification

- `uv run pytest tests/test_auth_entry_surface_contracts.py -q --tb=short`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`
