### PR TITLE
Add staging auto seed guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,13 @@ Set these Railway variables before sharing the app:
 - `ELBYSODIC_SECRET_KEY` to a random value of at least 32 characters
 - `ELBYSODIC_DEMO_MODE=1` only when seeded demo credentials should work
 
+For the shared staging demo, set `ELBYSODIC_ENV=staging`,
+`ELBYSODIC_DEMO_MODE=1`, `ELBYSODIC_AUTO_SEED_DEMO=1`, and
+`ELBYSODIC_DB_PATH=/app/var/elbysodic.sqlite3`. This lets staging self-heal
+missing demo rows on startup while still requiring demo mode and the
+volume-backed database path. Do not set `ELBYSODIC_AUTO_SEED_DEMO` in
+production.
+
 `ELBYSODIC_ALLOWED_HOSTS` is optional for Railway because production defaults
 allow Railway domains. Set it only after confirming the exact public or custom
 host list; values are comma-separated hostnames without `https://`.

--- a/changelog.d/+staging-auto-seed.added.md
+++ b/changelog.d/+staging-auto-seed.added.md
@@ -1,0 +1,1 @@
+Staging can now self-heal seeded demo realm data on startup when explicitly configured with the staging-only auto-seed flag.

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -36,6 +36,7 @@ Required staging variables:
 
 - `ELBYSODIC_ENV=staging`
 - `ELBYSODIC_DEMO_MODE=1`
+- `ELBYSODIC_AUTO_SEED_DEMO=1`
 - `ELBYSODIC_SECRET_KEY=<staging-only random secret>`
 - `ELBYSODIC_DB_PATH=/app/var/elbysodic.sqlite3`
 
@@ -68,6 +69,13 @@ seeded /app/var/elbysodic.sqlite3
 
 If it reports `seeded var/elbysodic.sqlite3`, the app is still writing to the
 container filesystem and persistence is not proven.
+
+With `ELBYSODIC_AUTO_SEED_DEMO=1`, staging also runs the idempotent demo seed
+path during app startup. The flag is accepted only when
+`ELBYSODIC_ENV=staging` and `ELBYSODIC_DEMO_MODE=1`; using it outside staging
+is a configuration error. Keep the manual `railway ssh --service elbysodic
+elbysodic seed-demo` step available for immediate repair and for proving the
+database path printed by the seed command.
 
 Staging smoke should include:
 
@@ -140,6 +148,23 @@ production run so staging proof and production proof stay distinct.
 Latest known staging smoke:
 
 ```text
+Railway staging seed repair:
+- Date: 2026-06-13
+- URL: https://elbysodic-staging.up.railway.app
+- Deployment: 598b31a9-b9cf-4253-9b25-09fc558df7bb
+- Commit: c165e0d469650a3487cb9f620130175ce8bc84e6
+- Volume path: /app/var
+- Database path: /app/var/elbysodic.sqlite3
+- Demo mode: on
+- Auto seed: ELBYSODIC_AUTO_SEED_DEMO=1 set for future staging deploys
+- Manual seed: `elbysodic seed-demo` reported `seeded /app/var/elbysodic.sqlite3`
+- Public GETs: /health, /network, /c/x-men-apocalypse, and
+  /elbysodic-static/seed-media/xmen-hero.svg returned 200
+- Restart persistence: not rerun in this repair pass
+- Result: staging seed data is restored on the volume-backed database; future
+  staging app startups can self-heal missing seed rows once this code is
+  deployed.
+
 Railway smoke:
 - Date: 2026-05-12
 - URL: https://elbysodic-staging.up.railway.app

--- a/docs/operations/sqlite-production.md
+++ b/docs/operations/sqlite-production.md
@@ -18,6 +18,9 @@ chooses a different persistence backend.
   persistent database file.
 - Seed demo data intentionally with `elbysodic seed-demo`; app startup creates
   the schema but should not be treated as a demo reset.
+- Staging may set `ELBYSODIC_AUTO_SEED_DEMO=1` together with
+  `ELBYSODIC_ENV=staging` and `ELBYSODIC_DEMO_MODE=1` to self-heal missing
+  demo rows on startup. Do not enable auto-seeding in production.
 - Demo seeding is idempotent for interrupted local/staging setup. If a seed run
   is stopped partway through, rerun `elbysodic seed-demo` or
   `elbysodic dev preview` against the same database to repair the missing demo

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -367,10 +367,14 @@ from elbysodic.services.timestamps import timestamp_key as _timestamp_key
 DEFAULT_DATABASE_PATH = Path("var/elbysodic.sqlite3")
 DATABASE_PATH_ENV = "ELBYSODIC_DB_PATH"
 RAILWAY_VOLUME_MOUNT_PATH_ENV = "RAILWAY_VOLUME_MOUNT_PATH"
+APP_ENV_ENV = "ELBYSODIC_ENV"
+DEMO_MODE_ENV = "ELBYSODIC_DEMO_MODE"
+AUTO_SEED_DEMO_ENV = "ELBYSODIC_AUTO_SEED_DEMO"
 HERO_TREATMENTS = frozenset({"split", "background", "poster", "text"})
 HERO_FOCAL_POINTS = frozenset({"center", "top", "bottom", "left", "right"})
 HERO_OVERLAYS = frozenset({"none", "light", "medium", "heavy"})
 HERO_HEIGHTS = frozenset({"compact", "standard", "immersive"})
+TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 
 
 def _load_viewer_role(
@@ -3601,7 +3605,10 @@ def create_services(path: str | Path | None = None, *, seed_demo: bool = True) -
     connection = connect(database_path, check_same_thread=False)
     create_schema(connection)
     repo = ForumRepository(connection)
-    seed = seed_demo_forum(repo) if seed_demo else None
+    auto_seed_demo = _auto_seed_demo_enabled()
+    seed = seed_demo_forum(repo) if seed_demo or auto_seed_demo else None
+    if auto_seed_demo:
+        sys.stderr.write(f"auto-seeded staging demo data at {database_path}\n")
     database = None if database_path == ":memory:" else Database(database_path)
     return AppServices(repo, seed, database=database, owns_repo=True)
 
@@ -3665,6 +3672,21 @@ def default_database_path() -> Path:
     if railway_volume:
         return Path(railway_volume) / "elbysodic.sqlite3"
     return DEFAULT_DATABASE_PATH
+
+
+def _auto_seed_demo_enabled() -> bool:
+    if not _truthy_env(AUTO_SEED_DEMO_ENV):
+        return False
+    app_env = (os.environ.get(APP_ENV_ENV) or "development").strip().lower()
+    if app_env != "staging":
+        raise RuntimeError(f"{AUTO_SEED_DEMO_ENV} is only supported when {APP_ENV_ENV}=staging")
+    if not _truthy_env(DEMO_MODE_ENV):
+        raise RuntimeError(f"{AUTO_SEED_DEMO_ENV} requires {DEMO_MODE_ENV}=1")
+    return True
+
+
+def _truthy_env(name: str) -> bool:
+    return (os.environ.get(name) or "").strip().lower() in TRUTHY_ENV_VALUES
 
 
 def _resolve_database_path(path: str | Path | None) -> str | Path:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ from chirp.testing import TestClient
 
 from elbysodic import cli
 from elbysodic.db import ForumRepository, connect, create_schema
-from elbysodic.services import AppServices, initialize_database
+from elbysodic.services import AppServices, create_services, initialize_database
 from elbysodic.web import app as web_app
 
 RAILWAY_HOST = ".".join(("0", "0", "0", "0"))
@@ -606,6 +606,44 @@ def test_initialize_database_leaves_demo_seed_explicit(tmp_path) -> None:
         connection.close()
 
     assert seeded_community_count > 0
+
+
+def test_staging_auto_seed_demo_seeds_volume_backed_database(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "staging" / "elbysodic.sqlite3"
+    monkeypatch.setenv("ELBYSODIC_ENV", "staging")
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+    monkeypatch.setenv("ELBYSODIC_AUTO_SEED_DEMO", "1")
+
+    services = create_services(db_path, seed_demo=False)
+    try:
+        communities = services.repo.list_communities()
+    finally:
+        services.close()
+
+    assert db_path.exists()
+    assert {community.slug for community in communities} >= {
+        "x-men-apocalypse",
+        "jurassic-park-universe",
+        "afterlight-accord",
+    }
+
+
+def test_auto_seed_demo_fails_closed_outside_staging(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "production")
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+    monkeypatch.setenv("ELBYSODIC_AUTO_SEED_DEMO", "1")
+
+    with pytest.raises(RuntimeError, match="ELBYSODIC_AUTO_SEED_DEMO"):
+        create_services(tmp_path / "production.sqlite3", seed_demo=False)
+
+
+def test_auto_seed_demo_requires_demo_mode(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "staging")
+    monkeypatch.delenv("ELBYSODIC_DEMO_MODE", raising=False)
+    monkeypatch.setenv("ELBYSODIC_AUTO_SEED_DEMO", "1")
+
+    with pytest.raises(RuntimeError, match="ELBYSODIC_DEMO_MODE"):
+        create_services(tmp_path / "staging.sqlite3", seed_demo=False)
 
 
 def test_initialize_database_repairs_partial_demo_seed(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- add `ELBYSODIC_AUTO_SEED_DEMO=1` as a staging-only startup seed gate
- fail closed if the auto-seed flag is set outside `ELBYSODIC_ENV=staging` or without `ELBYSODIC_DEMO_MODE=1`
- document Railway staging setup and record the 2026-06-13 seed repair
- add focused tests and a changelog fragment

## Railway staging

- `elbysodic seed-demo` was run through Railway SSH and reported `seeded /app/var/elbysodic.sqlite3`
- staging public GET checks returned 200 for `/health`, `/network`, `/c/x-men-apocalypse`, and `/elbysodic-static/seed-media/xmen-hero.svg`
- `ELBYSODIC_AUTO_SEED_DEMO=1` has been set on staging with `--skip-deploys` so the next deploy can self-heal seed rows

## Tests

- `uv run pytest tests/test_cli.py -q --tb=short -k "auto_seed_demo or initialize_database_leaves_demo_seed_explicit or repairs_partial_demo_seed"`
- `uv run pytest tests/test_cli.py -q --tb=short`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/test_cli.py`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check(warnings_as_errors=True)"`

## Steward Notes

- Storage/deploy: auto-seeding is staging-only, requires demo mode, and preserves explicit manual `seed-demo` for repair/path proof.
- Security: production fails closed if the auto-seed flag is accidentally enabled.
- Docs/changelog: Railway and SQLite runbooks plus user-visible release fragment updated.