### PR TITLE
Add public catalog freshness posture

### DIFF
--- a/changelog.d/+public-catalog-freshness.added.md
+++ b/changelog.d/+public-catalog-freshness.added.md
@@ -1,0 +1,1 @@
+Public Writer Network catalog cards now show public-safe activity freshness and request posture without exposing member continuation state.

--- a/docs/architecture/public-catalog-privacy-contract.md
+++ b/docs/architecture/public-catalog-privacy-contract.md
@@ -37,13 +37,21 @@ signals:
 - `published_application_material_count`
 - `public_claim_type_count`
 - `public_theme_preview`
+- `latest_public_activity_at`
+- `activity_freshness_label`
 - `request_access_href`
 - `invite_posture_label`
+- `access_posture_label`
 
 These fields answer public fit questions: premise, play engine, lore aperture,
-access posture, first-face/application posture, age/content rating, activity
-pace, roster posture, current chapter, wanted pressure, and public entry path.
-They are editorial discovery signals, not generic marketplace metrics.
+access posture, request posture, first-face/application posture,
+age/content rating, activity pace, public-safe freshness, roster posture,
+current chapter, wanted pressure, and public entry path. Freshness is derived
+only from published materials, open wanted hooks, and scene activity on public
+boards with non-private threads. It must not use private boards, private
+threads, unread state, staff queues, plotting rooms, active faces, or
+applications. These fields are editorial discovery signals, not generic
+marketplace metrics.
 
 ## Excluded Signals
 

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -316,7 +316,7 @@ class IdentityRepositoryMixin(RepositoryBase):
         ).fetchall()
         return {int(row["membership_id"]): _role_from_row(row) for row in rows}
 
-    def network_program_counts(self, community_ids: list[int]) -> dict[int, dict[str, int]]:
+    def network_program_counts(self, community_ids: list[int]) -> dict[int, dict[str, int | str]]:
         if not community_ids:
             return {}
         rows = self.connection.execute(
@@ -344,7 +344,44 @@ class IdentityRepositoryMixin(RepositoryBase):
                     SELECT COUNT(*)
                     FROM claim_types
                     WHERE claim_types.community_id = communities.id
-                ) AS claim_type_count
+                ) AS claim_type_count,
+                MAX(
+                    COALESCE((
+                        SELECT MAX(materials.updated_at)
+                        FROM materials
+                        WHERE materials.community_id = communities.id
+                          AND materials.status = 'published'
+                    ), ''),
+                    COALESCE((
+                        SELECT MAX(wanted_ads.updated_at)
+                        FROM wanted_ads
+                        WHERE wanted_ads.community_id = communities.id
+                          AND wanted_ads.status = 'open'
+                    ), ''),
+                    COALESCE((
+                        SELECT MAX(threads.updated_at)
+                        FROM threads
+                        JOIN boards
+                          ON boards.community_id = threads.community_id
+                         AND boards.id = threads.board_id
+                        WHERE threads.community_id = communities.id
+                          AND boards.is_private = 0
+                          AND threads.status != 'private'
+                    ), ''),
+                    COALESCE((
+                        SELECT MAX(posts.updated_at)
+                        FROM posts
+                        JOIN threads
+                          ON threads.community_id = posts.community_id
+                         AND threads.id = posts.thread_id
+                        JOIN boards
+                          ON boards.community_id = threads.community_id
+                         AND boards.id = threads.board_id
+                        WHERE posts.community_id = communities.id
+                          AND boards.is_private = 0
+                          AND threads.status != 'private'
+                    ), '')
+                ) AS latest_public_activity_at
             FROM communities
             WHERE communities.id IN (SELECT value FROM json_each(?))
             """,
@@ -356,6 +393,7 @@ class IdentityRepositoryMixin(RepositoryBase):
                 "open_wanted_count": int(row["open_wanted_count"]),
                 "application_material_count": int(row["application_material_count"]),
                 "claim_type_count": int(row["claim_type_count"]),
+                "latest_public_activity_at": str(row["latest_public_activity_at"] or ""),
             }
             for row in rows
         }

--- a/src/elbysodic/services/network.py
+++ b/src/elbysodic/services/network.py
@@ -175,8 +175,11 @@ PUBLIC_CATALOG_PRIVACY_CONTRACT = PublicCatalogPrivacyContract(
         "published_application_material_count",
         "public_claim_type_count",
         "public_theme_preview",
+        "latest_public_activity_at",
+        "activity_freshness_label",
         "request_access_href",
         "invite_posture_label",
+        "access_posture_label",
     ),
     excluded_signals=(
         "membership",
@@ -295,7 +298,7 @@ class NetworkCatalogRepository(
     def network_program_counts(
         self,
         community_ids: list[int],
-    ) -> dict[int, dict[str, int]]: ...
+    ) -> dict[int, dict[str, int | str]]: ...
 
     def public_scene_hub_community_ids(self, community_ids: list[int]) -> set[int]: ...
 
@@ -354,10 +357,13 @@ def studio_network(
                     facet_groups_by_community.get(community.id, []),
                     material_facets,
                 ),
-                roster_count=counts.get("roster_count", 0),
-                open_wanted_count=counts.get("open_wanted_count", 0),
-                application_material_count=counts.get("application_material_count", 0),
-                claim_type_count=counts.get("claim_type_count", 0),
+                roster_count=_network_count(counts, "roster_count"),
+                open_wanted_count=_network_count(counts, "open_wanted_count"),
+                application_material_count=_network_count(
+                    counts,
+                    "application_material_count",
+                ),
+                claim_type_count=_network_count(counts, "claim_type_count"),
                 application_count=membership_counts.get(
                     (
                         "reviewable_application_count"
@@ -372,6 +378,10 @@ def studio_network(
                 is_current=(
                     community.id == identity.community_id
                     and membership.id == identity.membership_id
+                ),
+                latest_public_activity_at=_network_count_text(
+                    counts,
+                    "latest_public_activity_at",
                 ),
             )
         )
@@ -432,15 +442,22 @@ def public_studio_network(repo: NetworkCatalogRepository) -> StudioNetworkDirect
                     facet_groups_by_community.get(community.id, []),
                     material_facets,
                 ),
-                roster_count=counts.get("roster_count", 0),
-                open_wanted_count=counts.get("open_wanted_count", 0),
-                application_material_count=counts.get("application_material_count", 0),
-                claim_type_count=counts.get("claim_type_count", 0),
+                roster_count=_network_count(counts, "roster_count"),
+                open_wanted_count=_network_count(counts, "open_wanted_count"),
+                application_material_count=_network_count(
+                    counts,
+                    "application_material_count",
+                ),
+                claim_type_count=_network_count(counts, "claim_type_count"),
                 application_count=0,
                 plotting_room_count=0,
                 unread_notification_count=0,
                 theme_preview=network_theme_preview(theme),
                 is_current=False,
+                latest_public_activity_at=_network_count_text(
+                    counts,
+                    "latest_public_activity_at",
+                ),
             )
         )
     return StudioNetworkDirectory(programs=programs)
@@ -544,6 +561,7 @@ def public_studio_program(
     materials = repo.list_materials(community.id, status="published")
     wanted_ads = repo.list_wanted_ads(community.id, status=None)
     community_characters = repo.list_community_characters(community.id)
+    counts = repo.network_program_counts([community.id]).get(community.id, {})
     theme = community_theme_view(repo.get_default_theme(community.id))
     return StudioNetworkProgramView(
         community=community,
@@ -568,6 +586,7 @@ def public_studio_program(
         unread_notification_count=0,
         theme_preview=network_theme_preview(theme),
         is_current=False,
+        latest_public_activity_at=_network_count_text(counts, "latest_public_activity_at"),
     )
 
 
@@ -577,6 +596,19 @@ def public_preview_community(repo: NetworkCatalogRepository, community_slug: str
     if not is_public_network_ready(repo, community, materials):
         raise LookupError(f"community not available for public preview: {community_slug}")
     return community
+
+
+def _network_count(counts: dict[str, int | str], key: str) -> int:
+    value = counts.get(key, 0)
+    if isinstance(value, int):
+        return value
+    if not value:
+        return 0
+    return int(value)
+
+
+def _network_count_text(counts: dict[str, int | str], key: str) -> str:
+    return str(counts.get(key, "") or "")
 
 
 def search_studio_network(
@@ -722,6 +754,7 @@ def public_catalog_card_from_program(
         application_material_count=program.application_material_count,
         claim_type_count=program.claim_type_count,
         theme_preview=program.theme_preview,
+        latest_public_activity_at=program.latest_public_activity_at,
     )
 
 
@@ -959,6 +992,12 @@ def _public_catalog_search_text(card: PublicCatalogCard) -> str:
         catalog_keywords.append("application applications first face")
     if card.current_event:
         catalog_keywords.append("event current event current chapter")
+    catalog_keywords.extend(
+        [
+            card.access_posture_label,
+            card.activity_freshness_label,
+        ]
+    )
     profile = card.discovery_profile
     if profile is not None:
         catalog_keywords.extend(

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -45,6 +45,7 @@ from elbysodic.domain.models import (
     WantedAdInterest,
 )
 from elbysodic.services.themes import ProgramThemeView, ThemeEditorView, ThemeHealthWarning
+from elbysodic.services.timestamps import relative_timestamp_label
 
 type BoardThreadFilter = Literal["all", "unread", "attention", "mine", "pinned", "locked"]
 type ThreadStatus = Literal["open", "active", "paused", "complete", "private", "archived"]
@@ -1860,6 +1861,7 @@ class StudioNetworkProgramView:
     unread_notification_count: int
     theme_preview: StudioNetworkThemePreview
     is_current: bool
+    latest_public_activity_at: str = ""
 
     @property
     def is_authenticated(self) -> bool:
@@ -1889,6 +1891,22 @@ class StudioNetworkProgramView:
         if self.community.launch_status != "public-preview":
             return ""
         return _program_href(self, "/request-access")
+
+    @property
+    def access_posture_label(self) -> str:
+        if self.request_access_href:
+            return "Request access open"
+        if self.community.launch_status == "invite-only":
+            return "Invitation required"
+        if self.community.launch_status == "public-preview":
+            return "Public preview open"
+        return self.launch_status_label
+
+    @property
+    def activity_freshness_label(self) -> str:
+        if not self.latest_public_activity_at:
+            return "No public activity yet"
+        return f"Public activity {relative_timestamp_label(self.latest_public_activity_at)}"
 
     @property
     def launch_status_label(self) -> str:
@@ -2144,6 +2162,7 @@ class PublicCatalogCard:
     application_material_count: int
     claim_type_count: int
     theme_preview: StudioNetworkThemePreview
+    latest_public_activity_at: str = ""
 
     @property
     def entry_href(self) -> str:
@@ -2173,6 +2192,27 @@ class PublicCatalogCard:
         if self.community.launch_status != "public-preview":
             return ""
         return f"{self.entry_href}/request-access"
+
+    @property
+    def access_posture_label(self) -> str:
+        access_model = ""
+        if self.discovery_profile is not None:
+            access_model = self.discovery_profile.access_model
+        if access_model == "invite-only":
+            return "Invitation required"
+        if access_model == "interest-form":
+            return "Interest form open"
+        if access_model == "request-access" or self.request_access_href:
+            return "Request access open"
+        if self.community.launch_status == "public-preview":
+            return "Public preview open"
+        return self.invite_posture_label
+
+    @property
+    def activity_freshness_label(self) -> str:
+        if not self.latest_public_activity_at:
+            return "No public activity yet"
+        return f"Public activity {relative_timestamp_label(self.latest_public_activity_at)}"
 
     @property
     def application_posture_label(self) -> str:

--- a/src/elbysodic/web/pages/_components/network_catalog.html
+++ b/src/elbysodic/web/pages/_components/network_catalog.html
@@ -66,7 +66,7 @@ A realm ready for scenes, casting, and writer movement.
         {% if viewer and viewer.community.id == program.community.id %}
         {{ badge("current membership", variant="success") }}
         {% end %}
-        <span {% if preview %}data-elbysodic-preview-access{% end %}>{{ badge(program.invite_posture_label, variant="info") }}</span>
+        <span {% if preview %}data-elbysodic-preview-access{% end %}>{{ badge(program.access_posture_label, variant="info") }}</span>
         {% if program.discovery_profile and program.discovery_profile.activity_pace %}
         <span {% if preview %}data-elbysodic-preview-pace{% end %}>{{ badge(program.discovery_profile.activity_pace, variant="info") }}</span>
         {% end %}
@@ -74,7 +74,7 @@ A realm ready for scenes, casting, and writer movement.
     </header>
     <p class="elbysodic-copy-summary" {% if preview %}data-elbysodic-preview-summary{% end %}>{{ program_summary(program) }}</p>
     <p class="elbysodic-copy-meta">
-      {{ program.application_posture_label }} · {{ program.claims_posture_label }}
+      {{ program.access_posture_label }} · {{ program.application_posture_label }} · {{ program.claims_posture_label }} · {{ program.activity_freshness_label }}
     </p>
     {% if program.discovery_profile %}
     <p class="elbysodic-copy-meta" {% if preview %}data-elbysodic-preview-fit{% end %}>

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2009,7 +2009,8 @@ def test_network_directory_lists_programs_and_realm_entry_actions() -> None:
         assert "Gaslight Ward" in response.text
         assert "Wayfarer Station" in response.text
         assert "your current realm is marked when it appears" in response.text
-        assert "Public preview" in response.text
+        assert "Request access open" in response.text
+        assert "Public activity " in response.text
         assert "Application guide ready" in response.text
         assert "Claims configured" in response.text
         assert "/applications/new" not in response.text

--- a/tests/test_public_catalog_privacy_contract.py
+++ b/tests/test_public_catalog_privacy_contract.py
@@ -1,15 +1,87 @@
 from __future__ import annotations
 
+import asyncio
+import re
 from pathlib import Path
+from urllib.parse import urlencode
 
+from chirp.testing import TestClient
+
+from elbysodic.db.seed import DemoSeed, SeedPersonaContext, resolve_seed_persona
 from elbysodic.services import create_services
 from elbysodic.services.network import (
     PUBLIC_CATALOG_FORBIDDEN_VIEWER_FIELDS,
     PUBLIC_CATALOG_PRIVACY_CONTRACT,
 )
+from elbysodic.web import create_app
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_DOC = ROOT / "docs" / "architecture" / "public-catalog-privacy-contract.md"
+_FORM = {"Content-Type": "application/x-www-form-urlencoded"}
+_CSRF_RE = re.compile(r'name="_csrf_token" value="([^"]+)"')
+_NETWORK_CARD_RE = re.compile(
+    r'<article class="[^"]*elbysodic-network-card[^"]*".*?</article>',
+    re.DOTALL,
+)
+
+
+def _response_headers(response, name: str) -> list[str]:
+    headers = response.headers
+    if isinstance(headers, dict):
+        value = headers.get(name)
+        return [] if value is None else [str(value)]
+    return [str(value) for key, value in headers if str(key).lower() == name.lower()]
+
+
+def _cookie_values(*responses) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for response in responses:
+        for cookie in _response_headers(response, "set-cookie"):
+            pair = cookie.split(";", 1)[0]
+            name, _, value = pair.partition("=")
+            values[name] = value
+    return values
+
+
+def _cookie_header(cookies: dict[str, str]) -> str:
+    return "; ".join(f"{name}={value}" for name, value in cookies.items())
+
+
+def _csrf_token(html: str) -> str:
+    match = _CSRF_RE.search(html)
+    assert match is not None
+    return match.group(1)
+
+
+def _dev_identity_cookie(seed: DemoSeed | SeedPersonaContext) -> str:
+    return f"elbysodic_dev_identity={seed.community.id}:{seed.user.id}:{seed.membership.id}"
+
+
+def _set_production_env(monkeypatch) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "production")
+    monkeypatch.setenv("ELBYSODIC_SECRET_KEY", "x" * 32)
+    monkeypatch.setenv("ELBYSODIC_ALLOWED_HOSTS", "*")
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+
+
+async def _production_login(client: TestClient, *, email: str) -> dict[str, str]:
+    page = await client.get("/login?next=/network")
+    cookies = _cookie_values(page)
+    response = await client.post(
+        "/login",
+        body=urlencode(
+            {
+                "email": email,
+                "password": "password",
+                "next": "/network",
+                "_csrf_token": _csrf_token(page.text),
+            }
+        ).encode(),
+        headers={**_FORM, "Cookie": _cookie_header(cookies)},
+    )
+    cookies.update(_cookie_values(response))
+    assert response.status == 302
+    return cookies
 
 
 def test_public_catalog_privacy_contract_names_allowed_and_excluded_state() -> None:
@@ -22,8 +94,11 @@ def test_public_catalog_privacy_contract_names_allowed_and_excluded_state() -> N
         "public_discovery_profile",
         "public_discovery_tags",
         "open_wanted_count",
+        "latest_public_activity_at",
+        "activity_freshness_label",
         "request_access_href",
         "invite_posture_label",
+        "access_posture_label",
     }.issubset(contract.searchable_signals)
     assert set(PUBLIC_CATALOG_FORBIDDEN_VIEWER_FIELDS).issubset(contract.excluded_signals)
     assert {
@@ -67,6 +142,9 @@ def test_public_catalog_cards_do_not_expose_forbidden_viewer_fields() -> None:
         )
         assert card.request_access_href == f"/c/{card.community.slug}/request-access"
         assert card.invite_posture_label == "Public preview"
+        assert card.access_posture_label
+        assert card.activity_freshness_label.startswith("Public activity ")
+        assert card.latest_public_activity_at
 
 
 def test_public_catalog_search_uses_public_signals_not_member_continuation() -> None:
@@ -77,6 +155,70 @@ def test_public_catalog_search_uses_public_signals_not_member_continuation() -> 
 
     assert public_results
     assert private_results == []
+
+
+def test_public_catalog_cards_render_safe_freshness_for_viewer_modes(monkeypatch) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        services = create_services(path=":memory:")
+        app = create_app(debug=False, services=services, dev_tools=True)
+
+        writer = resolve_seed_persona(services.repo, "xmen_writer")
+        staff = resolve_seed_persona(services.repo, "xmen_staff")
+        inactive = resolve_seed_persona(services.repo, "xmen_inactive")
+        cross_community = resolve_seed_persona(services.repo, "hp_director")
+
+        async with TestClient(app) as client:
+            signed_out = await client.get("/network")
+        async with TestClient(app) as client:
+            account_cookies = await _production_login(
+                client,
+                email="moira@example.com",
+            )
+            account_visitor = await client.get(
+                "/network",
+                headers={"Cookie": _cookie_header(account_cookies)},
+            )
+        async with TestClient(app) as client:
+            same_community_member = await client.get(
+                "/network",
+                headers={"Cookie": _dev_identity_cookie(writer)},
+            )
+            staff_response = await client.get(
+                "/network",
+                headers={"Cookie": _dev_identity_cookie(staff)},
+            )
+            inactive_member = await client.get(
+                "/network",
+                headers={"Cookie": _dev_identity_cookie(inactive)},
+            )
+            cross_community_viewer = await client.get(
+                "/network",
+                headers={"Cookie": _dev_identity_cookie(cross_community)},
+            )
+        responses = {
+            "signed_out": signed_out,
+            "account_visitor": account_visitor,
+            "same_community_member": same_community_member,
+            "staff": staff_response,
+            "inactive_member": inactive_member,
+            "cross_community_viewer": cross_community_viewer,
+        }
+
+        assert set(responses) == set(PUBLIC_CATALOG_PRIVACY_CONTRACT.viewer_modes)
+        for response in responses.values():
+            card_markup = "\n".join(_NETWORK_CARD_RE.findall(response.text))
+            assert card_markup
+            assert response.status == 200
+            assert "Request access open" in card_markup
+            assert "Public activity " in card_markup
+            assert "playing as" not in card_markup
+            assert "Application Review Room" not in card_markup
+            assert "Plotting Rooms" not in card_markup
+            assert "needs reply" not in card_markup
+            assert "Staff queue" not in card_markup
+
+    asyncio.run(run())
 
 
 def test_public_catalog_privacy_contract_doc_matches_service_contract() -> None:

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -240,7 +240,8 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert "HP Universe" in network.text
         assert "starlane" not in network.text
         assert "current realm" not in network.text
-        assert "Public preview" in network.text
+        assert "Request access open" in network.text
+        assert "Public activity " in network.text
         assert login.status == 200
         assert "_csrf_token" in login.text
         assert 'href="/request-access"' in login.text
@@ -630,7 +631,8 @@ def test_public_network_catalog_hides_membership_and_staff_signals(monkeypatch) 
             network = await client.get("/network?q=wanted")
 
         assert network.status == 200
-        assert "Public preview" in network.text
+        assert "Request access open" in network.text
+        assert "Public activity " in network.text
         assert "Application guide ready" in network.text
         assert "Claims configured" in network.text
         assert "Open Wanted" in network.text or "wanted hooks" in network.text


### PR DESCRIPTION
## Summary
- adds public-safe activity freshness and access posture to Writer Network public catalog cards
- derives freshness only from published materials, open wanted hooks, and public scene activity on non-private threads
- updates public catalog privacy contract docs, rendered privacy tests, and changelog collateral

Fixes #153.

## Steward Notes
- Consulted: root constitution, web, services, tests, docs, changelog.
- Accepted findings: Surface Contract Steward boundary for service-owned card labels and rendered privacy proof; docs/changelog collateral included.
- Deferred findings: none.
- Proof: service contract assertions, rendered viewer-mode matrix, security expectations, full local gates.
- Remaining risks: public freshness is coarse by design and does not expose source titles/counts beyond existing public card fields.

## Verification
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"