### PR TITLE
Add empty catalog diagnostics

### DIFF
--- a/changelog.d/+empty-catalog-diagnostics.added.md
+++ b/changelog.d/+empty-catalog-diagnostics.added.md
@@ -1,0 +1,1 @@
+Studio Operations now reports public-ready realm and database path diagnostics, and empty public catalogs explain that no public-ready realms are open yet.

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -77,6 +77,47 @@ is a configuration error. Keep the manual `railway ssh --service elbysodic
 elbysodic seed-demo` step available for immediate repair and for proving the
 database path printed by the seed command.
 
+## Empty Catalog Diagnostics
+
+When `/network` renders "No public-ready realms are open yet.", treat the page
+as a successful public request with an empty catalog, not as proof that Railway
+is healthy. Open Studio Operations as a director and inspect the read-only
+Runtime and persistence panel:
+
+- `Database path`: should match `ELBYSODIC_DB_PATH`, normally
+  `/app/var/elbysodic.sqlite3` on staging.
+- `Database directory` and `Database file`: both should be present. A missing
+  directory points to a wrong volume mount or path; a missing file points to an
+  uninitialized database path.
+- `Volume mount`: should show the configured Railway mount path as present when
+  `RAILWAY_VOLUME_MOUNT_PATH` is set.
+- `Realms`: `0` means Railway is using an empty schema-only database or the
+  wrong path.
+- `Public-ready realms`: `0` with nonzero realms means the database has tenant
+  roots, but no realm is both `public-preview` and ready for catalog discovery.
+- `Seed demo mode`: disabled means seeded demo passwords are not available; on
+  staging, confirm `ELBYSODIC_DEMO_MODE=1`.
+- `Auto seed demo`: disabled on staging means an empty volume will not self-heal
+  on app startup; confirm `ELBYSODIC_AUTO_SEED_DEMO=1` before relying on
+  automatic repair.
+- `Schema` and `Migration ledger`: both should equal the current schema version.
+  A mismatch means the database is not at the expected migration state.
+
+Common diagnoses:
+
+- Empty schema-only DB: `Realms=0`, schema and migration ledger are current,
+  and the database file is present. Run the staging seed command against the
+  displayed database path.
+- Wrong volume path: `Database path` is `var/elbysodic.sqlite3` or another
+  container-local path instead of `/app/var/elbysodic.sqlite3`, or the displayed
+  directory/file is missing. Fix Railway variables or the mounted volume path,
+  then redeploy before seeding.
+- Unseeded volume: database directory and file are present, schema is current,
+  but `Realms=0`. Run `elbysodic seed-demo` for staging or bootstrap the first
+  realm for production.
+- Real no-public-realms launch state: `Realms>0` and `Public-ready realms=0`.
+  Use Studio Launch and public preview readiness checks instead of reseeding.
+
 Staging smoke should include:
 
 - `GET /health` returns `200`.

--- a/src/elbysodic/services/network.py
+++ b/src/elbysodic/services/network.py
@@ -40,6 +40,7 @@ from elbysodic.services.read_models import (
     MaterialSummary,
     NetworkBrowseFacet,
     NetworkDiscoveryFilterGroup,
+    NetworkEmptyState,
     NetworkExploreLane,
     NetworkExploreView,
     NetworkHomeView,
@@ -512,12 +513,35 @@ def _premise_slice_title(value: str) -> str:
 
 def network_explore(cards: list[PublicCatalogCard], query: str = "") -> NetworkExploreView:
     cards = ensure_public_catalog_cards(cards, surface="network_explore")
+    normalized_query = query.strip()
     return NetworkExploreView(
-        query=query.strip(),
+        query=normalized_query,
         browse_facets=network_browse_facets(cards),
         filter_groups=network_filter_groups(cards),
         relationship_lanes=network_explore_lanes(cards),
-        results=search_public_catalog(cards, query),
+        results=search_public_catalog(cards, normalized_query),
+        empty_state=network_empty_state(query=normalized_query),
+    )
+
+
+def network_empty_state(*, query: str = "") -> NetworkEmptyState:
+    if query:
+        return NetworkEmptyState(
+            kicker="No search match",
+            title="No public realms match that search yet.",
+            summary=(
+                "The request completed, but no public-ready realm currently matches that "
+                "premise, pace, hook, roster, or chapter signal."
+            ),
+        )
+    return NetworkEmptyState(
+        kicker="No public-ready realms",
+        title="No public-ready realms are open yet.",
+        summary=(
+            "The request completed, but this database has no realm that is both public-preview "
+            "and ready for catalog discovery. Directors can confirm realm count, public-ready "
+            "count, seed posture, and database path from Studio Operations."
+        ),
     )
 
 

--- a/src/elbysodic/services/operations.py
+++ b/src/elbysodic/services/operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sqlite3
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -12,12 +13,16 @@ from typing import Protocol
 from elbysodic.db.migrations import CURRENT_SCHEMA_VERSION
 from elbysodic.domain.models import (
     Character,
+    Community,
     CommunityAccessRequest,
     CommunityInvitation,
     CommunityMembership,
+    Material,
     Role,
 )
 from elbysodic.services import policies
+from elbysodic.services.auth import seed_passwords_enabled
+from elbysodic.services.network import is_public_network_ready_from_batches
 from elbysodic.services.read_models import (
     ApplicationCharacterView,
     CastingDesk,
@@ -46,6 +51,17 @@ class OperationsRepository(Protocol):
     def list_community_characters(self, community_id: int) -> list[Character]: ...
 
     def list_memberships(self, community_id: int) -> list[CommunityMembership]: ...
+
+    def list_communities(self) -> list[Community]: ...
+
+    def list_materials_for_communities(
+        self,
+        community_ids: list[int],
+        *,
+        status: str | None = None,
+    ) -> dict[int, list[Material]]: ...
+
+    def public_scene_hub_community_ids(self, community_ids: list[int]) -> set[int]: ...
 
 
 class RestoreCheckRepository(OperationsRepository, Protocol):
@@ -152,6 +168,14 @@ class OperationsInspection:
     current_schema_version: int
     latest_migration_version: int
     community_count: int
+    public_ready_realm_count: int
+    database_parent_path: str
+    database_parent_present: bool
+    database_file_present: bool
+    volume_mount_path: str
+    volume_mount_present: bool
+    demo_mode_enabled: bool
+    auto_seed_demo_enabled: bool
     launch_status: str
 
 
@@ -599,7 +623,28 @@ def operations_inspection(
     journal_mode = connection.execute("PRAGMA journal_mode").fetchone()[0]
     integrity_check = connection.execute("PRAGMA integrity_check").fetchone()[0]
     user_version = connection.execute("PRAGMA user_version").fetchone()[0]
-    community_count = connection.execute("SELECT COUNT(*) AS count FROM communities").fetchone()
+    communities = repo.list_communities()
+    community_ids = [community.id for community in communities]
+    materials_by_community = repo.list_materials_for_communities(
+        community_ids,
+        status="published",
+    )
+    public_scene_hub_community_ids = repo.public_scene_hub_community_ids(community_ids)
+    public_ready_realm_count = sum(
+        1
+        for community in communities
+        if is_public_network_ready_from_batches(
+            community,
+            materials_by_community.get(community.id, []),
+            public_scene_hub_community_ids,
+        )
+    )
+    database_path = str(database_row["file"] or ":memory:")
+    database_file_path = Path(database_path) if database_path != ":memory:" else None
+    database_parent_path = (
+        str(database_file_path.parent) if database_file_path is not None else ":memory:"
+    )
+    volume_mount_path = os.environ.get("RAILWAY_VOLUME_MOUNT_PATH", "").strip()
     try:
         app_version = version("elbysodic")
     except PackageNotFoundError:
@@ -608,15 +653,29 @@ def operations_inspection(
         app_version=app_version,
         environment=config.environment,
         secure_cookies=config.secure_cookies,
-        database_path=str(database_row["file"] or ":memory:"),
+        database_path=database_path,
         journal_mode=str(journal_mode),
         integrity_check=str(integrity_check),
         sqlite_user_version=int(user_version),
         current_schema_version=CURRENT_SCHEMA_VERSION,
         latest_migration_version=int(migration_row["version"] or 0),
-        community_count=int(community_count["count"] if community_count is not None else 0),
+        community_count=len(communities),
+        public_ready_realm_count=public_ready_realm_count,
+        database_parent_path=database_parent_path,
+        database_parent_present=(
+            bool(database_file_path is not None and database_file_path.parent.exists())
+        ),
+        database_file_present=bool(database_file_path is not None and database_file_path.exists()),
+        volume_mount_path=volume_mount_path or "not configured",
+        volume_mount_present=bool(volume_mount_path and Path(volume_mount_path).exists()),
+        demo_mode_enabled=seed_passwords_enabled(),
+        auto_seed_demo_enabled=_truthy_env("ELBYSODIC_AUTO_SEED_DEMO"),
         launch_status=viewer.community.launch_status,
     )
+
+
+def _truthy_env(name: str) -> bool:
+    return (os.environ.get(name) or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def restore_check_database(path: Path) -> RestoreCheckResult:

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -2230,6 +2230,13 @@ class NetworkExploreLane:
 
 
 @dataclass(frozen=True, slots=True)
+class NetworkEmptyState:
+    kicker: str
+    title: str
+    summary: str
+
+
+@dataclass(frozen=True, slots=True)
 class NetworkReturnPath:
     desk_href: str
     notification_href: str
@@ -2252,6 +2259,7 @@ class NetworkExploreView:
     filter_groups: list[NetworkDiscoveryFilterGroup]
     relationship_lanes: list[NetworkExploreLane]
     results: list[PublicCatalogCard]
+    empty_state: NetworkEmptyState
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/elbysodic/web/pages/network/page.html
+++ b/src/elbysodic/web/pages/network/page.html
@@ -310,7 +310,11 @@
     </div>
     {% else %}
     {% call surface(variant="elevated") %}
-    <p class="elbysodic-empty-state">No reachable realms match that search yet.</p>
+    <div class="elbysodic-network-empty">
+      <p class="elbysodic-section-kicker">{{ network_empty_state.kicker }}</p>
+      <h2>{{ network_empty_state.title }}</h2>
+      <p class="elbysodic-empty-state">{{ network_empty_state.summary }}</p>
+    </div>
     {% end %}
     {% end %}
   </section>
@@ -353,16 +357,13 @@
   {% end %}
   {% else %}
   {% call section_header("Studio Network") %}
-  This Elbysodic studio has not opened its first play-by-post realm yet.
+  The public catalog request completed without public-ready realms.
   {% end %}
   {% call surface(variant="elevated") %}
   <div class="elbysodic-network-empty">
-    <p class="elbysodic-section-kicker">Opening soon</p>
-    <h2>The first realm is still preparing to open.</h2>
-    <p class="elbysodic-empty-state">
-      Once a director opens a realm, this studio network will show public worlds,
-      wanted hooks, faces, scenes, and current events here.
-    </p>
+    <p class="elbysodic-section-kicker">{{ network_empty_state.kicker }}</p>
+    <h2>{{ network_empty_state.title }}</h2>
+    <p class="elbysodic-empty-state">{{ network_empty_state.summary }}</p>
     <div class="elbysodic-network-empty__actions">
       <a class="chirpui-btn chirpui-btn--primary" href="/login?next=/">Log in</a>
     </div>

--- a/src/elbysodic/web/pages/network/page.py
+++ b/src/elbysodic/web/pages/network/page.py
@@ -31,6 +31,7 @@ def get(request: Request) -> Page:
         viewer=viewer,
         account_visitor=None if viewer is not None else services.account_visitor(request),
         explore_programs=network_explore.results,
+        network_empty_state=network_explore.empty_state,
         show_community_shell=False,
     )
 

--- a/src/elbysodic/web/pages/page.py
+++ b/src/elbysodic/web/pages/page.py
@@ -7,6 +7,7 @@ from chirp.http.request import Request
 from chirp.templating.returns import Page
 
 from elbysodic.services.forum import AppServices
+from elbysodic.services.network import network_empty_state
 from elbysodic.services.read_models import ForumView
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_tenant_slug
@@ -31,6 +32,7 @@ def get(request: Request) -> Page:
             relationship_lanes=[],
             return_path=network_home.return_path,
             explore_programs=[],
+            network_empty_state=network_empty_state(),
             viewer=viewer,
             account_visitor=None if viewer is not None else services.account_visitor(request),
             show_community_shell=False,

--- a/src/elbysodic/web/pages/studio/operations/page.html
+++ b/src/elbysodic/web/pages/studio/operations/page.html
@@ -129,6 +129,18 @@
         <dd>{{ operations.inspection.database_path }}</dd>
       </div>
       <div>
+        <dt>Database directory</dt>
+        <dd>{{ operations.inspection.database_parent_path }} - {{ "present" if operations.inspection.database_parent_present else "missing" }}</dd>
+      </div>
+      <div>
+        <dt>Database file</dt>
+        <dd>{{ "present" if operations.inspection.database_file_present else "missing" }}</dd>
+      </div>
+      <div>
+        <dt>Volume mount</dt>
+        <dd>{{ operations.inspection.volume_mount_path }} - {{ "present" if operations.inspection.volume_mount_present else "not present" }}</dd>
+      </div>
+      <div>
         <dt>Journal mode</dt>
         <dd>{{ operations.inspection.journal_mode }}</dd>
       </div>
@@ -147,6 +159,18 @@
       <div>
         <dt>Realms</dt>
         <dd>{{ operations.inspection.community_count }}</dd>
+      </div>
+      <div>
+        <dt>Public-ready realms</dt>
+        <dd>{{ operations.inspection.public_ready_realm_count }}</dd>
+      </div>
+      <div>
+        <dt>Seed demo mode</dt>
+        <dd>{{ "enabled" if operations.inspection.demo_mode_enabled else "disabled" }}</dd>
+      </div>
+      <div>
+        <dt>Auto seed demo</dt>
+        <dd>{{ "enabled" if operations.inspection.auto_seed_demo_enabled else "disabled" }}</dd>
       </div>
       <div>
         <dt>Opening</dt>

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -5159,20 +5159,30 @@ def test_studio_operations_hides_review_queue_from_non_staff_members() -> None:
         assert "queue names hidden from non-staff" in member_operations.text
         assert "Live check" not in member_operations.text
         assert "Database path" not in member_operations.text
+        assert "Database directory" not in member_operations.text
+        assert "Volume mount" not in member_operations.text
         assert "Journal mode" not in member_operations.text
         assert "Integrity check" not in member_operations.text
+        assert "Public-ready realms" not in member_operations.text
+        assert "Seed demo mode" not in member_operations.text
         assert staff_operations.status == 200
         assert "Privacy Queue Face - ready" in staff_operations.text
         assert "ready apps" in staff_operations.text
         assert "Live check" in staff_operations.text
         assert "Runtime and persistence" in staff_operations.text
         assert "Database path" in staff_operations.text
+        assert "Database directory" in staff_operations.text
+        assert "Database file" in staff_operations.text
+        assert "Volume mount" in staff_operations.text
         assert "Journal mode" in staff_operations.text
         assert "Integrity check" in staff_operations.text
         assert "ok" in staff_operations.text
         assert "Queue contracts" in staff_operations.text
         assert "visible to managers only" in staff_operations.text
         assert "Schema" in staff_operations.text
+        assert "Public-ready realms" in staff_operations.text
+        assert "Seed demo mode" in staff_operations.text
+        assert "Auto seed demo" in staff_operations.text
         assert "Opening" in staff_operations.text
 
     asyncio.run(run())
@@ -12463,8 +12473,11 @@ def test_startup_seed_preserves_director_edited_boards_and_materials(tmp_path: P
 
 
 def test_file_backed_operations_inspection_reports_wal_and_integrity(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.delenv("RAILWAY_VOLUME_MOUNT_PATH", raising=False)
+    monkeypatch.delenv("ELBYSODIC_AUTO_SEED_DEMO", raising=False)
     services = create_services(path=tmp_path / "elbysodic.sqlite3")
 
     inspection = operations_inspection(
@@ -12478,6 +12491,14 @@ def test_file_backed_operations_inspection_reports_wal_and_integrity(
     assert inspection.integrity_check == "ok"
     assert inspection.latest_migration_version == inspection.current_schema_version
     assert inspection.community_count > 0
+    assert inspection.public_ready_realm_count > 0
+    assert inspection.database_parent_path == str(tmp_path)
+    assert inspection.database_parent_present
+    assert inspection.database_file_present
+    assert inspection.volume_mount_path == "not configured"
+    assert not inspection.volume_mount_present
+    assert inspection.demo_mode_enabled
+    assert not inspection.auto_seed_demo_enabled
 
 
 def test_restore_check_database_reports_redacted_service_readback(tmp_path: Path) -> None:

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -555,9 +555,9 @@ def test_production_empty_network_renders_launch_state(monkeypatch) -> None:
         assert root.status == 200
         assert network.status == 200
         for response in (root, network):
-            assert "Opening soon" in response.text
-            assert "The first realm is still preparing to open." in response.text
-            assert "wanted hooks, faces, scenes, and current events" in response.text
+            assert "No public-ready realms" in response.text
+            assert "No public-ready realms are open yet." in response.text
+            assert "The request completed, but this database has no realm" in response.text
             assert 'href="/request-access"' in response.text
             assert 'href="/login?next=/"' in response.text
             assert "No programs are available yet." not in response.text
@@ -600,8 +600,8 @@ def test_production_backstage_realm_stays_out_of_public_network(monkeypatch) -> 
         assert root.status == 200
         assert network.status == 200
         for response in (root, network):
-            assert "Opening soon" in response.text
-            assert "The first realm is still preparing to open." in response.text
+            assert "No public-ready realms" in response.text
+            assert "No public-ready realms are open yet." in response.text
             assert "Starter Realm" not in response.text
             assert "starter-realm" not in response.text
         assert direct_preview.status == 404
@@ -610,7 +610,7 @@ def test_production_backstage_realm_stays_out_of_public_network(monkeypatch) -> 
         assert "Starter Director" not in direct_world.text
         assert login.status == 302
         assert director_network.status == 200
-        assert "The first realm is still preparing to open." in director_network.text
+        assert "No public-ready realms are open yet." in director_network.text
         assert "Starter Director" in director_network.text
         assert "Director in Starter Realm" in director_network.text
         assert (


### PR DESCRIPTION
## Summary
- adds service-owned empty-state copy for public catalog routes when no public-ready realms exist
- extends Studio Operations runtime inspection with public-ready realm count, DB directory/file presence, volume mount posture, and seed/auto-seed posture
- updates Railway smoke runbook guidance, rendered diagnostics tests, empty catalog tests, and changelog collateral

Fixes #144.

## Steward Notes
- Consulted: root constitution, web, services, db, tests, docs, changelog.
- Accepted findings: Surface Contract Steward boundary for service-owned empty-state copy; Storage/Migration Steward boundary for read-only diagnostics using repository methods; Operations runbook collateral included.
- Deferred findings: live Railway validation deferred because Railway/release-surface operations require explicit human check-in and are covered by #146/#147.
- Proof: rendered Studio Operations tests, signed-out empty catalog tests, full local gates.
- Remaining risks: volume mount presence reports the configured Railway volume mount environment variable; environments that only set the database path still diagnose path/file presence, but not a named Railway mount.

## Verification
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python app check for create_app(debug=False, db_path=:memory:)