### PR TITLE
Document invite reissue policy

### DIFF
--- a/changelog.d/+invite-delivery-policy.changed.md
+++ b/changelog.d/+invite-delivery-policy.changed.md
@@ -1,0 +1,1 @@
+Invite-only alpha guidance now names copy-only delivery, pending-only reissue, and terminal accepted, revoked, or expired invite handling.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -199,7 +199,13 @@ communities must not be changed by the invite acceptance flow.
 Invitation delivery is copy-only until a sender policy exists. "Resend" means
 reissue, not recover: a director revokes the pending invitation and creates a
 fresh token for the same email. Accepted, revoked, or expired invitations do
-not expose raw tokens and should not be resurrected.
+not expose raw tokens and should not be resurrected. Bounced email, mistaken
+recipient, or lost-link support follows the same rule: if the invitation is
+still pending, revoke and reissue; if it is accepted, revoked, or expired, use
+membership/account support or create a deliberately new invitation after
+confirming the corrected recipient. Support replies may name the email and
+state but must not include token hashes, raw tokens recovered from storage, staff
+notes, or private access-request details.
 
 Current community and membership selection is stored on `user_sessions` as
 `selected_community_id` and `selected_membership_id`. Switching membership

--- a/docs/operations/invite-only-alpha.md
+++ b/docs/operations/invite-only-alpha.md
@@ -58,6 +58,14 @@ not reissue them as though the same token can be recovered. If a writer already
 accepted the invitation, use membership support workflows instead of creating a
 second invite.
 
+| State | Director action | Token posture | Support language |
+|---|---|---|---|
+| Pending | Copy the creation link now, revoke it, or reissue it. | Raw token is visible only in the creation/reissue response. | If the link is lost or sent to the wrong person, reissue: revoke the pending row and create a fresh invitation for the same email. |
+| Accepted | No resend or reissue. Support the membership. | Raw token is not recoverable and the accepted token no longer grants access. | Help the writer sign in, reset their account route, or adjust the community membership; do not create a duplicate membership. |
+| Revoked | No resend or reissue. Create a new invite only after confirming intent. | Raw token is not recoverable and the revoked token is dead. | Tell the recipient the prior invite was revoked; create a new invitation only for the corrected recipient. |
+| Expired | No resend or recovery. Create a new invite if still wanted. | Raw token is not recoverable and the expired token is dead. | Explain that the window closed; issue a fresh invite if the director still wants that writer. |
+| Bounced or mistaken recipient | Revoke pending invite, then create a new invite for the corrected email. | Never paste stored hashes or staff notes into support replies. | Confirm only the recipient email and state; keep staff notes and access-request details inside Studio. |
+
 ## 5. Smoke
 
 - Run the Railway smoke checklist.

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -4807,6 +4807,8 @@ def test_director_can_revoke_pending_writer_invitation() -> None:
         assert revoked.status == 200
         assert "Invitation for revoked-writer@example.com was revoked." in revoked.text
         assert "Revoked" in revoked.text
+        assert "Reissue invitation" not in revoked.text
+        assert "Revoke invitation" not in revoked.text
         assert denied.status == 403
         assert invitation.status == "revoked"
         assert invitation.revoked_at is not None
@@ -4870,6 +4872,60 @@ def test_director_can_reissue_pending_writer_invitation() -> None:
     asyncio.run(run())
 
 
+def test_writer_invitation_reissue_policy_is_pending_only_and_hash_only() -> None:
+    services = create_services(path=":memory:")
+    staff = resolve_seed_persona(services.repo, "xmen_staff")
+    staff_services = AppServices(
+        services.repo,
+        DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+    )
+
+    pending = staff_services.create_writer_invitation("lost-link@example.com")
+    reissued = staff_services.reissue_writer_invitation(pending.invitation.id)
+    old_pending = services.repo.get_community_invitation(
+        staff.community.id,
+        pending.invitation.id,
+    )
+    new_pending = services.repo.get_community_invitation(
+        staff.community.id,
+        reissued.invitation.id,
+    )
+
+    accepted = staff_services.create_writer_invitation("accepted-reissue@example.com")
+    staff_services.accept_invitation(
+        accepted.token,
+        username="accepted-reissue",
+        display_name="Accepted Reissue",
+        password="-".join(("writer", "password")),
+    )
+    revoked = staff_services.create_writer_invitation("revoked-reissue@example.com")
+    staff_services.revoke_writer_invitation(revoked.invitation.id)
+    expired = staff_services.create_writer_invitation("expired-reissue@example.com")
+    services.repo.connection.execute(
+        """
+        UPDATE community_invitations
+        SET expires_at = '2026-01-01T00:00:00+00:00'
+        WHERE community_id = ? AND id = ?
+        """,
+        (staff.community.id, expired.invitation.id),
+    )
+    services.repo.connection.commit()
+
+    assert old_pending.status == "revoked"
+    assert old_pending.revoked_at is not None
+    assert new_pending.status == "pending"
+    assert new_pending.email == "lost-link@example.com"
+    assert reissued.token != pending.token
+    assert pending.token not in old_pending.token_hash
+    assert reissued.token not in new_pending.token_hash
+    with pytest.raises(ValueError, match="only pending invitations can be reissued"):
+        staff_services.reissue_writer_invitation(accepted.invitation.id)
+    with pytest.raises(ValueError, match="only pending invitations can be reissued"):
+        staff_services.reissue_writer_invitation(revoked.invitation.id)
+    with pytest.raises(ValueError, match="only pending invitations can be reissued"):
+        staff_services.reissue_writer_invitation(expired.invitation.id)
+
+
 def test_expired_writer_invitation_cannot_be_accepted_or_revoked() -> None:
     async def run() -> None:
         services = create_services(path=":memory:")
@@ -4913,6 +4969,7 @@ def test_expired_writer_invitation_cannot_be_accepted_or_revoked() -> None:
         assert launch.status == 200
         assert "expired-writer@example.com" in launch.text
         assert "Expired" in launch.text
+        assert "Reissue invitation" not in launch.text
         assert "Revoke invitation" not in launch.text
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- documents V1 invite delivery as copy-only, with resend treated as pending-only reissue
- adds support language for lost links, mistaken recipients, bounced email, and terminal accepted/revoked/expired states
- adds service proof that reissue revokes pending invites, creates a fresh token, stores only hashes, and rejects accepted/revoked/expired invites
- tightens rendered launch-room assertions that terminal invites do not offer reissue/revoke controls

Fixes #145.

## Steward Notes
- Consulted: root constitution, services, web, tests, docs, changelog.
- Accepted findings: invite-token posture remains unchanged; this PR adds policy and regression proof around the existing copy-only/reissue behavior.
- Deferred findings: actual email delivery/sender policy remains out of scope until a sender is approved.
- Proof: focused invite service/rendered tests plus full local gates.
- Remaining risks: none for runtime behavior; this is documentation and proof around existing behavior.

## Verification
- uv run ruff check .
- uv run ruff format . --check
- uv run ty check src/elbysodic/ tests/
- uv run pytest -q --tb=short
- uv run python app check for create_app(debug=False, db_path=:memory:)