### PR TITLE
Add community hub story frame

### DIFF
--- a/changelog.d/+community-hub-story-frame.added.md
+++ b/changelog.d/+community-hub-story-frame.added.md
@@ -1,0 +1,1 @@
+Community homes now show a service-owned story frame that orients visitors, writers, staff, and directors around public-safe premise, cast, places, wanted pressure, and next action.

--- a/docs/product/information-hierarchy.md
+++ b/docs/product/information-hierarchy.md
@@ -90,6 +90,11 @@ Use this contract before adding or expanding a hub:
 - **Community home** answers: where am I in the world? It should orient around
   realm identity, playable locations, current activity, and reply pressure. It
   should not become a second Writer Desk or Studio dashboard.
+  Its top story frame is service-owned and audience-specific: public visitors,
+  signed-in account visitors, members, staff, directors, inactive members, and
+  cross-realm viewers should see the same public-safe premise, event/material,
+  cast, places, and wanted pressure, with only the next action and viewer
+  framing changing by access state.
 - **Character hub** answers: what is true and playable for this face? It can
   show profile identity, active hooks, recent scenes, tracker context, and
   character-specific actions. It should not repeat roster-wide work that the

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -297,6 +297,7 @@ from elbysodic.services.read_models import (
     PublicCatalogCard,
     RealmGatewayAction,
     RealmGatewayAtmosphere,
+    RealmGatewayAudienceContract,
     RealmGatewayCastMember,
     RealmGatewayContinuation,
     RealmGatewayEntryPath,
@@ -1484,7 +1485,11 @@ class AppServices:
             or viewer.current_character.application_status != "accepted"
             else None
         )
-        return replace(gateway, continuation=_realm_gateway_continuation(viewer, activation))
+        return replace(
+            gateway,
+            story_frame=_realm_gateway_story_frame_for_viewer(gateway, viewer),
+            continuation=_realm_gateway_continuation(viewer, activation),
+        )
 
     def realm_home(self) -> RealmHome:
         boards = self.list_boards()
@@ -4187,7 +4192,15 @@ def _public_realm_gateway(repo: ForumRepository, community: Community) -> RealmG
         guidebook=guidebook,
         hero=_realm_gateway_hero(program, premise, atmosphere),
         premise=premise,
-        story_frame=_realm_gateway_story_frame(program, premise),
+        story_frame=_realm_gateway_story_frame(
+            program,
+            premise,
+            atmosphere,
+            premise_stage,
+            scene_hubs,
+            cast_members,
+            wanted_previews,
+        ),
         premise_stage=premise_stage,
         premise_evolution=_realm_gateway_premise_evolution(
             program,
@@ -4300,6 +4313,11 @@ def _realm_gateway_hero(
 def _realm_gateway_story_frame(
     program: StudioNetworkProgramView,
     premise: RealmGatewayPremise,
+    atmosphere: RealmGatewayAtmosphere,
+    premise_stage: RealmGatewayPremiseStage,
+    scene_hubs: tuple[RealmGatewaySceneHub, ...],
+    cast_members: tuple[RealmGatewayCastMember, ...],
+    wanted_previews: tuple[RealmGatewayWantedPreview, ...],
 ) -> RealmGatewayStoryFrame:
     profile = premise.discovery_profile
     rating_parts = []
@@ -4316,6 +4334,8 @@ def _realm_gateway_story_frame(
         if profile is not None and profile.activity_expectation.strip()
         else "Scene cadence, writing length, and fit are set by the realm's public guidebook."
     )
+    audience_contracts = _realm_gateway_audience_contracts(program)
+    public_contract = audience_contracts[0]
     return RealmGatewayStoryFrame(
         eyebrow=premise.premise_label,
         access_label=program.invite_posture_label,
@@ -4323,7 +4343,147 @@ def _realm_gateway_story_frame(
         cadence_label=cadence_label,
         writing_expectation=writing_expectation,
         roster_posture=premise.roster_posture,
+        audience_label=public_contract.label,
+        audience_summary=public_contract.summary,
+        premise_stage_label=f"{premise_stage.label}: {premise_stage.title}",
+        featured_signal=f"{atmosphere.label}: {atmosphere.title}",
+        cast_signal=_realm_gateway_cast_signal(program, cast_members),
+        places_signal=_realm_gateway_places_signal(scene_hubs),
+        wanted_pressure=_realm_gateway_wanted_pressure(program, wanted_previews),
+        next_action=public_contract.next_action,
+        audience_contracts=audience_contracts,
     )
+
+
+def _realm_gateway_story_frame_for_viewer(
+    gateway: RealmGatewayView,
+    viewer: ForumView,
+) -> RealmGatewayStoryFrame:
+    mode = "member"
+    if policies.can_manage_world(viewer.membership, viewer.role):
+        mode = "director"
+    elif (
+        policies.can_manage_applications(viewer.membership, viewer.role)
+        or policies.can_manage_casting(viewer.membership, viewer.role)
+        or policies.can_manage_navigation(viewer.membership, viewer.role)
+        or policies.can_manage_threads(viewer.membership, viewer.role)
+    ):
+        mode = "staff"
+
+    if not viewer.membership.is_active:
+        mode = "inactive_member"
+    elif mode == "member" and (
+        viewer.current_character is None
+        or viewer.current_character.application_status != "accepted"
+    ):
+        mode = "account_visitor"
+
+    contract = _realm_gateway_audience_contract(gateway.story_frame, mode)
+    return replace(
+        gateway.story_frame,
+        audience_label=contract.label,
+        audience_summary=contract.summary,
+        next_action=contract.next_action,
+    )
+
+
+def _realm_gateway_audience_contract(
+    story_frame: RealmGatewayStoryFrame,
+    mode: str,
+) -> RealmGatewayAudienceContract:
+    for contract in story_frame.audience_contracts:
+        if contract.mode == mode:
+            return contract
+    return story_frame.audience_contracts[0]
+
+
+def _realm_gateway_audience_contracts(
+    program: StudioNetworkProgramView,
+) -> tuple[RealmGatewayAudienceContract, ...]:
+    request_access = RealmGatewayAction(
+        "Request access",
+        _community_href(program, "/request-access"),
+        is_hx_boost_safe=False,
+    )
+    read_public = _realm_gateway_primary_action(program, _realm_gateway_reading_action(program))
+    return (
+        RealmGatewayAudienceContract(
+            "public_visitor",
+            "Public visitor",
+            "Read the public premise, scan places and wanted hooks, then decide whether to request access.",
+            read_public,
+        ),
+        RealmGatewayAudienceContract(
+            "account_visitor",
+            "Signed-in account visitor",
+            "Browse the public preview with your account ready for a director-reviewed access request.",
+            request_access,
+        ),
+        RealmGatewayAudienceContract(
+            "member",
+            "Realm member",
+            "Continue writing from your Desk after checking the realm's public story pressure.",
+            RealmGatewayAction("Open Desk", _community_href(program, "/desk")),
+        ),
+        RealmGatewayAudienceContract(
+            "staff",
+            "Staff",
+            "Check the public story frame, then move into Studio for queues, moderation, and production work.",
+            RealmGatewayAction("Open Studio", "/studio"),
+        ),
+        RealmGatewayAudienceContract(
+            "director",
+            "Director",
+            "Review the public story frame and manage the home spotlight from Studio Structure.",
+            RealmGatewayAction("Manage home spotlight", "/studio/structure#gateway-curation"),
+        ),
+        RealmGatewayAudienceContract(
+            "inactive_member",
+            "Inactive member",
+            "Public preview only; staff must restore membership before private queues or faces reopen.",
+            request_access,
+        ),
+        RealmGatewayAudienceContract(
+            "cross_community_viewer",
+            "Cross-realm visitor",
+            "Preview this realm as an outside writer without carrying another community's private context.",
+            request_access,
+        ),
+    )
+
+
+def _realm_gateway_cast_signal(
+    program: StudioNetworkProgramView,
+    cast_members: tuple[RealmGatewayCastMember, ...],
+) -> str:
+    if cast_members:
+        featured_count = len(cast_members)
+        featured_label = "featured face" if featured_count == 1 else "featured faces"
+        return f"{featured_count} {featured_label}; {program.roster_count} rostered faces."
+    if program.roster_count:
+        face_label = "face" if program.roster_count == 1 else "faces"
+        return f"{program.roster_count} rostered {face_label} visible from the public roster."
+    return "Roster signals open after accepted faces join play."
+
+
+def _realm_gateway_places_signal(scene_hubs: tuple[RealmGatewaySceneHub, ...]) -> str:
+    if scene_hubs:
+        place_label = "public place" if len(scene_hubs) == 1 else "public places"
+        return f"{len(scene_hubs)} {place_label} in play."
+    return "Public places open when directors publish scene hubs."
+
+
+def _realm_gateway_wanted_pressure(
+    program: StudioNetworkProgramView,
+    wanted_previews: tuple[RealmGatewayWantedPreview, ...],
+) -> str:
+    if wanted_previews:
+        wanted_titles = _joined_labels(tuple(preview.title for preview in wanted_previews[:2]))
+        return f"Open calls include {wanted_titles}."
+    if program.open_wanted_count:
+        hook_label = "open call" if program.open_wanted_count == 1 else "open calls"
+        return f"{program.open_wanted_count} {hook_label} waiting for writers."
+    return "No public wanted pressure is open right now."
 
 
 def _realm_gateway_premise_stage(

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -1935,6 +1935,14 @@ class RealmGatewayAction:
 
 
 @dataclass(frozen=True, slots=True)
+class RealmGatewayAudienceContract:
+    mode: str
+    label: str
+    summary: str
+    next_action: RealmGatewayAction
+
+
+@dataclass(frozen=True, slots=True)
 class RealmGatewayHero:
     kicker: str
     title: str
@@ -1965,6 +1973,15 @@ class RealmGatewayStoryFrame:
     cadence_label: str
     writing_expectation: str
     roster_posture: str
+    audience_label: str
+    audience_summary: str
+    premise_stage_label: str
+    featured_signal: str
+    cast_signal: str
+    places_signal: str
+    wanted_pressure: str
+    next_action: RealmGatewayAction
+    audience_contracts: tuple[RealmGatewayAudienceContract, ...]
 
     @property
     def fit_labels(self) -> tuple[str, ...]:

--- a/src/elbysodic/web/pages/_components/realm_gateway.html
+++ b/src/elbysodic/web/pages/_components/realm_gateway.html
@@ -50,6 +50,35 @@
     <p class="elbysodic-copy-lead">{{ gateway.hero.lead }}</p>
     <p class="elbysodic-realm-gateway-fit">{{ gateway.story_frame.fit_summary }}</p>
     <p class="elbysodic-realm-gateway-writing">{{ gateway.story_frame.writing_expectation }}</p>
+    <dl class="elbysodic-realm-gateway-story-frame" aria-label="Realm story frame">
+      <div>
+        <dt>Audience</dt>
+        <dd>
+          <strong>{{ gateway.story_frame.audience_label }}</strong>
+          <span>{{ gateway.story_frame.audience_summary }}</span>
+        </dd>
+      </div>
+      <div>
+        <dt>Now</dt>
+        <dd>{{ gateway.story_frame.featured_signal }}</dd>
+      </div>
+      <div>
+        <dt>Places</dt>
+        <dd>{{ gateway.story_frame.places_signal }}</dd>
+      </div>
+      <div>
+        <dt>Cast</dt>
+        <dd>{{ gateway.story_frame.cast_signal }}</dd>
+      </div>
+      <div>
+        <dt>Wanted</dt>
+        <dd>{{ gateway.story_frame.wanted_pressure }}</dd>
+      </div>
+      <div>
+        <dt>Next</dt>
+        <dd>{{ gateway.story_frame.next_action.label }}</dd>
+      </div>
+    </dl>
     <p class="elbysodic-realm-gateway-first-face">
       <strong>Start here</strong>
       <span>{{ gateway.hero.first_face_path }}</span>

--- a/src/elbysodic/web/static/elbysodic-theme/30-page-patterns.css
+++ b/src/elbysodic/web/static/elbysodic-theme/30-page-patterns.css
@@ -843,6 +843,47 @@
     max-inline-size: 42rem;
 }
 
+.elbysodic-realm-gateway-story-frame {
+    display: grid;
+    gap: 0.55rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin: 0;
+}
+
+.elbysodic-realm-gateway-story-frame div {
+    background: color-mix(in srgb, var(--chirpui-bg) 64%, transparent);
+    border: 1px solid color-mix(in srgb, var(--chirpui-border) 54%, transparent);
+    border-radius: var(--chirpui-radius-sm);
+    display: grid;
+    gap: 0.2rem;
+    min-inline-size: 0;
+    padding: 0.65rem 0.7rem;
+}
+
+.elbysodic-realm-gateway-story-frame dt {
+    color: var(--chirpui-text);
+    font-size: var(--chirpui-font-xs);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    line-height: 1.2;
+    text-transform: uppercase;
+}
+
+.elbysodic-realm-gateway-story-frame dd {
+    color: var(--chirpui-text-muted);
+    display: grid;
+    gap: 0.15rem;
+    font-size: var(--chirpui-font-sm);
+    line-height: 1.35;
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+.elbysodic-realm-gateway-story-frame dd strong {
+    color: var(--chirpui-text);
+    font-size: var(--chirpui-font-sm);
+}
+
 .elbysodic-realm-gateway-now,
 .elbysodic-realm-gateway-first-face {
     background: color-mix(in srgb, var(--chirpui-bg) 70%, transparent);
@@ -1429,6 +1470,10 @@
 
     .elbysodic-realm-gateway-hero h1 {
         font-size: clamp(2.35rem, 16vw, 3.4rem);
+    }
+
+    .elbysodic-realm-gateway-story-frame {
+        grid-template-columns: 1fr;
     }
 
     .elbysodic-realm-gateway-hero__media {

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2329,6 +2329,23 @@ def test_original_premise_gateways_surface_premise_entry_and_scene_hubs() -> Non
         assert gateway.story_frame.cadence_label
         assert gateway.story_frame.writing_expectation
         assert gateway.story_frame.roster_posture
+        assert gateway.story_frame.audience_label == "Public visitor"
+        assert gateway.story_frame.audience_summary
+        assert gateway.story_frame.premise_stage_label
+        assert gateway.story_frame.featured_signal
+        assert gateway.story_frame.cast_signal
+        assert gateway.story_frame.places_signal
+        assert gateway.story_frame.wanted_pressure
+        assert gateway.story_frame.next_action.label == "Browse open calls"
+        assert {contract.mode for contract in gateway.story_frame.audience_contracts} == {
+            "public_visitor",
+            "account_visitor",
+            "member",
+            "staff",
+            "director",
+            "inactive_member",
+            "cross_community_viewer",
+        }
         assert gateway.premise_stage.title
         assert not gateway.premise_stage.title.lower().startswith(("current chapter:", "premise:"))
         assert gateway.premise_stage.summary
@@ -2627,6 +2644,12 @@ def test_public_realm_gateway_contract_uses_fallbacks_and_denies_backstage() -> 
     assert gateway.hero.primary_action.label == "Request access"
     assert gateway.hero.primary_action.href == "/c/quiet-harbor/request-access"
     assert gateway.hero.primary_action.is_hx_boost_safe is False
+    assert gateway.story_frame.audience_label == "Public visitor"
+    assert gateway.story_frame.next_action.label == "Request access"
+    assert gateway.story_frame.premise_stage_label == "Story promise: Quiet Harbor Premise"
+    assert gateway.story_frame.featured_signal == "Standing premise: Quiet Harbor Premise"
+    assert gateway.story_frame.places_signal == "1 public place in play."
+    assert gateway.story_frame.wanted_pressure == "No public wanted pressure is open right now."
     assert gateway.hero.secondary_action is not None
     assert gateway.hero.secondary_action.label == "Read premise"
     assert gateway.wanted_previews == ()
@@ -2656,6 +2679,11 @@ def test_public_realm_gateway_contract_uses_fallbacks_and_denies_backstage() -> 
 
             assert response.status == 200
             assert "Quiet Harbor Premise" in content
+            assert "Public visitor" in content
+            assert "Standing premise: Quiet Harbor Premise" in content
+            assert "1 public place in play." in content
+            assert "No public wanted pressure is open right now." in content
+            assert 'aria-label="Realm story frame"' in response.text
             assert "Locked Harbor" not in content
             assert "Director-only pressure" not in content
             assert "Main Street" in content
@@ -8480,10 +8508,13 @@ def test_rendered_surface_contract_parity_across_realm_viewers() -> None:
             member_thread = await client.get("/boards/danger-room/threads/sentinel-drill")
 
         async with TestClient(create_app(debug=False, services=staff_services)) as client:
+            staff_home = await client.get("/c/x-men-apocalypse")
             staff_claims = await client.get("/claims")
             staff_studio = await client.get("/studio")
 
         async with TestClient(create_app(debug=False, services=hp_services)) as client:
+            hp_home = await client.get("/c/x-men-apocalypse")
+            hp_own_home = await client.get(f"/c/{hp_director.community.slug}")
             hp_claims = await client.get("/claims")
             hp_roster = await client.get("/characters")
             hp_notifications = await client.get("/notifications")
@@ -8495,9 +8526,27 @@ def test_rendered_surface_contract_parity_across_realm_viewers() -> None:
 
         assert member_home.status == 200
         assert "playing as Rogue" in member_home.text
+        assert "Realm member" in _page_content(member_home.text)
+        assert "Continue writing from your Desk" in _page_content(member_home.text)
         assert 'href="/c/x-men-apocalypse/desk"' in member_home.text
         assert "Cross-Realm Only Face" not in member_home.text
         assert "HP DIRECTOR CONTRACT NOTE" not in member_home.text
+
+        staff_home_content = _page_content(staff_home.text)
+        assert staff_home.status == 200
+        assert "Staff" in staff_home_content or "Director" in staff_home_content
+        assert "Studio" in staff_home_content
+        assert "HP DIRECTOR CONTRACT NOTE" not in staff_home_content
+
+        hp_home_content = _page_content(hp_home.text)
+        assert hp_home.status == 200
+        assert "Cross-Realm Only Face" not in hp_home_content
+        assert "HP DIRECTOR CONTRACT NOTE" not in hp_home_content
+
+        hp_own_home_content = _page_content(hp_own_home.text)
+        assert hp_own_home.status == 200
+        assert "Director" in hp_own_home_content
+        assert "Manage home spotlight" in hp_own_home_content
 
         member_claims_content = _page_content(member_claims.text)
         assert member_claims.status == 200


### PR DESCRIPTION
## Summary
- add a service-owned community hub story-frame read model with audience contracts for public visitors, account visitors, members, staff, directors, inactive members, and cross-realm viewers
- render public-safe story, places, cast, wanted, and next-action signals in the realm gateway hero
- document the community-home information hierarchy update and add a changelog fragment

Fixes #151

## Steward Notes
- Consulted root constitution plus services, web, tests, docs, and changelog stewards.
- Accepted: Surface Contract Steward concern that top story assembly belongs in the service read model, with rendered privacy proof.
- Deferred: no route or data-model changes; inactive member rendering remains governed by existing viewer resolution and public-safe fallback.
- Collateral: docs/product/information-hierarchy.md and changelog.d/+community-hub-story-frame.added.md.

## Proof
- uv run ruff check .
- uv run ruff format . --check
- uv run pytest tests/test_forum_slice.py -q --tb=short -k "realm_gateway or rendered_surface_contract_parity"
- uv run pytest -q --tb=short
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"