### PR TITLE
Add auth posture remediation diagnostics

### DIFF
--- a/changelog.d/+auth-trust-diagnostics.security.md
+++ b/changelog.d/+auth-trust-diagnostics.security.md
@@ -1,0 +1,1 @@
+Auth trust posture diagnostics now include stable remediation codes, severity, production-blocking status, and recommended fixes without exposing secrets.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -96,7 +96,10 @@ operations diagnostic for this posture. It reports environment, production
 mode, demo-mode seed password posture, secret-key presence/minimum status,
 session cookie name, session TTL, development identity availability, and
 session-required status without exposing secret values, token hashes, raw
-cookies, account emails, membership names, or private identity state.
+cookies, account emails, membership names, or private identity state. Each
+warning also has a stable code, severity, affected surface, recommended fix,
+production-blocking flag, and local-development exception flag. The operator
+remediation guide lives in `docs/operations/auth-trust-posture.md`.
 
 The logged-out `/` and `/network` surfaces use public catalog read models.
 They can show realm names, public premise or current-event summaries, public

--- a/docs/operations/auth-trust-posture.md
+++ b/docs/operations/auth-trust-posture.md
@@ -1,0 +1,48 @@
+# Auth Trust Posture Diagnostics
+
+`auth_trust_posture()` reports a redacted deployment checklist for login,
+session, demo-account, and entry-flow trust. It is diagnostic-only: it does not
+change route access, session resolution, cookie handling, CSRF enforcement, or
+writer entry policy.
+
+Never paste secret values, session tokens, token hashes, passwords, raw cookies,
+account emails, membership names, private notes, or invite tokens into a smoke
+record. Use the diagnostic code, severity, production-blocking posture, and
+recommended fix.
+
+## Warning Codes
+
+| Code | Severity | Surface | Production blocking | Meaning | Recommended fix |
+|---|---|---|---|---|---|
+| `auth.secret_key.too_short` | blocker | session secret | yes | `ELBYSODIC_SECRET_KEY` is missing or shorter than the production minimum. | Set `ELBYSODIC_SECRET_KEY` to a random value with at least 32 characters before serving a shared environment. |
+| `auth.demo_mode.seed_passwords` | warning | demo login | yes for `production`/`prod`; staging exception | Seeded demo password hashes are accepted because `ELBYSODIC_DEMO_MODE=1`. | Unset `ELBYSODIC_DEMO_MODE` for real production. Keep it only for staging or seeded demo rehearsals. |
+| `auth.development_identity.shortcuts` | note | local identity | no | Local development identity shortcuts are enabled outside production-like environments. | Accept only for local development. Use `ELBYSODIC_ENV=production` or `staging` before shared smoke runs. |
+
+## Informational Codes
+
+| Code | Surface | Meaning | Operator check |
+|---|---|---|---|
+| `auth.secret_key.configured` | session secret | The current environment has acceptable session-secret posture. | No action for this environment. |
+| `auth.secure_cookies.expected` | session cookie | Shared deployments are expected to issue Secure, HttpOnly, SameSite=Lax session cookies through app security config. | Run shared deployments with `ELBYSODIC_ENV=production` or `staging` and debug disabled. |
+| `auth.csrf.configured` | mutating forms | Server-rendered mutating forms depend on Chirp CSRF middleware and rendered `csrf_field()` inputs. | Keep POST forms rendering `csrf_field()` and keep CSRF middleware enabled in the app factory. |
+| `auth.forwarded_headers.not_trusted` | request origin | Login trust decisions do not depend on spoofable forwarded headers. | Do not add forwarded-header trust without proxy configuration and security tests. |
+| `auth.invite_only.entry` | writer entry | Public self-registration is not part of the current auth posture. | Keep new writer entry behind request-access and invitation flows until a separate registration policy is approved. |
+| `auth.deployment_environment` | deployment mode | The diagnostic names which `ELBYSODIC_ENV` posture was evaluated. | Use `production` for production and `staging` for shared seeded smoke rehearsals. |
+
+## Local Development Exceptions
+
+Local development may report:
+
+- `auth.development_identity.shortcuts`
+- non-secure local session-cookie posture
+- seed passwords enabled without demo mode
+
+Those are acceptable for local fixture work only. They are not evidence that a
+shared Railway, staging, or production deployment is safe.
+
+## Production Readiness
+
+A launch-readiness record should treat `production_blocking: yes` as a blocker
+until remediated or explicitly scoped to a staging rehearsal. A staging record
+may include `auth.demo_mode.seed_passwords` only when the smoke run is meant to
+exercise seeded demo accounts and the record says so.

--- a/docs/operations/production-bootstrap.md
+++ b/docs/operations/production-bootstrap.md
@@ -14,6 +14,9 @@ production bootstrap creates the first real director identity and realm.
 - Demo mode is off for production unless the session is explicitly a demo.
 - The redacted auth trust posture reports the expected production, demo-mode,
   secret-key minimum, session cookie, and session-required settings.
+- Auth trust warnings have been recorded by code, severity,
+  production-blocking status, and recommended fix using
+  `docs/operations/auth-trust-posture.md`.
 - A fresh backup exists, or the database is confirmed empty.
 - If a backup exists, the read-only restore-check service reports `restore-check
   ok` against the copied database without exposing secrets or private content.
@@ -39,6 +42,10 @@ production bootstrap creates the first real director identity and realm.
 ## Execution Record
 
 Record values, not secrets:
+Do not paste secrets, cookies, token hashes, passwords, raw invite tokens,
+account emails, membership names, or private notes. For auth posture, record
+only diagnostic codes, severity, production-blocking status, and recommended
+fixes.
 
 ```text
 Production bootstrap:

--- a/src/elbysodic/services/auth.py
+++ b/src/elbysodic/services/auth.py
@@ -69,6 +69,17 @@ class LoginSession:
 
 
 @dataclass(frozen=True, slots=True)
+class AuthTrustDiagnostic:
+    code: str
+    severity: str
+    surface: str
+    message: str
+    recommended_fix: str
+    production_blocking: bool
+    local_development_exception: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class AuthTrustPosture:
     environment: str
     production: bool
@@ -83,14 +94,143 @@ class AuthTrustPosture:
 
     @property
     def warnings(self) -> tuple[str, ...]:
-        warnings: list[str] = []
+        return tuple(diagnostic.message for diagnostic in self.warning_diagnostics)
+
+    @property
+    def warning_diagnostics(self) -> tuple[AuthTrustDiagnostic, ...]:
+        return tuple(
+            diagnostic
+            for diagnostic in self.diagnostics
+            if diagnostic.severity in {"blocker", "warning"}
+            or diagnostic.code == "auth.development_identity.shortcuts"
+        )
+
+    @property
+    def diagnostics(self) -> tuple[AuthTrustDiagnostic, ...]:
+        diagnostics: list[AuthTrustDiagnostic] = []
+        production_launch = self.environment in {"production", "prod"}
         if self.production and not self.secret_key_meets_minimum:
-            warnings.append("production secret key is missing or too short")
+            diagnostics.append(
+                AuthTrustDiagnostic(
+                    code="auth.secret_key.too_short",
+                    severity="blocker",
+                    surface="session secret",
+                    message="production secret key is missing or too short",
+                    recommended_fix=(
+                        "Set ELBYSODIC_SECRET_KEY to a random value with at least "
+                        "32 characters before serving a shared environment."
+                    ),
+                    production_blocking=True,
+                )
+            )
+        else:
+            diagnostics.append(
+                AuthTrustDiagnostic(
+                    code="auth.secret_key.configured",
+                    severity="ok",
+                    surface="session secret",
+                    message="session secret posture is acceptable for this environment",
+                    recommended_fix="No action needed for the current environment.",
+                    production_blocking=False,
+                )
+            )
         if self.production and self.demo_mode_enabled:
-            warnings.append("production demo mode accepts seeded demo passwords")
+            diagnostics.append(
+                AuthTrustDiagnostic(
+                    code="auth.demo_mode.seed_passwords",
+                    severity="warning",
+                    surface="demo login",
+                    message="production demo mode accepts seeded demo passwords",
+                    recommended_fix=(
+                        "Unset ELBYSODIC_DEMO_MODE for a real production launch; keep it "
+                        "only for staging or seeded demo rehearsals."
+                    ),
+                    production_blocking=production_launch,
+                    local_development_exception=self.environment == "staging",
+                )
+            )
         if not self.production and self.development_identity_allowed:
-            warnings.append("development identity shortcuts are enabled")
-        return tuple(warnings)
+            diagnostics.append(
+                AuthTrustDiagnostic(
+                    code="auth.development_identity.shortcuts",
+                    severity="note",
+                    surface="local identity",
+                    message="development identity shortcuts are enabled",
+                    recommended_fix=(
+                        "Accept this only for local development; use production or staging "
+                        "environment mode before shared smoke runs."
+                    ),
+                    production_blocking=False,
+                    local_development_exception=True,
+                )
+            )
+        diagnostics.extend(
+            (
+                AuthTrustDiagnostic(
+                    code="auth.secure_cookies.expected",
+                    severity="ok" if self.production else "note",
+                    surface="session cookie",
+                    message=(
+                        "secure session cookies are expected in production-like app configuration"
+                        if self.production
+                        else "local development may use non-secure cookies"
+                    ),
+                    recommended_fix=(
+                        "Run shared deployments with ELBYSODIC_ENV=production or staging "
+                        "and debug disabled so session cookies are Secure, HttpOnly, and "
+                        "SameSite=Lax."
+                    ),
+                    production_blocking=False,
+                    local_development_exception=not self.production,
+                ),
+                AuthTrustDiagnostic(
+                    code="auth.csrf.configured",
+                    severity="ok",
+                    surface="mutating forms",
+                    message="server-rendered mutating forms use Chirp CSRF middleware",
+                    recommended_fix=(
+                        "Keep POST forms rendering csrf_field() and keep CSRF middleware "
+                        "enabled in the app factory."
+                    ),
+                    production_blocking=False,
+                ),
+                AuthTrustDiagnostic(
+                    code="auth.forwarded_headers.not_trusted",
+                    severity="ok",
+                    surface="request origin",
+                    message="login trust decisions do not depend on spoofable forwarded headers",
+                    recommended_fix=(
+                        "Do not add forwarded-header trust without pairing it with proxy "
+                        "configuration and security tests."
+                    ),
+                    production_blocking=False,
+                ),
+                AuthTrustDiagnostic(
+                    code="auth.invite_only.entry",
+                    severity="ok",
+                    surface="writer entry",
+                    message="public self-registration is not part of the current auth posture",
+                    recommended_fix=(
+                        "Keep new writer entry behind request-access and invitation flows "
+                        "until a separate registration policy is approved."
+                    ),
+                    production_blocking=False,
+                ),
+                AuthTrustDiagnostic(
+                    code="auth.deployment_environment",
+                    severity="ok",
+                    surface="deployment mode",
+                    message=f"auth posture evaluated for {self.environment or 'development'}",
+                    recommended_fix=(
+                        "Use ELBYSODIC_ENV=production for production and staging for "
+                        "shared seeded smoke rehearsals."
+                    ),
+                    production_blocking=False,
+                    local_development_exception=not self.production,
+                ),
+            )
+        )
+        return tuple(diagnostics)
 
 
 def auth_trust_posture() -> AuthTrustPosture:
@@ -128,7 +268,18 @@ def format_auth_trust_posture(posture: AuthTrustPosture) -> str:
     ]
     if posture.warnings:
         lines.append("warnings:")
-        lines.extend(f"- {warning}" for warning in posture.warnings)
+        lines.extend(
+            (
+                "- "
+                f"[{diagnostic.code}] {diagnostic.severity}; "
+                f"surface: {diagnostic.surface}; "
+                f"production_blocking: {_yes_no(diagnostic.production_blocking)}; "
+                f"local_dev_exception: {_yes_no(diagnostic.local_development_exception)}; "
+                f"message: {diagnostic.message}; "
+                f"fix: {diagnostic.recommended_fix}"
+            )
+            for diagnostic in posture.warning_diagnostics
+        )
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_auth_contracts.py
+++ b/tests/test_auth_contracts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from elbysodic.services.auth import (
     SESSION_COOKIE,
+    AuthTrustDiagnostic,
     auth_trust_posture,
     format_auth_trust_posture,
     seed_passwords_enabled,
@@ -28,9 +29,17 @@ def test_auth_trust_posture_reports_production_demo_state_without_secret(
     assert posture.session_required_for_app_routes is True
     assert seed_passwords_enabled() is True
     assert "production demo mode accepts seeded demo passwords" in posture.warnings
+    demo_diagnostic = _diagnostic(posture.diagnostics, "auth.demo_mode.seed_passwords")
+    assert demo_diagnostic.severity == "warning"
+    assert demo_diagnostic.surface == "demo login"
+    assert demo_diagnostic.production_blocking is True
+    assert demo_diagnostic.local_development_exception is False
+    assert "Unset ELBYSODIC_DEMO_MODE" in demo_diagnostic.recommended_fix
     assert "super-secret-production-key-value" not in report
     assert "secret_key_configured: yes" in report
     assert "secret_key_meets_minimum: yes" in report
+    assert "[auth.demo_mode.seed_passwords] warning" in report
+    assert "production_blocking: yes" in report
 
 
 def test_auth_trust_posture_reports_production_secret_warning(monkeypatch) -> None:
@@ -50,8 +59,14 @@ def test_auth_trust_posture_reports_production_secret_warning(monkeypatch) -> No
     assert posture.session_required_for_app_routes is True
     assert seed_passwords_enabled() is False
     assert posture.warnings == ("production secret key is missing or too short",)
+    secret_diagnostic = _diagnostic(posture.diagnostics, "auth.secret_key.too_short")
+    assert secret_diagnostic.severity == "blocker"
+    assert secret_diagnostic.surface == "session secret"
+    assert secret_diagnostic.production_blocking is True
+    assert "32 characters" in secret_diagnostic.recommended_fix
     assert "tiny-secret-value" not in report
     assert "secret_key_meets_minimum: no" in report
+    assert "[auth.secret_key.too_short] blocker" in report
 
 
 def test_auth_trust_posture_reports_development_shortcuts(monkeypatch) -> None:
@@ -67,3 +82,45 @@ def test_auth_trust_posture_reports_development_shortcuts(monkeypatch) -> None:
     assert posture.development_identity_allowed is True
     assert posture.session_required_for_app_routes is False
     assert posture.warnings == ("development identity shortcuts are enabled",)
+    dev_diagnostic = _diagnostic(posture.diagnostics, "auth.development_identity.shortcuts")
+    assert dev_diagnostic.severity == "note"
+    assert dev_diagnostic.surface == "local identity"
+    assert dev_diagnostic.production_blocking is False
+    assert dev_diagnostic.local_development_exception is True
+    assert "local development" in dev_diagnostic.recommended_fix
+
+
+def test_auth_trust_posture_diagnostics_cover_remediation_surfaces(monkeypatch) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "production")
+    monkeypatch.delenv("ELBYSODIC_DEMO_MODE", raising=False)
+    monkeypatch.setenv("ELBYSODIC_SECRET_KEY", "x" * 32)
+
+    posture = auth_trust_posture()
+    diagnostics = {diagnostic.code: diagnostic for diagnostic in posture.diagnostics}
+
+    assert {
+        "auth.secret_key.configured",
+        "auth.secure_cookies.expected",
+        "auth.csrf.configured",
+        "auth.forwarded_headers.not_trusted",
+        "auth.invite_only.entry",
+        "auth.deployment_environment",
+    }.issubset(diagnostics)
+    assert diagnostics["auth.secure_cookies.expected"].surface == "session cookie"
+    assert "Secure, HttpOnly, and SameSite=Lax" in (
+        diagnostics["auth.secure_cookies.expected"].recommended_fix
+    )
+    assert diagnostics["auth.csrf.configured"].surface == "mutating forms"
+    assert "csrf_field()" in diagnostics["auth.csrf.configured"].recommended_fix
+    assert diagnostics["auth.forwarded_headers.not_trusted"].surface == "request origin"
+    assert "security tests" in diagnostics["auth.forwarded_headers.not_trusted"].recommended_fix
+    assert diagnostics["auth.invite_only.entry"].surface == "writer entry"
+    assert "request-access and invitation" in diagnostics["auth.invite_only.entry"].recommended_fix
+    assert all("x" * 32 not in diagnostic.recommended_fix for diagnostic in diagnostics.values())
+
+
+def _diagnostic(
+    diagnostics: tuple[AuthTrustDiagnostic, ...],
+    code: str,
+) -> AuthTrustDiagnostic:
+    return next(diagnostic for diagnostic in diagnostics if diagnostic.code == code)


### PR DESCRIPTION
## Summary

- adds structured auth trust posture diagnostics with stable codes, severity, affected surface, recommended fix, production-blocking status, and local-development exception status
- keeps the existing warning messages compatible while formatting warnings with remediation metadata
- documents the auth posture remediation guide, production bootstrap recording rules, and security-boundary contract
- adds a security changelog fragment for operator-facing diagnostics

## Steward Notes

- Consulted root constitution plus services, tests, docs, package/tooling, and changelog stewards.
- Accepted: #110 is diagnostic-only; no route, session, cookie, CSRF, login/logout, or enforcement behavior changed.
- Collateral: `docs/operations/auth-trust-posture.md`, `docs/architecture/security-boundaries.md`, `docs/operations/production-bootstrap.md`, and a security changelog fragment.
- Remaining risk: secure-cookie and CSRF entries describe configured posture and operator checks; they do not replace app/security tests for enforcement changes.

## Verification

- `uv run pytest tests/test_auth_contracts.py -q --tb=short`
- `uv run ruff check src/elbysodic/services/auth.py tests/test_auth_contracts.py`
- `uv run ruff format src/elbysodic/services/auth.py tests/test_auth_contracts.py --check`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`

Fixes #110
