### PR TITLE
Document restore-check operator contract

### DIFF
--- a/docs/operations/invite-only-alpha.md
+++ b/docs/operations/invite-only-alpha.md
@@ -80,7 +80,8 @@ Stay invite-only unless all are true:
 
 - backup/restore has been rehearsed recently
 - the copied backup reports `restore-check ok` without leaking secrets or
-  private content
+  private content, following the operator contract in
+  `docs/operations/sqlite-production.md`
 - notification/sidebar privacy tests are green
 - public catalog copy is intentional
 - signed-out preview routes expose only published public content

--- a/docs/operations/production-bootstrap.md
+++ b/docs/operations/production-bootstrap.md
@@ -19,7 +19,9 @@ production bootstrap creates the first real director identity and realm.
   `docs/operations/auth-trust-posture.md`.
 - A fresh backup exists, or the database is confirmed empty.
 - If a backup exists, the read-only restore-check service reports `restore-check
-  ok` against the copied database without exposing secrets or private content.
+  ok` against the copied database without exposing secrets or private content;
+  use the operator contract in `docs/operations/sqlite-production.md` when
+  recording the result.
 - Studio Operations shows the expected environment, database path, journal
   mode, integrity check, schema version, migration ledger, realm count, and
   launch status.

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -127,7 +127,9 @@ Staging smoke should include:
   `/elbysodic-static/seed-media/xmen-hero.svg`, returns `200`.
 - A restart preserves database row counts and rendered seeded realms.
 - A copied staging database reports `restore-check ok` through the read-only
-  restore-check service before any destructive restore rehearsal.
+  restore-check service before any destructive restore rehearsal. Use the
+  operator contract in `docs/operations/sqlite-production.md` for accepted
+  inputs, redacted output, success criteria, and failure handling.
 - Demo login works for the intended seed account policy.
 
 Known follow-up: `HEAD` requests to some app and static routes can currently

--- a/docs/operations/sqlite-production.md
+++ b/docs/operations/sqlite-production.md
@@ -136,6 +136,52 @@ continuity source links, export privacy, and auth/session posture. A blocked
 plan means operators should not mutate or restore the candidate until the named
 failure is understood.
 
+## Restore-Check Operator Contract
+
+The restore-check contract is a read-only service contract. Until a dedicated
+CLI command is approved, run it through the Python service entrypoint above and
+record only the redacted report. Adding or changing a public CLI command,
+deployment setting, destructive restore command, or repair workflow needs human
+approval before implementation.
+
+Inputs:
+
+| Input | Contract |
+|---|---|
+| Candidate path | Must be a filesystem SQLite path, not `:memory:`. |
+| Open mode | Must open the candidate read-only with `query_only` enabled. |
+| Source environment | Record local, staging, or production context without secrets. |
+| Backup metadata | Record source path, backup path, timestamp, schema version, migration version, core counts, and result when available. |
+
+Success criteria:
+
+| Check | Expected result |
+|---|---|
+| SQLite integrity | `PRAGMA integrity_check` returns `ok`. |
+| Foreign keys | `PRAGMA foreign_key_check` reports `0` violations. |
+| Schema version | SQLite `user_version`, current schema version, and latest migration version match. |
+| Realm roots | At least one community is present for a non-empty backup. |
+| Service readback | Communities, memberships, boards/materials, threads/posts, sessions, command submissions, invitations, access requests, plotting rooms, and notifications read through service/repository contracts. |
+| Restore plan | The derived restore plan has no blockers before a destructive restore is considered. |
+
+Failure modes to record:
+
+| Failure | Operator response |
+|---|---|
+| Missing file or inaccessible path | Stop; confirm volume mount, copied path, and operator permissions. |
+| In-memory path | Stop; restore-check requires a copied filesystem database. |
+| Integrity failure | Stop; do not trust row-level readback until the SQLite failure is understood. |
+| Foreign-key violation | Stop; treat as tenant or persistence integrity risk. |
+| Schema or migration mismatch | Stop; align app code, migrations, and candidate database before restore. |
+| Empty or wrong database | Stop; confirm the source path and backup timestamp before any cutover. |
+| Service readback failure | Stop; inspect the named domain and keep the candidate out of production. |
+
+Redaction rules:
+
+| Never record | Acceptable record |
+|---|---|
+| Secret keys, cookies, session tokens, token hashes, passwords, raw invite tokens, reset links, credentials, private notes, post bodies, application answers, private material bodies, or applicant emails. | Status, counts, schema and migration versions, journal mode, integrity result, foreign-key violation count, readback labels, blocker labels, and non-secret file paths. |
+
 For tenant-boundary incidents, migration rehearsals, imported data, or
 pre-launch checks, use the read-only tenant integrity audit service before any
 manual repair. The service groups findings by community and severity, names the


### PR DESCRIPTION
## Summary
- adds a restore-check operator contract covering read-only inputs, success criteria, failure modes, and redaction rules
- links Railway smoke, production bootstrap, and invite-only alpha runbooks back to the SQLite operations contract

Closes #169

## Proof
- git diff --check
- uv run pytest -q tests/test_forum_slice.py -k restore_check --tb=short
- app check for create_app(debug=False, db_path=":memory:").check()

## Not run
- full ruff/ty/pytest gate; docs-only contract update with focused restore-check proof

## Steward Notes
- Docs steward: centralized the operator contract in SQLite production docs and kept the other runbooks as references.
- Storage/ops boundary: no CLI, config, deploy, schema, migration, or destructive restore behavior changed.
- Changelog: no fragment; no user/operator-visible command or runtime behavior changed.

## Tracker correction
- The original PR body accidentally referenced #166 because the pickup issues were created in parallel and returned out of numeric order. #166 was reopened and remains the tenant integrity audit matrix task; #169 is the restore-check task completed by this PR.