### PR TITLE
Document access request lifecycle matrix

### DIFF
--- a/docs/architecture/rendered-route-privacy-matrix.md
+++ b/docs/architecture/rendered-route-privacy-matrix.md
@@ -89,6 +89,8 @@ hidden state.
   creation. Public and account-visitor previews must not reveal request notes,
   email addresses, face concepts, wanted-hook interest, invitation links, or
   review state; same-community directors inspect and act on them from Studio.
+  The lifecycle and visibility matrix lives in
+  `docs/architecture/security-boundaries.md`.
 - Inactive memberships are absent from `/members`, `/members/{username}`, and
   direct character profile routes, and recovery does not offer cross-realm
   switches for inactive faces.

--- a/docs/architecture/request-identity-and-command-protocol.md
+++ b/docs/architecture/request-identity-and-command-protocol.md
@@ -114,6 +114,11 @@ Identity-switch `next` recovery applies the same rule to stale community paths.
 Character, application, wanted, world-material, plotting-room, board, and
 thread destinations must either remain valid inside the selected realm or fall
 back to a safe local hub for that route family.
+Access-request recovery follows the lifecycle matrix in
+`docs/architecture/security-boundaries.md`: duplicate, account-link, replayed
+invite, decline, withdrawal, and expiry states cannot reveal request notes,
+invitation links, raw tokens, staff review state, or another community's
+request history.
 
 ## Notification Read Models
 

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -142,17 +142,55 @@ or active-face state. The account-link event is recorded for director-visible
 history, but it does not change request status or expose private request details
 to the applicant or public preview.
 
-The access-request lifecycle is `pending -> reviewed -> invited` or
-`pending/reviewed -> declined`. An invited request may link to the invitation
-row that was created from it, but the raw invite token is still shown only at
-creation time because stored invitations retain token hashes. A lost link
-requires revoking the pending invitation and creating a fresh one; the original
-access request remains the audit trail for why the invite was issued.
+The access-request lifecycle is service-owned and director-private. It is the
+planning contract for #107, #86, #57, and #139, not approval to add schema,
+routes, token behavior, or privacy-boundary changes without a separate review.
+Access requests are interest records; only explicit invitation acceptance can
+create or reuse a global `User`, create `CommunityMembership`, create a first
+face, select session identity, or hand the writer into first-face/application
+work.
+
+| State | Entry Transition | Allowed Next Transitions | Idempotency And Replay | Visibility |
+|---|---|---|---|---|
+| `submitted` / `pending` | Public or account visitor submits request access for one community. | Account link, director review, decline, invite, withdraw or expire when implemented. | Duplicate open request for the same community/email returns or links the existing record; it does not create membership, role, face, invite, reserve, claim, session, or active-face state. | Public/account visitor may see receipt posture only; same-community directors may inspect details. |
+| `account_linked` | Signed-in account submits or claims a duplicate request for the same email. | Review, decline, invite, withdraw or expire when implemented. | Repeated account-link attempts are no-ops when linked to the same user; wrong-account or cross-community attempts must fail without exposing another request. | Applicant still cannot see review notes, invite linkage, staff history, or other applicant data. |
+| `reviewed` | Director marks the request reviewed or records director-only context. | Invite, decline, withdraw or expire when implemented. | Re-review updates director workflow state only through an approved service transition; it must not send or recover an invite token. | Director-only; hidden from public, account visitors, ordinary members, inactive members, and other communities. |
+| `invited` | Director creates an invitation from the request. | Invite acceptance through `/invite/{token}`, revoke/reissue while pending, or expire when implemented. | Replayed invite creation should reuse the existing linked invitation or require explicit reissue; raw invite token is visible only at creation/reissue. | Directors may see linked invitation state; applicant never sees the raw token from request status. |
+| `accepted` | Invitation token is accepted and creates/reuses account plus local membership. | First-face or application handoff. | Replaying the accepted token fails without exposing Studio, staff queues, or membership internals. | Writer sees the invited realm membership path; access-request notes and director review history remain staff-only. |
+| `declined` | Director declines the request. | Reopen only through a separately approved transition. | Duplicate submissions after decline follow the approved duplicate/reopen policy; they must not reveal prior notes or invitation state. | Applicant may see generic closed or received posture if surfaced; director details stay private. |
+| `withdrawn` | Applicant withdraws interest when that route exists. | Reopen through a new request or approved recovery path. | Replayed withdraw is a no-op; director history remains audit-only. | Public/account view must not expose director notes or staff state. |
+| `expired` | System or director expiry closes stale interest when implemented. | New request or explicit director reactivation. | Replayed links and stale actions fail closed. | Expiry reason is director-private unless a public-safe receipt state is approved. |
+
+Visibility rules:
+
+| Viewer | May See | Must Not See |
+|---|---|---|
+| Public visitor | Public request-access form, receipt posture, and realm-safe entry copy. | Applicant email from another request, private notes, review state, invitation link, account-link history, staff queues, or membership state. |
+| Account visitor | Account-linked request posture for their own submitted email in the current community. | Director notes, invite linkage, raw token, another account's request, or local membership controls before invitation acceptance. |
+| Ordinary member | Public-safe preview and member shell for their own realm. | Request queue, applicant notes, invitation state, account-link history, or director review state. |
+| Inactive member | Public-safe preview or recovery copy only. | Request queue, switch options, private request data, staff controls, or local entry grants. |
+| Director/staff with capability | Current-community request details, lifecycle history, duplicate/account-link context, and linked invitation state. | Raw invite token after creation/reissue, token hashes, passwords, sessions, other-community requests, or unrelated applicant data. |
+| Cross-community staff/director | Nothing beyond public-safe preview for the target realm. | Request existence, applicant email, notes, review state, linked invitation, lifecycle history, or counts. |
+
+Transition proof required before implementation:
+
+- Service tests for legal transitions, duplicate email recovery,
+  same-account idempotency, wrong-account replay, stale invite replay, decline,
+  withdrawal, and expiry once those states become behavior.
+- Rendered privacy tests for public visitor, account visitor, ordinary member,
+  inactive member, same-community director, and cross-community staff/director
+  if any route or read model changes.
+- Security tests proving raw tokens appear only in creation/reissue responses
+  and token hashes, private notes, applicant emails, and staff review history do
+  not leak through public/account/member surfaces.
+- Repository tests proving request, event, invitation, actor membership, and
+  account link rows remain scoped to the same `community_id`.
+
 Director-visible access-request activity events are stored in
 `community_access_request_events` with `community_id`, request id, optional
 actor membership, status transition, optional invitation id, and timestamp.
-Submitted, account-linked, reviewed, invited, and declined events are staff
-workflow history, not public preview data.
+Submitted, account-linked, reviewed, invited, accepted, declined, withdrawn,
+and expired events are staff workflow history, not public preview data.
 
 Community export manifests are director-only backend read models. They may count
 community-scoped workflow rows and preserve source links, membership ownership,

--- a/docs/operations/invite-only-alpha.md
+++ b/docs/operations/invite-only-alpha.md
@@ -42,6 +42,9 @@ replica, and explicit smoke evidence before writers are invited.
   duplicate for the same email should link that account to the existing open
   request instead of creating a second queue item or granting membership. Studio
   records that account-link event in the director-visible request history.
+- Use the access-request lifecycle matrix in
+  `docs/architecture/security-boundaries.md` before changing request review,
+  duplicate, invitation, withdrawal, expiry, or replay behavior.
 
 ### Invitation Delivery Policy
 

--- a/docs/product/invite-to-first-face-onboarding-journey.md
+++ b/docs/product/invite-to-first-face-onboarding-journey.md
@@ -14,8 +14,10 @@ public preview -> request access or invitation -> local membership -> first face
 
 This guide does not define the backend lifecycle for access requests,
 invitations, membership creation, sessions, claims, reserves, or applications.
-Those stay in the existing backend issues. This guide defines what rendered
-pages must communicate while using those service-owned contracts.
+The access-request state and privacy matrix lives in
+`docs/architecture/security-boundaries.md`; other backend lifecycle work stays
+in the existing backend issues. This guide defines what rendered pages must
+communicate while using those service-owned contracts.
 
 ## Journey States
 


### PR DESCRIPTION
## Summary
- expands the access-request lifecycle contract into explicit states, transitions, idempotency/replay posture, and visibility rules
- links the rendered privacy matrix, request identity protocol, onboarding journey, and invite-only alpha runbook back to the canonical lifecycle matrix
- names required service, rendered privacy, security, and repository proof for future behavior changes

Closes #167

## Proof
- git diff --check
- uv run pytest -q tests/test_onboarding_journey_contracts.py tests/test_web_security.py -k "access_request or request_access or invite or invitation or duplicate" --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

## Not run
- full ruff/ty/pytest gate; docs-only lifecycle matrix with focused onboarding/security proof

## Steward Notes
- Docs steward: canonicalized the backend lifecycle matrix in security boundaries and kept product/runbook docs as cross-links.
- Surface/security boundary: no route, schema, token, invitation, service, CSRF, privacy, or runtime behavior changed.
- User panel: applicant/account visitor anxieties are addressed by separating request receipt, director-only state, invite linkage, and first-face handoff.
- Changelog: no fragment; no user/operator-visible behavior changed.