### PR TITLE
Add access request replay regression proof

### DIFF
--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -429,6 +429,17 @@ def test_production_signed_in_duplicate_access_request_links_existing_record(
                 headers={"Cookie": _cookie_header(cookies)},
             )
             request_cookies = {**cookies, **_cookie_values(request_access)}
+            before_memberships = services.repo.list_memberships(community.id)
+            before_characters = services.repo.list_community_characters(community.id)
+            before_invitations = services.repo.list_community_invitations(community.id)
+            before_claims = services.repo.list_character_claims(community.id, status=None)
+            before_reserves = services.repo.list_character_reserves_for_community(
+                community.id,
+                status=None,
+            )
+            before_session_count = services.repo.connection.execute(
+                "SELECT COUNT(*) FROM user_sessions"
+            ).fetchone()[0]
             response = await client.post(
                 "/request-access",
                 body=urlencode(
@@ -457,6 +468,18 @@ def test_production_signed_in_duplicate_access_request_links_existing_record(
         assert requests[0].id == existing.id
         assert requests[0].account_user_id == moira.id
         assert requests[0].display_name == "Anonymous Moira"
+        assert services.repo.list_memberships(community.id) == before_memberships
+        assert services.repo.list_community_characters(community.id) == before_characters
+        assert services.repo.list_community_invitations(community.id) == before_invitations
+        assert services.repo.list_character_claims(community.id, status=None) == before_claims
+        assert (
+            services.repo.list_character_reserves_for_community(community.id, status=None)
+            == before_reserves
+        )
+        assert (
+            services.repo.connection.execute("SELECT COUNT(*) FROM user_sessions").fetchone()[0]
+            == before_session_count
+        )
         with pytest.raises(LookupError):
             services.repo.get_membership_for_user(community.id, moira.id)
 


### PR DESCRIPTION
## Summary
- strengthens duplicate signed-in access-request regression proof
- verifies duplicate account-link replay does not create membership, face, invitation, claim, reserve, session, or active-face state
- keeps existing assertion that the anonymous request is linked instead of duplicated

Closes #178

## Proof
- git diff --check
- uv run pytest -q tests/test_web_security.py -k "duplicate_access_request" --tb=short
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"

## Not run
- full ruff/ty/pytest gate; test-only access-request replay regression proof

## Steward Notes
- Security/onboarding: test-only coverage against the lifecycle matrix; no schema, route, token, privacy, invitation, membership, session, claim/reserve, or runtime behavior changed.