### PR TITLE
[codex] Add restore-check read-only blocker proof

### DIFF
--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -12792,6 +12792,36 @@ def test_restore_plan_from_check_orders_read_only_operator_steps(tmp_path: Path)
     assert "Do not emit this restore plan body." not in report
 
 
+def test_restore_plan_blocks_writable_restore_check_result() -> None:
+    result = RestoreCheckResult(
+        database_path="/private/tmp/candidate.sqlite3",
+        opened_read_only=False,
+        integrity_check="ok",
+        foreign_key_violations=0,
+        journal_mode="wal",
+        sqlite_user_version=1,
+        current_schema_version=1,
+        latest_migration_version=1,
+        community_count=1,
+        core_counts=(),
+        readback_checks=(RestoreCheckReadback("communities", "ok", "1 community row read back"),),
+        failures=(),
+    )
+
+    plan = restore_plan_from_check(result)
+    report = format_restore_plan_report(plan)
+    read_only_blockers = [
+        step for step in plan.blockers if step.source == "restore_check.opened_read_only"
+    ]
+
+    assert plan.status == "blocked"
+    assert len(read_only_blockers) == 1
+    assert read_only_blockers[0].title == "Open candidate database read-only"
+    assert read_only_blockers[0].human_confirmation_required is True
+    assert "restore-plan blocked" in report
+    assert "destructive restore command" not in report
+
+
 def test_restore_plan_from_check_maps_blockers_to_sensitive_domains() -> None:
     result = RestoreCheckResult(
         database_path="/private/tmp/candidate.sqlite3",


### PR DESCRIPTION
## Summary

- adds a restore-plan regression for a restore-check result that was not opened read-only
- asserts the operator plan blocks on `restore_check.opened_read_only` and requires human confirmation
- keeps the slice test-only with no CLI, route, schema, deployment, or destructive restore changes

Closes #184

## Validation

- `uv run pytest tests/test_forum_slice.py -q --tb=short -k restore_plan`
- `uv run ruff check tests/test_forum_slice.py`
- `uv run ruff format tests/test_forum_slice.py --check`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`
