### PR TITLE
[codex] Add auth staging demo posture proof

### DIFF
--- a/tests/test_auth_contracts.py
+++ b/tests/test_auth_contracts.py
@@ -42,6 +42,32 @@ def test_auth_trust_posture_reports_production_demo_state_without_secret(
     assert "production_blocking: yes" in report
 
 
+def test_auth_trust_posture_allows_staging_demo_rehearsal_without_launch_blocker(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "staging")
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+    monkeypatch.setenv("ELBYSODIC_SECRET_KEY", "staging-demo-secret-value-123456")
+
+    posture = auth_trust_posture()
+    report = format_auth_trust_posture(posture)
+
+    assert posture.production is True
+    assert posture.environment == "staging"
+    assert posture.demo_mode_enabled is True
+    assert posture.seed_passwords_enabled is True
+    assert posture.secret_key_meets_minimum is True
+    assert posture.session_required_for_app_routes is True
+    demo_diagnostic = _diagnostic(posture.diagnostics, "auth.demo_mode.seed_passwords")
+    assert demo_diagnostic.severity == "warning"
+    assert demo_diagnostic.production_blocking is False
+    assert demo_diagnostic.local_development_exception is True
+    assert "staging or seeded demo rehearsals" in demo_diagnostic.recommended_fix
+    assert "staging-demo-secret-value-123456" not in report
+    assert "[auth.demo_mode.seed_passwords] warning" in report
+    assert "production_blocking: no" in report
+
+
 def test_auth_trust_posture_reports_production_secret_warning(monkeypatch) -> None:
     monkeypatch.setenv("ELBYSODIC_ENV", "staging")
     monkeypatch.delenv("ELBYSODIC_DEMO_MODE", raising=False)


### PR DESCRIPTION
## Summary

- adds auth trust posture proof for `ELBYSODIC_ENV=staging` with demo mode enabled
- asserts staging remains production-like for session posture while the demo-mode diagnostic is a warning, not a real production-launch blocker
- verifies the formatted posture report does not include the configured secret value

Closes #186

## Validation

- `uv run pytest tests/test_auth_contracts.py -q --tb=short`
- `uv run ruff check tests/test_auth_contracts.py`
- `uv run ruff format tests/test_auth_contracts.py --check`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `uv run pytest -q --tb=short`
