### PR TITLE
[codex] Move member role badge posture into read models

### DIFF
--- a/src/elbysodic/services/identity.py
+++ b/src/elbysodic/services/identity.py
@@ -170,12 +170,14 @@ def member_profile(repo: IdentityRepository, viewer: ForumView, username: str) -
     membership = repo.get_membership_by_username(viewer.community.id, username)
     if not membership.is_active:
         raise LookupError(f"membership not found in community {viewer.community.id}: {username}")
+    role = repo.get_role(viewer.community.id, membership.role_id)
     roster = repo.list_characters(viewer.community.id, membership.id)
     roster_ids = {character.id for character in roster}
     active_threads = thread_obligations(repo, viewer, roster_ids)
     return MemberProfile(
         membership=membership,
-        role=repo.get_role(viewer.community.id, membership.role_id),
+        role=role,
+        role_badge_variant=_role_badge_variant(membership, role),
         roster=roster,
         default_character=default_character(roster, membership.default_character_id),
         known_for=known_for_characters(repo, viewer, roster, limit=3),
@@ -288,13 +290,15 @@ def member_directory_card(
     viewer: ForumView,
     membership: CommunityMembership,
 ) -> MemberDirectoryCard:
+    role = repo.get_role(viewer.community.id, membership.role_id)
     roster = repo.list_characters(viewer.community.id, membership.id)
     roster_ids = {character.id for character in roster}
     active_threads = thread_obligations(repo, viewer, roster_ids)
     latest_posts = recent_character_posts(repo, viewer, roster_ids, limit=1)
     return MemberDirectoryCard(
         membership=membership,
-        role=repo.get_role(viewer.community.id, membership.role_id),
+        role=role,
+        role_badge_variant=_role_badge_variant(membership, role),
         roster=roster,
         default_character=default_character(roster, membership.default_character_id),
         known_for=known_for_characters(repo, viewer, roster, limit=2),
@@ -303,6 +307,15 @@ def member_directory_card(
         latest_post=latest_posts[0] if latest_posts else None,
         is_current_member=membership.id == viewer.membership.id,
     )
+
+
+def _role_badge_variant(membership: CommunityMembership, role: Role) -> str:
+    if any(
+        policies.has_capability(membership, role, capability)
+        for capability in policies.ADMIN_CAPABILITIES
+    ):
+        return "warning"
+    return "muted"
 
 
 def default_character(

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -786,6 +786,7 @@ class ApplicationReviewRoom:
 class MemberDirectoryCard:
     membership: CommunityMembership
     role: Role
+    role_badge_variant: str
     roster: list[Character]
     default_character: Character | None
     known_for: list[Character]
@@ -963,6 +964,7 @@ class WriterCollaborator:
 class MemberProfile:
     membership: CommunityMembership
     role: Role
+    role_badge_variant: str
     roster: list[Character]
     default_character: Character | None
     known_for: list[Character]

--- a/src/elbysodic/web/pages/members/page.html
+++ b/src/elbysodic/web/pages/members/page.html
@@ -46,7 +46,7 @@
         </div>
         <div class="chirpui-cluster chirpui-cluster--sm">
           {{ badge("you", variant="success") if card.is_current_member else "" }}
-          {{ badge(card.role.name, variant="warning" if card.role.is_admin else "muted") }}
+          {{ badge(card.role.name, variant=card.role_badge_variant) }}
         </div>
       </div>
       <div class="elbysodic-command-panel__metrics elbysodic-member-card__metrics" aria-label="{{ card.membership.display_name }} writing totals">

--- a/src/elbysodic/web/pages/members/{username}/page.html
+++ b/src/elbysodic/web/pages/members/{username}/page.html
@@ -32,7 +32,7 @@
         <div class="chirpui-cluster chirpui-cluster--sm">
           <h2>{{ profile.membership.display_name }}</h2>
           {{ badge("you", variant="success") if profile.is_current_member else "" }}
-          {{ badge(profile.role.name, variant="warning" if profile.role.is_admin else "muted") }}
+          {{ badge(profile.role.name, variant=profile.role_badge_variant) }}
         </div>
         <p class="elbysodic-copy-meta">@{{ profile.membership.username }}</p>
         {% if profile.default_character %}

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -91,9 +91,10 @@ def test_staff_capability_contracts_cover_named_helpers(
         assert contract.audit_event_candidates
 
 
-def test_page_handlers_and_services_do_not_check_admin_flag_directly() -> None:
+def test_page_handlers_templates_and_services_do_not_check_admin_flag_directly() -> None:
     checked_paths = [
         *Path("src/elbysodic/web/pages").rglob("page.py"),
+        *Path("src/elbysodic/web/pages").rglob("*.html"),
         *(
             path
             for path in Path("src/elbysodic/services").glob("*.py")


### PR DESCRIPTION
## Summary

- Moves member directory/profile role badge variant decisions into service read models.
- Updates member templates to consume the read-model badge variant instead of checking the V1 role admin storage flag.
- Extends the policy static guard so page templates cannot inspect role.is_admin directly.

Closes #200.

## Validation

- uv run pytest -q --tb=short tests/test_policies.py::test_page_handlers_templates_and_services_do_not_check_admin_flag_directly tests/test_forum_slice.py::test_members_directory_and_profile_show_visible_community_cast
- uv run ruff check .
- uv run ruff format . --check
- uv run pytest -q --tb=short
- uv run ty check src/elbysodic/ tests/
- uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"