### PR TITLE
Complete Cloud CI epic (#213)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,19 @@ jobs:
           PYTHON_GIL: "0"
         run: make contract-diff CONTRACT_DIFF_BASE=origin/${{ github.base_ref || 'main' }}
 
-      - name: Test suite
+      - name: Changelog enforcement
+        run: make changelog-check
+
+      - name: Validate changed changelog fragments
+        if: github.event_name == 'pull_request'
+        run: |
+          BASE="origin/${{ github.base_ref }}"
+          FILES=$(git diff --name-only --diff-filter=ACMRT "$BASE"...HEAD -- 'changelog.d/*.md' || true)
+          if [ -n "$FILES" ]; then
+            uv run python scripts/check_changelog_fragments.py $FILES
+          fi
+
+      - name: Test suite with coverage
         env:
           PYTHON_GIL: "0"
-        run: make test
+        run: make test-cov

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ make ci
 Useful commands:
 
 - `make test` runs the test suite.
+- `make test-cov` runs tests with coverage; CI enforces an 80% floor via pytest-cov.
 - `make lint` runs Ruff.
 - `make format` formats the project.
 - `make format-check` checks Ruff formatting.

--- a/changelog.d/+cloud-ci-gates.changed.md
+++ b/changelog.d/+cloud-ci-gates.changed.md
@@ -1,0 +1,1 @@
+GitHub Actions CI now enforces changelog fragments, towncrier checks, and an 80% pytest-cov coverage floor alongside the existing lint, typecheck, and contract gates.


### PR DESCRIPTION
## Summary
- Add `make changelog-check` and PR-only changelog fragment validation to GitHub Actions CI
- Switch the test step from `make test` to `make test-cov`, enforcing the existing 80% pytest-cov floor
- Document the coverage gate in README

Closes remaining acceptance criteria for #213.

## Test plan
- [ ] CI workflow runs green on this PR
- [ ] `make changelog-check` passes locally
- [ ] `make test-cov` reports coverage above 80%

Made with [Cursor](https://cursor.com)