### PR TITLE
Honor cluster justification intent

### DIFF
--- a/changelog.d/+cluster-justification.changed.md
+++ b/changelog.d/+cluster-justification.changed.md
@@ -1,0 +1,1 @@
+Clustered headings, status badges, and form actions now honor their intended split or end alignment across writer and Studio surfaces.

--- a/src/elbysodic/web/pages/studio/page.html
+++ b/src/elbysodic/web/pages/studio/page.html
@@ -1086,7 +1086,7 @@
         <li>
           <div class="chirpui-stack chirpui-stack--xs">
             <a href="/world/{{ item.material.slug }}">{{ item.material.title }}</a>
-            <div class="chirpui-cluster elbysodic-cluster--start">
+            <div class="chirpui-cluster">
               {{ badge(item.type_label, variant="muted") }}
               <form method="post">
         {{ csrf_field() }}

--- a/src/elbysodic/web/static/elbysodic-theme/10-chirp-primitives.css
+++ b/src/elbysodic/web/static/elbysodic-theme/10-chirp-primitives.css
@@ -32,3 +32,12 @@
     border-color: var(--chirpui-border);
 }
 
+@layer app.overrides {
+    .chirpui-cluster.elbysodic-cluster--between {
+        justify-content: space-between;
+    }
+
+    .chirpui-cluster.elbysodic-cluster--end {
+        justify-content: flex-end;
+    }
+}

--- a/tests/test_theme_css.py
+++ b/tests/test_theme_css.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts/check_theme_css.py"
@@ -13,3 +14,30 @@ SPEC.loader.exec_module(check_theme_css)
 
 def test_theme_css_manifest_and_owner_ledgers_are_valid() -> None:
     assert check_theme_css.validate_theme_css() == []
+
+
+def test_cluster_alignment_modifiers_have_owned_layout_rules() -> None:
+    theme_css = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(check_theme_css.THEME_DIR.glob("*.css"))
+    )
+    assert re.search(
+        r"\.elbysodic-cluster--between\s*\{[^}]*justify-content:\s*space-between",
+        theme_css,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"\.elbysodic-cluster--end\s*\{[^}]*justify-content:\s*flex-end",
+        theme_css,
+        re.DOTALL,
+    )
+
+    pages_root = Path(__file__).resolve().parents[1] / "src/elbysodic/web/pages"
+    modifiers = {
+        modifier
+        for path in pages_root.rglob("*.html")
+        for modifier in re.findall(
+            r"elbysodic-cluster--([a-z-]+)",
+            path.read_text(encoding="utf-8"),
+        )
+    }
+    assert modifiers <= {"between", "end"}


### PR DESCRIPTION
## Summary

- define app-owned `between` and `end` justification rules for Chirp clusters in `@layer app.overrides`
- remove the lone redundant `start` modifier, leaving every cluster modifier behavior-bearing
- add regression proof that only defined alignment modifiers appear in templates
- record the user-visible alignment change

Closes #250.

## Why

The Chirp-UI upgrade renamed phantom cluster modifiers to preserve layout, but the app never supplied their intended justification. Headings/status rows and form/action rows therefore rendered with the base cluster alignment despite carrying explicit intent.

## User impact

Status badges and split actions now occupy opposite edges where intended, while save, publish, reserve, and other form actions align at the inline end. Cluster wrapping remains intact for narrow layouts.

## Steward notes

- Consulted: Rendering/UI, Surface Contract, Test Steward, and the simulated Elbysodic persona panel.
- Accepted: honor the existing `between` and `end` intent with one shared app-layer contract; remove the default `start` no-op.
- Deferred/not now: upstreaming a `cluster(justify=...)` API to Chirp-UI.
- No docs/privacy collateral: this changes presentation only; service read models, route audiences, identity, capability, and rendered privacy contracts are unchanged.

## Validation

Passed:

- `uv run pytest tests/test_theme_css.py -q --tb=short`
- `uv run ruff check tests/test_theme_css.py`
- `uv run ruff format tests/test_theme_css.py --check`
- `uv run ty check tests/test_theme_css.py`
- `uv run python scripts/check_theme_css.py`
- `uv run python scripts/kida_check.py`
- `.venv/bin/chirp check elbysodic.web.contract_app:app --baseline tests/fixtures/chirp_hypermedia_baseline.json`
- production app check
- `git diff --check`

Browser QA:

- deep Playwright crawl produced desktop/tablet/mobile screenshots for the affected writer, wanted, claims, application, thread, world, and Studio surfaces
- inspected desktop wanted/Studio and mobile claims output; intended alignment and wrapping render correctly
- the full harness still reports existing tablet `h1` overflow checks on world/location routes and skips protected Studio launch/discovery routes with 403

Known upstream gate failures unrelated to this diff:

- `make ci` stops on pre-existing Ruff findings in `src/elbysodic/web/app.py` and `tests/test_chirp_hypermedia_contract.py`
- full pytest has one reproducible failure in `tests/test_cli.py::test_create_app_closes_internally_created_services_on_shutdown` because `FakeAppServices` lacks `_database`
- full ty reports the existing Pounce/`DrainingAwareApp` diagnostic set
