### PR TITLE
Retire legacy Chirp-UI utility classes

### DIFF
--- a/changelog.d/+legacy-utility-migration.changed.md
+++ b/changelog.d/+legacy-utility-migration.changed.md
@@ -1,0 +1,1 @@
+Accessibility labels and muted scene metadata now use app-owned styles instead of Chirp-UI compatibility utilities, preserving their behavior through future framework upgrades.

--- a/scripts/check_theme_css.py
+++ b/scripts/check_theme_css.py
@@ -9,10 +9,55 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 THEME_ENTRYPOINT = REPO_ROOT / "src/elbysodic/web/static/elbysodic-theme.css"
 THEME_DIR = REPO_ROOT / "src/elbysodic/web/static/elbysodic-theme"
+PAGES_DIR = REPO_ROOT / "src/elbysodic/web/pages"
 EMPTY_SELECTOR_FILES = {
     "50-page-compositions.css": "composition review queue",
     "90-legacy.css": "legacy ledger",
 }
+LEGACY_CHIRPUI_UTILITY_CLASSES = frozenset(
+    {
+        "chirpui-clamp-2",
+        "chirpui-clamp-3",
+        "chirpui-display",
+        "chirpui-display--xl",
+        "chirpui-focus-ring",
+        "chirpui-font-2xl",
+        "chirpui-font-base",
+        "chirpui-font-lg",
+        "chirpui-font-medium",
+        "chirpui-font-mono",
+        "chirpui-font-sm",
+        "chirpui-font-xl",
+        "chirpui-font-xs",
+        "chirpui-list-reset",
+        "chirpui-mb-md",
+        "chirpui-measure-lg",
+        "chirpui-measure-md",
+        "chirpui-measure-sm",
+        "chirpui-min-w-0",
+        "chirpui-mt-md",
+        "chirpui-mt-sm",
+        "chirpui-placeholder-inline",
+        "chirpui-prose-lg",
+        "chirpui-prose-sm",
+        "chirpui-scroll-x",
+        "chirpui-text-muted",
+        "chirpui-truncate",
+        "chirpui-ui-base",
+        "chirpui-ui-bold",
+        "chirpui-ui-label",
+        "chirpui-ui-lg",
+        "chirpui-ui-medium",
+        "chirpui-ui-meta",
+        "chirpui-ui-normal",
+        "chirpui-ui-semibold",
+        "chirpui-ui-sm",
+        "chirpui-ui-title",
+        "chirpui-ui-xl",
+        "chirpui-ui-xs",
+        "chirpui-visually-hidden",
+    }
+)
 EXTERNALLY_PROVIDED_PROPERTIES = {
     "--elbysodic-preview-accent",
     "--elbysodic-preview-bg",
@@ -25,6 +70,7 @@ _IMPORT_RE = re.compile(r'@import\s+url\("\./elbysodic-theme/([^"]+\.css)"\);')
 _SELECTOR_RE = re.compile(r"^(?:[.#]|[a-z][\w-]*(?:[.#:\[]|\s|,|>|\+|~))", re.IGNORECASE)
 _CUSTOM_PROPERTY_DEFINITION_RE = re.compile(r"(?<![\w-])(--[A-Za-z0-9_-]+)\s*:")
 _CUSTOM_PROPERTY_REFERENCE_RE = re.compile(r"var\(\s*(--[A-Za-z0-9_-]+)(\s*,)?")
+_CHIRPUI_CLASS_RE = re.compile(r"\bchirpui-[a-z0-9-]+\b")
 
 
 def imported_theme_files(entrypoint: Path = THEME_ENTRYPOINT) -> list[str]:
@@ -83,10 +129,29 @@ def theme_custom_property_errors(
     ]
 
 
+def legacy_chirpui_utility_errors(pages_dir: Path = PAGES_DIR) -> list[str]:
+    errors: list[str] = []
+    for path in sorted(pages_dir.rglob("*.html")):
+        try:
+            display_path = path.relative_to(REPO_ROOT)
+        except ValueError:
+            display_path = path
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            legacy_classes = sorted(
+                set(_CHIRPUI_CLASS_RE.findall(line)) & LEGACY_CHIRPUI_UTILITY_CLASSES
+            )
+            errors.extend(
+                f"{display_path}:{line_number} uses legacy Chirp-UI utility {name}"
+                for name in legacy_classes
+            )
+    return errors
+
+
 def validate_theme_css(
     *,
     entrypoint: Path = THEME_ENTRYPOINT,
     theme_dir: Path = THEME_DIR,
+    pages_dir: Path = PAGES_DIR,
 ) -> list[str]:
     errors: list[str] = []
     imports = imported_theme_files(entrypoint)
@@ -122,6 +187,7 @@ def validate_theme_css(
             )
 
     errors.extend(theme_custom_property_errors(entrypoint=entrypoint, theme_dir=theme_dir))
+    errors.extend(legacy_chirpui_utility_errors(pages_dir))
 
     return errors
 

--- a/src/elbysodic/web/pages/_components/network_catalog.html
+++ b/src/elbysodic/web/pages/_components/network_catalog.html
@@ -21,7 +21,7 @@ A realm ready for scenes, casting, and writer movement.
 {% call tooltip(label, position="left", cls="elbysodic-network-card__tooltip") %}
   <a class="elbysodic-network-card__icon-action" href="{{ href }}" aria-label="{{ label }}">
     <span aria-hidden="true">{{ icon | icon }}</span>
-    <span class="chirpui-visually-hidden">{{ label }}</span>
+    <span class="elbysodic-visually-hidden">{{ label }}</span>
   </a>
 {% end %}
 {% end %}
@@ -38,7 +38,7 @@ A realm ready for scenes, casting, and writer movement.
          style="--elbysodic-network-accent: {{ program.theme_preview.accent }}; --elbysodic-network-surface: {{ program.theme_preview.surface }}; --elbysodic-network-text: {{ program.theme_preview.text }}; --elbysodic-network-display-font: {{ program.theme_preview.display_font }};"
          {% if preview %}data-elbysodic-discovery-preview-card{% end %}>
   <a class="elbysodic-network-card__realm-link" href="{{ program.entry_href }}" aria-label="Preview {{ program.community.name }}">
-    <span class="chirpui-visually-hidden">Preview {{ program.community.name }}</span>
+    <span class="elbysodic-visually-hidden">Preview {{ program.community.name }}</span>
   </a>
   <a class="elbysodic-network-card__poster" href="{{ program.entry_href }}">
     {% if program.community.world_hero_image_url %}

--- a/src/elbysodic/web/pages/_components/posts.html
+++ b/src/elbysodic/web/pages/_components/posts.html
@@ -65,7 +65,7 @@
 {% call surface(variant="elevated", cls=post_shell_cls, style=post_shell_style) %}
 <article id="{{ item.anchor }}"
          class="elbysodic-post elbysodic-post--{{ item.author.slug }}">
-  <span id="post-id-{{ item.post.id }}" class="chirpui-visually-hidden" aria-hidden="true"></span>
+  <span id="post-id-{{ item.post.id }}" class="elbysodic-visually-hidden" aria-hidden="true"></span>
   {{ post_profile_rail(item) }}
   <div class="elbysodic-post__body">
     <header class="elbysodic-post__meta">

--- a/src/elbysodic/web/pages/_components/thread_summary.html
+++ b/src/elbysodic/web/pages/_components/thread_summary.html
@@ -179,7 +179,7 @@
       {{ post.author.name }}
     </a>
     · writer <a class="chirpui-link" href="/members/{{ post.author_membership.username }}">{{ post.author_membership.username }}</a>
-    <span class="chirpui-text-muted">
+    <span class="elbysodic-text-muted">
       in
       <a class="chirpui-link" href="/boards/{{ board.slug }}">{{ board.name }}</a>
       · {{ post.created_at_label }}

--- a/src/elbysodic/web/pages/_components/ui.html
+++ b/src/elbysodic/web/pages/_components/ui.html
@@ -10,7 +10,7 @@
 <span class="elbysodic-counter" title="{{ value }} {{ label }}" aria-label="{{ value }} {{ label }}">
   <span class="elbysodic-counter__mark" aria-hidden="true">{{ mark }}</span>
   <span class="elbysodic-counter__value">{{ value }}</span>
-  <span class="elbysodic-counter__label chirpui-visually-hidden">{{ label }}</span>
+  <span class="elbysodic-counter__label elbysodic-visually-hidden">{{ label }}</span>
 </span>
 {% end %}
 

--- a/src/elbysodic/web/pages/_layout.html
+++ b/src/elbysodic/web/pages/_layout.html
@@ -250,7 +250,7 @@
 
 {% def topbar_search(scope_label, query="", compact_label="") %}
 <form class="elbysodic-topbar-search" action="/search" method="get" role="search" hx-boost="false">
-  <label class="chirpui-visually-hidden" for="elbysodic-topbar-search-input">Search {{ scope_label }}</label>
+  <label class="elbysodic-visually-hidden" for="elbysodic-topbar-search-input">Search {{ scope_label }}</label>
   <span class="elbysodic-topbar-search__scope">
     <span class="elbysodic-topbar-search__scope-full">{{ scope_label }}</span>
     <span class="elbysodic-topbar-search__scope-short">{{ compact_label or scope_label }}</span>

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.html
@@ -93,7 +93,7 @@
         {{ composer_view_toggle("thread-composer-view") }}
       </div>
       <div class="elbysodic-composer-body" x-show="!previewMode">
-        <label class="chirpui-visually-hidden" for="thread-body">Opening post</label>
+        <label class="elbysodic-visually-hidden" for="thread-body">Opening post</label>
         {{ composer_toolbar("thread-body") }}
       <textarea id="thread-body"
                 class="chirpui-field__input"

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.html
@@ -126,7 +126,7 @@
                 title="Scene actions"
                 @click.prevent="toggleInspector()">
           <span aria-hidden="true">{{ "logs" | icon }}</span>
-          <span class="chirpui-visually-hidden">Scene actions</span>
+          <span class="elbysodic-visually-hidden">Scene actions</span>
         </button>
       </div>
     </aside>
@@ -134,7 +134,7 @@
 
   {% call thread_reader_layout(label="Scene transcript", cls="elbysodic-thread-reader-layout") %}
   {% slot header %}
-  <h2 id="scene-transcript-title" class="chirpui-visually-hidden">Scene posts</h2>
+  <h2 id="scene-transcript-title" class="elbysodic-visually-hidden">Scene posts</h2>
   {% end %}
 
   {% slot local_nav %}
@@ -224,7 +224,7 @@
           {{ composer_view_toggle("reply-composer-view") }}
         </div>
         <div class="elbysodic-composer-body" x-show="!previewMode">
-          <label class="chirpui-visually-hidden" for="reply-body">Reply body</label>
+          <label class="elbysodic-visually-hidden" for="reply-body">Reply body</label>
           <textarea id="reply-body"
                     name="body"
                     class="chirpui-field__input"

--- a/src/elbysodic/web/pages/identity/page.html
+++ b/src/elbysodic/web/pages/identity/page.html
@@ -45,7 +45,7 @@
               {{ csrf_field() }}
               <input type="hidden" name="intent" value="rename_passkey">
               <input type="hidden" name="passkey_id" value="{{ passkey.id }}">
-              <label class="chirpui-visually-hidden" for="passkey-label-{{ passkey.id }}">New name for {{ passkey.label or "this passkey" }}</label>
+              <label class="elbysodic-visually-hidden" for="passkey-label-{{ passkey.id }}">New name for {{ passkey.label or "this passkey" }}</label>
               <input id="passkey-label-{{ passkey.id }}"
                      class="chirpui-field__input"
                      name="label"

--- a/src/elbysodic/web/pages/members/{username}/page.html
+++ b/src/elbysodic/web/pages/members/{username}/page.html
@@ -168,7 +168,7 @@
     <article class="elbysodic-activity-item">
       <div class="elbysodic-activity-item__meta">
         <a class="chirpui-link" href="/characters/{{ item.post.author.slug }}">{{ item.post.author.name }}</a>
-        <span class="chirpui-text-muted">
+        <span class="elbysodic-text-muted">
           in
           <a class="chirpui-link" href="/boards/{{ item.board.slug }}">{{ item.board.name }}</a>
           · {{ item.post.created_at_label }}

--- a/src/elbysodic/web/pages/studio/intake/page.html
+++ b/src/elbysodic/web/pages/studio/intake/page.html
@@ -134,7 +134,7 @@
           {{ csrf_field() }}
           <input type="hidden" name="intent" value="apply_blueprint">
           <input type="hidden" name="preview_fingerprint" value="{{ blueprint_preview.preview_fingerprint }}">
-          <textarea class="chirpui-field__input chirpui-visually-hidden"
+          <textarea class="chirpui-field__input elbysodic-visually-hidden"
                     name="blueprint_yaml"
                     aria-label="Blueprint YAML for gated apply">{{ blueprint_yaml }}</textarea>
           <p class="chirpui-field__label">Apply readiness review</p>

--- a/src/elbysodic/web/static/elbysodic-theme.css
+++ b/src/elbysodic/web/static/elbysodic-theme.css
@@ -6,6 +6,7 @@
 
 @import url("./elbysodic-theme/00-tokens.css");
 @import url("./elbysodic-theme/10-chirp-primitives.css");
+@import url("./elbysodic-theme/15-app-utilities.css");
 @import url("./elbysodic-theme/20-shell.css");
 @import url("./elbysodic-theme/30-page-patterns.css");
 @import url("./elbysodic-theme/35-media-patterns.css");

--- a/src/elbysodic/web/static/elbysodic-theme/15-app-utilities.css
+++ b/src/elbysodic/web/static/elbysodic-theme/15-app-utilities.css
@@ -1,0 +1,21 @@
+/* Small, app-owned utilities with stable semantic jobs.
+ *
+ * Keep these independent of Chirp-UI's compatibility utility classes so
+ * framework upgrades cannot remove accessibility or hierarchy behavior.
+ */
+
+.elbysodic-visually-hidden {
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    height: 1px;
+    margin: -1px;
+    overflow: clip;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.elbysodic-text-muted {
+    color: var(--chirpui-text-muted);
+}

--- a/tests/test_theme_css.py
+++ b/tests/test_theme_css.py
@@ -13,3 +13,32 @@ SPEC.loader.exec_module(check_theme_css)
 
 def test_theme_css_manifest_and_owner_ledgers_are_valid() -> None:
     assert check_theme_css.validate_theme_css() == []
+
+
+def test_legacy_chirpui_utility_gate_reports_template_and_line(tmp_path: Path) -> None:
+    template = tmp_path / "sample.html"
+    template.write_text(
+        '<span class="chirpui-visually-hidden">Scene label</span>\n',
+        encoding="utf-8",
+    )
+
+    errors = check_theme_css.legacy_chirpui_utility_errors(tmp_path)
+
+    assert errors == [f"{template}:1 uses legacy Chirp-UI utility chirpui-visually-hidden"]
+
+
+def test_app_owned_accessibility_utilities_preserve_behavior() -> None:
+    css = (check_theme_css.THEME_DIR / "15-app-utilities.css").read_text(encoding="utf-8")
+
+    assert ".elbysodic-visually-hidden" in css
+    for declaration in (
+        "clip: rect(0, 0, 0, 0);",
+        "height: 1px;",
+        "overflow: clip;",
+        "position: absolute;",
+        "white-space: nowrap;",
+        "width: 1px;",
+    ):
+        assert declaration in css
+    assert ".elbysodic-text-muted" in css
+    assert "color: var(--chirpui-text-muted);" in css


### PR DESCRIPTION
## Summary

- replace all 13 remaining Chirp-UI compatibility utilities in app templates
- add app-owned screen-reader-only and muted-metadata styles
- add a gate covering the full Chirp-UI 0.11 compatibility-token set
- preserve accessibility and visual hierarchy through future framework upgrades

Closes #234.

## Why

Chirp-UI marks its typography and spacing utilities as compatibility-only and may move them before 1.0. Elbysodic still depended on `chirpui-visually-hidden` for 11 accessibility labels and `chirpui-text-muted` for two scene metadata rows.

## User impact

There is no intended visual or workflow change. Screen-reader labels remain programmatically available, and scene metadata retains the same muted color. The behavior is now owned by the app instead of a framework compatibility layer.

## Steward notes

- Consulted: Rendering/UI, Test, Changelog, and the simulated Active Writer, Applicant, Staff, and Safety-Boundary panel lenses.
- Accepted: retain exact screen-reader-only behavior; never replace labels with `hidden` or `display:none`; preserve muted metadata hierarchy.
- No service/privacy collateral: route audiences, read models, identity, permissions, and rendered data are unchanged.
- Browser QA not required: this is a behavior-preserving class ownership migration with exact CSS declaration proof.

## Validation

Passed:

- `pytest tests/test_theme_css.py -q --tb=short`
- `ruff check scripts/check_theme_css.py tests/test_theme_css.py`
- `ruff format scripts/check_theme_css.py tests/test_theme_css.py --check`
- `python scripts/check_theme_css.py`
- `python scripts/kida_check.py`
- production app check
- route smoke, hypermedia baseline, and affected passkey identity render tests
- focused `ty` check
- changelog fragment validation
- `git diff --check`
- zero legacy compatibility tokens found under `src/elbysodic/web/pages/`

Known upstream gate state:

- `main` is already red under open issue #213; its unrelated lint, wrapper-typing, and lifecycle-test defects are not included here.
