### PR TITLE
Add response-shape conformance matrix

### DIFF
--- a/tests/test_response_shape_conformance.py
+++ b/tests/test_response_shape_conformance.py
@@ -1,0 +1,119 @@
+"""Full, boosted, and targeted response-shape contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from chirp.testing import TestClient
+
+from elbysodic.db.seed import DemoSeed, resolve_seed_persona
+from elbysodic.services import AppServices, create_services
+from elbysodic.web import create_app
+
+_DOCUMENT_WRAPPERS = ("<!DOCTYPE", "<html", "<body")
+_SHELL_OUTLET_MARKERS = (
+    'id="main"',
+    'hx-select="#page-content"',
+    'id="page-content"',
+    'id="page-root"',
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _AudienceRoute:
+    name: str
+    path: str
+    content_marker: str
+
+
+_MEMBER_ROUTES = (
+    _AudienceRoute("network", "/network", 'id="network-explore-heading"'),
+    _AudienceRoute("character", "/characters/rogue", 'aria-label="Rogue posts"'),
+)
+_STAFF_ROUTES = (_AudienceRoute("director", "/studio", "Director Studio"),)
+
+
+def _assert_contains(response_text: str, markers: tuple[str, ...], *, case: str) -> None:
+    for marker in markers:
+        assert marker in response_text, f"{case} is missing {marker!r}"
+
+
+def _assert_omits(response_text: str, markers: tuple[str, ...], *, case: str) -> None:
+    for marker in markers:
+        assert marker not in response_text, f"{case} unexpectedly contains {marker!r}"
+
+
+async def _assert_response_matrix(
+    client: TestClient,
+    routes: tuple[_AudienceRoute, ...],
+) -> None:
+    for route in routes:
+        full = await client.get(route.path)
+        full_case = f"{route.name} full document"
+        assert full.status == 200, full_case
+        assert full.header("X-Chirp-Render-Intent") == "full_page", full_case
+        _assert_contains(
+            full.text,
+            (*_DOCUMENT_WRAPPERS, *_SHELL_OUTLET_MARKERS, route.content_marker),
+            case=full_case,
+        )
+        _assert_omits(full.text, ("hx-swap-oob",), case=full_case)
+
+        boosted = await client.boosted(route.path, target="main")
+        boosted_case = f"{route.name} boosted shell outlet"
+        assert boosted.status == 200, boosted_case
+        assert boosted.header("X-Chirp-Render-Intent") == "fragment", boosted_case
+        _assert_contains(
+            boosted.text,
+            (
+                *_DOCUMENT_WRAPPERS,
+                *_SHELL_OUTLET_MARKERS,
+                route.content_marker,
+                "hx-swap-oob",
+            ),
+            case=boosted_case,
+        )
+
+        targeted = await client.fragment(route.path, target="page-root")
+        targeted_case = f"{route.name} targeted fragment"
+        assert targeted.status == 200, targeted_case
+        assert targeted.header("X-Chirp-Render-Intent") == "fragment", targeted_case
+        _assert_contains(
+            targeted.text,
+            (route.content_marker, "hx-swap-oob"),
+            case=targeted_case,
+        )
+        _assert_omits(
+            targeted.text,
+            (*_DOCUMENT_WRAPPERS, *_SHELL_OUTLET_MARKERS),
+            case=targeted_case,
+        )
+
+
+def test_member_response_shape_matrix_preserves_the_negotiated_shell() -> None:
+    """Boosted documents stay safe because #main selects only #page-content."""
+
+    async def run() -> None:
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+        async with TestClient(app.chirp_app) as client:
+            await _assert_response_matrix(client, _MEMBER_ROUTES)
+
+    asyncio.run(run())
+
+
+def test_staff_response_shape_matrix_preserves_the_director_boundary() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        staff = resolve_seed_persona(services.repo, "xmen_staff")
+        app = create_app(
+            debug=False,
+            services=AppServices(
+                services.repo,
+                DemoSeed(staff.community, staff.user, staff.membership, staff.character),
+            ),
+        )
+        async with TestClient(app.chirp_app) as client:
+            await _assert_response_matrix(client, _STAFF_ROUTES)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

- add a full / boosted / targeted response-shape conformance matrix for network, character, and director surfaces
- prove boosted `#main` responses keep fragment intent, OOB shell updates, and the `hx-select="#page-content"` safety boundary
- prove targeted `#page-root` fragments omit document and shell wrappers

## Why

Issue #235 calls for the Furantena response-matrix idiom adapted to Elbysodic. Existing route smoke checked render intent, but did not encode the complete response envelope across member and staff audiences.

The coverage gap could allow a shell selector or response shape to drift without a focused failure.

## Impact

This is test-only regression proof; runtime behavior, routes, privacy policy, and product UI are unchanged.

Refs #235

## Validation

- `ruff check tests/test_response_shape_conformance.py`
- `ruff format tests/test_response_shape_conformance.py --check`
- `ty check tests/test_response_shape_conformance.py`
- `pytest -n 2 tests/test_response_shape_conformance.py tests/test_route_smoke.py tests/test_link_integrity.py tests/test_chirp_hypermedia_contract.py -q --tb=short` (9 passed)
- `python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`

## Steward Notes

- Consulted: Surface Contract and Test stewards.
- Accepted: semantic response markers for member, character, and director audiences; proof runs in the parallel-safe lane.
- Collateral: no docs or changelog; this PR records existing behavior without changing a user-visible or public contract.
- Remaining scope: #235 still tracks contract baseline/diff CI, deploy escalation, declaration cleanup, and agent-facing MCP work.
