### PR TITLE
Adopt Chirp-UI inline counters

### DIFF
--- a/changelog.d/+inline-counter-adoption.changed.md
+++ b/changelog.d/+inline-counter-adoption.changed.md
@@ -1,0 +1,1 @@
+Scene, board, discovery, and world counts now use the shared Chirp-UI metadata treatment with visible labels.

--- a/src/elbysodic/web/pages/_components/boards.html
+++ b/src/elbysodic/web/pages/_components/boards.html
@@ -1,9 +1,10 @@
 {% imports %}
   {% from "chirpui/ascii_icon.html" import ascii_icon %}
   {% from "chirpui/badge.html" import badge %}
+  {% from "chirpui/inline_counter.html" import inline_counter %}
   {% from "chirpui/surface.html" import surface %}
   {% from "_components/facets.html" import facet_pills %}
-  {% from "_components/ui.html" import counter, latest_line, meta_hint %}
+  {% from "_components/ui.html" import latest_line, meta_hint %}
 {% end %}
 
 {% def board_media_image(board, cls) %}
@@ -72,10 +73,10 @@ elbysodic-board-media--{{ board.slug }} elbysodic-board-media-treatment--{{ boar
 
 {% def board_stat_row(summary, viewer, include_children=True) %}
 <div class="elbysodic-board-stat-row">
-  {{ counter("T", summary.thread_count, "threads") }}
-  {{ counter("P", summary.post_count, "posts") }}
+  {{ inline_counter("T", summary.thread_count, "threads") }}
+  {{ inline_counter("P", summary.post_count, "posts") }}
   {% if include_children and summary.child_boards %}
-  {{ counter(">", summary.child_boards | length, "places") }}
+  {{ inline_counter(">", summary.child_boards | length, "places") }}
   {% end %}
   {% if summary.unread_thread_count %}
   {{ badge(summary.unread_thread_count ~ " new", variant="info") }}

--- a/src/elbysodic/web/pages/_components/thread_summary.html
+++ b/src/elbysodic/web/pages/_components/thread_summary.html
@@ -1,8 +1,9 @@
 {% imports %}
   {% from "chirpui/badge.html" import badge %}
+  {% from "chirpui/inline_counter.html" import inline_counter %}
   {% from "chirpui/surface.html" import surface %}
   {% from "_components/facets.html" import facet_pills %}
-  {% from "_components/ui.html" import cast_faces, counter, latest_line %}
+  {% from "_components/ui.html" import cast_faces, latest_line %}
 {% end %}
 
 {% def thread_card(board, thread, author, author_membership, participants, facets, latest_post, jump_post, jump_label, last_own_post, reply_count, is_unread, badges, heading_level, show_board_name, show_last_own_post, episode=None) %}
@@ -92,7 +93,7 @@
     </div>
     {% if reply_count %}
     <div class="elbysodic-thread-card__metrics">
-      {{ counter("chat" | icon, reply_count, "replies") }}
+      {{ inline_counter("chat" | icon, reply_count, "replies") }}
     </div>
     {% end %}
     {% if facets %}
@@ -151,7 +152,7 @@
     {% for item_badge in badges %}
     {{ badge(item_badge.label, variant=item_badge.variant) }}
     {% end %}
-    {{ counter("R", reply_count, "replies") if reply_count else "" }}
+    {{ inline_counter("R", reply_count, "replies") if reply_count else "" }}
     {{ cast_faces(participants, label="Cast") }}
   </div>
   {% if latest_post %}

--- a/src/elbysodic/web/pages/_components/ui.html
+++ b/src/elbysodic/web/pages/_components/ui.html
@@ -6,14 +6,6 @@
   {% from "chirpui/timeline.html" import timeline %}
 {% end %}
 
-{% def counter(mark, value, label) %}
-<span class="elbysodic-counter" title="{{ value }} {{ label }}" aria-label="{{ value }} {{ label }}">
-  <span class="elbysodic-counter__mark" aria-hidden="true">{{ mark }}</span>
-  <span class="elbysodic-counter__value">{{ value }}</span>
-  <span class="elbysodic-counter__label chirpui-visually-hidden">{{ label }}</span>
-</span>
-{% end %}
-
 {% def page_section(title, summary="", heading_id=none, cls="") %}
 <section class="elbysodic-page-section{{ " " ~ cls if cls else "" }}" {% if heading_id %}aria-labelledby="{{ heading_id }}"{% end %}>
   <div class="elbysodic-page-section__header">

--- a/src/elbysodic/web/pages/discover/page.html
+++ b/src/elbysodic/web/pages/discover/page.html
@@ -1,9 +1,9 @@
 {% imports %}
   {% from "chirpui/badge.html" import badge %}
+  {% from "chirpui/inline_counter.html" import inline_counter %}
   {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
   {% from "chirpui/surface.html" import surface %}
   {% from "_components/facets.html" import facet_filter_link, facet_pills %}
-  {% from "_components/ui.html" import counter %}
 {% end %}
 
 {% block page_root %}
@@ -144,7 +144,7 @@
             <a class="chirpui-link" href="/characters/{{ result.author.slug }}">{{ result.author.name }}</a>
           </p>
         </div>
-        {{ counter("R", result.reply_count, "replies") }}
+        {{ inline_counter("R", result.reply_count, "replies") }}
       </div>
       {% if result.thread.summary %}
       <p class="elbysodic-copy-summary">{{ result.thread.summary }}</p>

--- a/src/elbysodic/web/pages/world/{material_slug}/page.html
+++ b/src/elbysodic/web/pages/world/{material_slug}/page.html
@@ -1,10 +1,11 @@
 {% imports %}
   {% from "chirpui/detail_header.html" import detail_header %}
+  {% from "chirpui/inline_counter.html" import inline_counter %}
   {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "chirpui/surface.html" import surface %}
   {% from "_components/boards.html" import board_signal %}
   {% from "_components/facets.html" import facet_pills %}
-  {% from "_components/ui.html" import cast_faces, continuity_timeline, counter, inline_nav, inline_nav_link, scene_state_badges, studio_facts %}
+  {% from "_components/ui.html" import cast_faces, continuity_timeline, inline_nav, inline_nav_link, scene_state_badges, studio_facts %}
   {% from "_components/wanted.html" import wanted_card %}
 {% end %}
 
@@ -24,7 +25,7 @@
   </div>
   {{ scene_state_badges(item.thread) }}
   <div class="elbysodic-material-scene-card__footer">
-    {{ counter("R", item.reply_count, "replies") }}
+    {{ inline_counter("R", item.reply_count, "replies") }}
     {{ cast_faces(item.participants) }}
   </div>
 </article>

--- a/src/elbysodic/web/static/elbysodic-theme/40-pbp-components.css
+++ b/src/elbysodic/web/static/elbysodic-theme/40-pbp-components.css
@@ -94,39 +94,6 @@ a.elbysodic-metric:focus-visible {
     letter-spacing: 0;
 }
 
-.elbysodic-counter {
-    align-items: center;
-    color: var(--chirpui-text-muted);
-    display: inline-flex;
-    font-size: var(--chirpui-font-sm);
-    gap: 0.28rem;
-    line-height: 1;
-    min-height: 1.6rem;
-}
-
-.elbysodic-counter__mark {
-    align-items: center;
-    background: color-mix(in srgb, var(--chirpui-accent) 10%, var(--chirpui-bg-subtle));
-    border: 1px solid var(--chirpui-border-subtle);
-    border-radius: var(--chirpui-radius-sm);
-    color: var(--chirpui-text-muted);
-    display: inline-flex;
-    font-size: var(--chirpui-font-xs);
-    font-weight: 900;
-    height: 1.25rem;
-    justify-content: center;
-    min-width: 1.25rem;
-}
-
-.elbysodic-counter__value {
-    color: var(--chirpui-text);
-    font-weight: 800;
-}
-
-.elbysodic-counter__label {
-    color: var(--chirpui-text-muted);
-}
-
 .elbysodic-signal {
     display: grid;
     gap: 0.15rem;

--- a/src/elbysodic/web/static/elbysodic-theme/41-boards-places.css
+++ b/src/elbysodic/web/static/elbysodic-theme/41-boards-places.css
@@ -689,21 +689,21 @@
     color: var(--elbysodic-on-media-muted);
 }
 
-.elbysodic-board-stage .elbysodic-counter {
+.elbysodic-board-stage .chirpui-inline-counter {
     color: var(--elbysodic-on-media-muted);
 }
 
-.elbysodic-board-stage .elbysodic-counter__mark {
+.elbysodic-board-stage .chirpui-inline-counter__mark {
     background: var(--elbysodic-on-media-chip-bg);
     border-color: var(--elbysodic-on-media-chip-border);
     color: var(--elbysodic-on-media-muted);
 }
 
-.elbysodic-board-stage .elbysodic-counter__value {
+.elbysodic-board-stage .chirpui-inline-counter__value {
     color: var(--elbysodic-on-media-text);
 }
 
-.elbysodic-board-stage .elbysodic-counter__label {
+.elbysodic-board-stage .chirpui-inline-counter__label {
     color: var(--elbysodic-on-media-muted);
 }
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -7516,7 +7516,8 @@ def test_world_materials_render_pillars_events_and_application_guides() -> None:
             assert "elbysodic-continuity-timeline" in event.text
             assert "elbysodic-continuity-timeline__title-link" in event.text
             assert "Event opened" in event.text
-            assert "elbysodic-counter__label chirpui-visually-hidden" in event.text
+            assert "chirpui-inline-counter__label" in event.text
+            assert ">replies</span>" in event.text
 
             location = await client.get("/boards/frozen-midtown")
             assert location.status == 200

--- a/tests/test_frontend_surface_contracts.py
+++ b/tests/test_frontend_surface_contracts.py
@@ -144,3 +144,25 @@ def test_access_and_search_surfaces_keep_labelled_controls() -> None:
         text = (PAGES / template_path).read_text(encoding="utf-8")
         for snippet in required_snippets:
             assert snippet in text, f"{template_path} is missing {snippet!r}"
+
+
+def test_compact_counts_use_the_chirp_ui_inline_counter() -> None:
+    migrated_templates = (
+        "_components/boards.html",
+        "_components/thread_summary.html",
+        "discover/page.html",
+        "world/{material_slug}/page.html",
+    )
+
+    for template_path in migrated_templates:
+        text = (PAGES / template_path).read_text(encoding="utf-8")
+        assert 'from "chirpui/inline_counter.html" import inline_counter' in text
+        assert "inline_counter(" in text
+        assert 'from "_components/ui.html" import counter' not in text
+        assert "{{ counter(" not in text
+
+    shared_ui = (PAGES / "_components/ui.html").read_text(encoding="utf-8")
+    assert "{% def counter(" not in shared_ui
+
+    theme = (REPO_ROOT / "src/elbysodic/web/static/elbysodic-theme").glob("*.css")
+    assert all(".elbysodic-counter" not in path.read_text(encoding="utf-8") for path in theme)


### PR DESCRIPTION
## Summary

- replace the hand-rolled `counter()` macro at all seven call sites with Chirp-UI's stable `inline_counter()`
- delete the redundant app-owned counter component CSS while preserving the board-stage contrast override against the library classes
- make compact count labels visible on scene, board, discovery, and world surfaces
- add a static migration ratchet, rendered proof, and a changelog fragment

## Why

Issue #231 calls for shared data-display primitives to move to Chirp-UI ownership. Elbysodic's counter macro duplicated the library component but hid its label, leaving writers to decode marks such as `R`, `T`, and `P`.

This slice removes that duplicate component completely while retaining the app-specific media contrast treatment.

## Impact

Writers and directors now see compact labels such as `replies`, `threads`, and `posts`. No counts, routes, permissions, privacy boundaries, or data behavior change.

Refs #231

## Validation

- `python scripts/kida_check.py`
- `pytest tests/test_theme_css.py tests/test_frontend_surface_contracts.py tests/test_chirp_hypermedia_contract.py -q --tb=short` (19 passed)
- focused forum route tests for discovery, world materials, and seeded boards (3 passed)
- `create_app(...).check()`
- changed-file Ruff checks and changelog-fragment validation
- focused Playwright QA at 1440px and 390px: 22 counters per viewport across discovery, event, and board surfaces; all labels visible; no counter or document overflow
- smoke browser QA generated desktop/tablet/mobile screenshots; its only findings were pre-existing tablet `h1` overflow on RL world and locations

## Known base failures

The repository-wide gates still inherit #213:

- Ruff: import ordering in `web/app.py` and S603 in `test_chirp_hypermedia_contract.py`
- format check: pre-existing drift in `web/app.py` and `test_forum_slice.py`
- typing: 208 existing diagnostics around the draining app wrapper and Pounce monkeypatches
- full pytest: first failure remains `test_create_app_closes_internally_created_services_on_shutdown` because `FakeAppServices` lacks `_database`

## Steward Notes

- Consulted: Rendering/UI, Test, Changelog, and a local synthetic user panel.
- Accepted: use the library primitive directly; keep labels visible; preserve board-stage contrast; add rendered and static ratchets.
- Synthetic panel confidence: medium. Visible labels reduce mark decoding without adding new metadata or privacy exposure.
- Collateral: rendered/static tests and a user-facing changelog fragment.
- Deferred: the remaining #231 component migrations.
