### PR TITLE
Adopt Chirp-UI metadata tooltips

### DIFF
--- a/changelog.d/+shared-metadata-tooltips.changed.md
+++ b/changelog.d/+shared-metadata-tooltips.changed.md
@@ -1,0 +1,1 @@
+Active-face board hints and latest-scene details now use the shared Chirp-UI tooltip treatment, with board relevance also announced and revealed on keyboard focus.

--- a/src/elbysodic/web/pages/_components/boards.html
+++ b/src/elbysodic/web/pages/_components/boards.html
@@ -2,8 +2,9 @@
   {% from "chirpui/ascii_icon.html" import ascii_icon %}
   {% from "chirpui/badge.html" import badge %}
   {% from "chirpui/surface.html" import surface %}
+  {% from "chirpui/tooltip.html" import tooltip %}
   {% from "_components/facets.html" import facet_pills %}
-  {% from "_components/ui.html" import counter, latest_line, meta_hint %}
+  {% from "_components/ui.html" import counter, latest_line %}
 {% end %}
 
 {% def board_media_image(board, cls) %}
@@ -21,10 +22,10 @@ elbysodic-board-media--{{ board.slug }} elbysodic-board-media-treatment--{{ boar
 {% def board_poster(summary, viewer=None, compact=False, tile=False, title_level="h2") %}
 <a class="elbysodic-board-poster {{ board_media_classes(summary.board) }} {{ "elbysodic-board-poster--compact" if compact else "" }}{{ " elbysodic-board-poster--tile" if tile else "" }}"
    href="{{ summary.href }}"
-   aria-label="{{ summary.board.name }}">
+   aria-label="{{ summary.board.name }}{{ " · Relevant to active face" if viewer and summary.is_relevant_to_current_face and viewer.current_character else "" }}">
   {{ board_media_image(summary.board, "elbysodic-board-poster__media") }}
   {% if viewer and summary.is_relevant_to_current_face and viewer.current_character %}
-  {% call meta_hint("Relevant to the active face: this location shares one of their world lenses.", position="left", cls="elbysodic-board-poster__face-signal-hint") %}
+  {% call tooltip("Relevant to the active face: this location shares one of their world lenses.", position="left", cls="elbysodic-board-poster__face-signal-hint") %}
     <span class="elbysodic-board-poster__face-signal"
           aria-label="Relevant to the active face">
       {{ ascii_icon("user" | icon, size="sm", cls="elbysodic-board-poster__face-icon") }}

--- a/src/elbysodic/web/pages/_components/ui.html
+++ b/src/elbysodic/web/pages/_components/ui.html
@@ -4,6 +4,7 @@
   {% from "chirpui/badge.html" import badge %}
   {% from "chirpui/description_list.html" import description_item, description_list %}
   {% from "chirpui/timeline.html" import timeline %}
+  {% from "chirpui/tooltip.html" import tooltip %}
 {% end %}
 
 {% def counter(mark, value, label) %}
@@ -69,23 +70,12 @@
 </a>
 {% end %}
 
-{% def meta_hint(hint, position="top", cls="") %}
-{% set pos = position if position in ("top", "bottom", "left", "right") else "top" %}
-{% set pos_class = "chirpui-tooltip--bottom" if pos == "bottom" else ("chirpui-tooltip--left" if pos == "left" else ("chirpui-tooltip--right" if pos == "right" else "chirpui-tooltip--top")) %}
-<span class="chirpui-tooltip {{ pos_class }} elbysodic-meta-hint{{ " " ~ cls if cls else "" }}"
-      data-chirpui-tooltip
-      data-tooltip="{{ hint | e }}">
-  {% slot %}
-  <span class="chirpui-tooltip__bubble" role="tooltip">{{ hint }}</span>
-</span>
-{% end %}
-
 {% def latest_line(label, href, title, author=None, author_href=None, writer=None, writer_href=None, updated=None) %}
 <div class="elbysodic-latest">
   <span class="elbysodic-latest__label">{{ label }}</span>
   {% set detail = ((("by " ~ author) if author else "") ~ ((" · writer " ~ writer) if writer else "") ~ ((" · " ~ updated) if updated else "")) %}
   {% if detail %}
-  {% call meta_hint("Latest details: " ~ title ~ " · " ~ detail, position="top", cls="elbysodic-latest__tooltip") %}
+  {% call tooltip("Latest details: " ~ title ~ " · " ~ detail, position="top", cls="elbysodic-latest__tooltip") %}
     <a class="elbysodic-latest__title" href="{{ href }}">{{ title }}</a>
   {% end %}
   {% else %}

--- a/src/elbysodic/web/static/elbysodic-theme/41-boards-places.css
+++ b/src/elbysodic/web/static/elbysodic-theme/41-boards-places.css
@@ -210,17 +210,28 @@
     text-shadow: 0 2px 12px rgba(0, 0, 0, 0.45);
 }
 
-.elbysodic-board-poster__face-signal-hint {
-    display: inline-flex;
-    inset-block-start: 0.75rem;
-    inset-inline-end: 0.75rem;
-    position: absolute;
-    z-index: 2;
+.elbysodic-board-poster__face-signal-hint .chirpui-tooltip__bubble {
+    max-width: min(12rem, calc(100vw - 2rem));
+}
+
+.elbysodic-board-poster:focus-visible
+    .elbysodic-board-poster__face-signal-hint
+    .chirpui-tooltip__bubble {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
 }
 
 .elbysodic-board-poster > :not(.elbysodic-board-poster__media) {
     position: relative;
     z-index: 2;
+}
+
+.elbysodic-board-poster > .elbysodic-board-poster__face-signal-hint {
+    display: inline-flex;
+    inset-block-start: 0.75rem;
+    inset-inline-end: 0.75rem;
+    position: absolute;
+    z-index: 3;
 }
 
 .elbysodic-board-poster__face-signal {

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -3187,6 +3187,11 @@ def test_forum_pages_render_seeded_boards_and_thread() -> None:
             assert "written by" in board.text
             assert "Next unread" in board.text
             assert "Magneto" in board.text
+            assert (
+                'class="chirpui-tooltip chirpui-tooltip--top '
+                'elbysodic-latest__tooltip"' in board.text
+            )
+            assert 'data-tooltip="Latest details:' in board.text
 
             thread = await client.get("/boards/plotting/threads/open-thread-roster")
             assert thread.status == 200
@@ -6396,6 +6401,15 @@ def test_board_pages_render_location_stage_and_place_tiles() -> None:
             assert "elbysodic-location-compass" in academy.text
             assert "What is playable here" in academy.text
             assert "Relevant to the active face" in academy.text
+            assert 'aria-label="Med Bay · Relevant to active face"' in academy.text
+            assert (
+                'class="chirpui-tooltip chirpui-tooltip--left '
+                'elbysodic-board-poster__face-signal-hint"' in academy.text
+            )
+            assert (
+                'data-tooltip="Relevant to the active face: this location '
+                'shares one of their world lenses."' in academy.text
+            )
             assert "Plot pressure" in academy.text
             assert "No scene spotlight yet" in academy.text
             assert "Total" in academy.text

--- a/tests/test_frontend_surface_contracts.py
+++ b/tests/test_frontend_surface_contracts.py
@@ -144,3 +144,17 @@ def test_access_and_search_surfaces_keep_labelled_controls() -> None:
         text = (PAGES / template_path).read_text(encoding="utf-8")
         for snippet in required_snippets:
             assert snippet in text, f"{template_path} is missing {snippet!r}"
+
+
+def test_metadata_hints_use_the_chirp_ui_tooltip() -> None:
+    shared_ui = (PAGES / "_components/ui.html").read_text(encoding="utf-8")
+    boards = (PAGES / "_components/boards.html").read_text(encoding="utf-8")
+
+    for text in (shared_ui, boards):
+        assert 'from "chirpui/tooltip.html" import tooltip' in text
+        assert "{% call tooltip(" in text
+
+    assert "{% def meta_hint(" not in shared_ui
+    assert all(
+        "meta_hint" not in path.read_text(encoding="utf-8") for path in PAGES.rglob("*.html")
+    )


### PR DESCRIPTION
## Summary

- replace both uses of the hand-rolled `meta_hint` wrapper with Chirp-UI's stable `tooltip()` component
- remove the duplicated wrapper from `_components/ui.html`
- make active-face board relevance part of the poster's accessible label
- restore the hint's intended top-right position and reveal its bubble on keyboard focus
- add static and rendered ratchets plus a changelog fragment

## Why

Issue #231 calls for app-owned tooltip wrappers to move to Chirp-UI ownership.

The migration audit also found two inherited call-site defects: a later generic child rule overrode the hint's absolute positioning, and keyboard focus landed on the containing board link rather than inside the tooltip wrapper. The old left-edge bubble consequently rendered beneath the persistent sidebar or outside the mobile canvas.

## Impact

Latest-scene details retain their existing hover/focus behavior. Active-face hints now sit at the intended top-right of board artwork, remain inside the poster/viewport, open when the board link receives keyboard focus, and announce relevance through the link's accessible name.

No routes, data, counts, permissions, or privacy boundaries change.

Refs #231

## Validation

- `python scripts/kida_check.py`
- focused rendered/theme/frontend contracts (19 passed)
- changed-file Ruff and targeted `ty` checks
- `create_app(...).check()`
- changelog-fragment validation
- Playwright at 1440px and 390px:
  - latest-detail bubble opens on keyboard focus
  - board posters are keyboard reachable and `:focus-visible`
  - active-face bubble reaches opacity 1
  - bubble geometry remains inside the poster and mobile viewport
  - mobile document has no horizontal overflow
- manual screenshot review of focused desktop/mobile states

## Known base failures

The repository-wide gates still inherit #213:

- Ruff: import ordering in `web/app.py` and S603 in `test_chirp_hypermedia_contract.py`
- format check: pre-existing drift in `web/app.py` and `test_forum_slice.py`
- full pytest: first failure remains `test_create_app_closes_internally_created_services_on_shutdown` because `FakeAppServices` lacks `_database`
- full typing remains the existing draining-wrapper/Pounce diagnostic set

## Steward Notes

- Consulted: Rendering/UI, Test, Changelog, and a local synthetic user panel.
- Accepted: direct library ownership; preserve visible context without hover; announce active-face relevance; prove keyboard and mobile behavior.
- Synthetic panel confidence: medium. Tooltips remain supplementary, while essential identity/relevance context stays visible or announced.
- Collateral: rendered/static tests and a user-facing changelog fragment.
- Deferred: the remaining #231 component migrations.
