### PR TITLE
Adopt Chirp-UI filter navigation

### DIFF
--- a/changelog.d/+chirp-ui-filter-navigation.changed.md
+++ b/changelog.d/+chirp-ui-filter-navigation.changed.md
@@ -1,0 +1,1 @@
+Board thread filters, guidebook section jumps, and writer queue lenses now use the shared Chirp-UI chip patterns for more consistent selected, hover, and wrapping behavior.

--- a/src/elbysodic/web/pages/_components/ui.html
+++ b/src/elbysodic/web/pages/_components/ui.html
@@ -45,30 +45,6 @@
 </div>
 {% end %}
 
-{% def inline_nav(label, cls="") %}
-<nav class="chirpui-saved-view-strip elbysodic-filter-bar{{ " " ~ cls if cls else "" }}" aria-label="{{ label }}">
-  {% slot %}
-</nav>
-{% end %}
-
-{% def inline_nav_link(label, href, active=false, hx_target=none, hx_select=none, hx_swap="innerHTML show:none", hx_push_url=false) %}
-<a class="chirpui-chip{{ " chirpui-chip--selected" if active else "" }} elbysodic-filter-link{{ " elbysodic-filter-link--active" if active else "" }}"
-   href="{{ href }}"
-   {% if active %}aria-current="page"{% end %}
-   {% if hx_target %}
-   hx-boost="false"
-   hx-get="{{ href }}"
-   hx-target="{{ hx_target }}"
-   hx-swap="{{ hx_swap }}"
-   hx-sync="closest nav:replace"
-   hx-disinherit="hx-select hx-target hx-swap"
-   {% if hx_select %} hx-select="{{ hx_select }}"{% end %}
-   {% if hx_push_url %} hx-push-url="true"{% end %}
-   {% end %}>
-  {{ label }}
-</a>
-{% end %}
-
 {% def meta_hint(hint, position="top", cls="") %}
 {% set pos = position if position in ("top", "bottom", "left", "right") else "top" %}
 {% set pos_class = "chirpui-tooltip--bottom" if pos == "bottom" else ("chirpui-tooltip--left" if pos == "left" else ("chirpui-tooltip--right" if pos == "right" else "chirpui-tooltip--top")) %}

--- a/src/elbysodic/web/pages/boards/{board_slug}/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/page.html
@@ -1,11 +1,28 @@
 {% imports %}
   {% from "chirpui/breadcrumbs.html" import breadcrumbs %}
+  {% from "chirpui/filter_chips.html" import filter_group %}
   {% from "chirpui/layout.html" import container, stack, cluster, section_header %}
   {% from "_components/boards.html" import board_media_classes, board_media_image, board_stat_row, subboard_card %}
   {% from "_components/director_controls.html" import director_action_menu, director_context_panel %}
   {% from "_components/facets.html" import facet_pills %}
   {% from "_components/thread_summary.html" import thread_card %}
-  {% from "_components/ui.html" import empty_policy_block, event_bridge, inline_nav, inline_nav_link %}
+  {% from "_components/ui.html" import empty_policy_block, event_bridge %}
+{% end %}
+
+{# Chirp-UI's filter_chip does not yet expose hx-disinherit or hx-sync. Keep
+   this board-region request local so shell selection cannot leak into it. #}
+{% def thread_filter_chip(option) %}
+<a class="chirpui-badge {{ "chirpui-badge--primary" if option.is_active else "chirpui-badge--muted" }} chirpui-filter-chip{{ " chirpui-filter-chip--active" if option.is_active else "" }}"
+   href="{{ option.href }}"
+   {% if option.is_active %}aria-current="page"{% end %}
+   hx-boost="false"
+   hx-get="{{ option.href }}"
+   hx-target="#board-thread-region"
+   hx-swap="outerHTML show:none"
+   hx-sync="closest nav:replace"
+   hx-disinherit="hx-select hx-target hx-swap"
+   hx-select="#board-thread-region"
+   hx-push-url="true"><span class="chirpui-badge__text">{{ option.label }}</span></a>
 {% end %}
 
 {% def next_unread_link(item) %}
@@ -206,11 +223,13 @@
       <p class="elbysodic-copy-section">Direct threads in this board.</p>
       {% end %}
     </header>
-    {% call inline_nav("Thread filters", "elbysodic-scene-filter-bar") %}
+    <nav aria-label="Thread filters">
+    {% call filter_group("Thread status", cls="elbysodic-scene-filter-bar") %}
       {% for option in filter_options %}
-      {{ inline_nav_link(option.label, option.href, option.is_active, "#board-thread-region", "#board-thread-region", "outerHTML show:none", true) }}
+      {{ thread_filter_chip(option) }}
       {% end %}
     {% end %}
+    </nav>
 
     <div class="chirpui-stack chirpui-stack--md elbysodic-thread-list">
       {% if threads %}

--- a/src/elbysodic/web/pages/my/threads/page.html
+++ b/src/elbysodic/web/pages/my/threads/page.html
@@ -1,4 +1,5 @@
 {% imports %}
+  {% from "chirpui/filter_chips.html" import filter_chip, filter_group %}
   {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "chirpui/surface.html" import surface %}
   {% from "_components/thread_summary.html" import compact_thread_card, thread_card %}
@@ -119,17 +120,13 @@
       <small>Switch to one face when you want a tighter writing lane.</small>
       {% end %}
     </summary>
-    <nav class="elbysodic-filter-bar" aria-label="Queue lens">
-      <a class="chirpui-btn {{ "chirpui-btn--primary" if not dashboard.selected_character else "chirpui-btn--secondary" }}"
-         href="/my/threads?character=all">
-        Whole roster
-      </a>
+    <nav aria-label="Queue lens">
+    {% call filter_group("Face lens") %}
+      {{ filter_chip("Whole roster", href="/my/threads?character=all", active=not dashboard.selected_character) }}
       {% for activity in dashboard.roster_activity %}
-      <a class="chirpui-btn {{ "chirpui-btn--primary" if dashboard.selected_character and dashboard.selected_character.id == activity.character.id else "chirpui-btn--secondary" }}"
-         href="/my/threads?character={{ activity.character.slug }}">
-        {{ activity.character.name }} · {{ activity.needs_reply | length }}
-      </a>
+      {{ filter_chip(activity.character.name ~ " · " ~ (activity.needs_reply | length), href="/my/threads?character=" ~ activity.character.slug, active=dashboard.selected_character and dashboard.selected_character.id == activity.character.id) }}
       {% end %}
+    {% end %}
     </nav>
   </details>
   {% end %}

--- a/src/elbysodic/web/pages/world/{material_slug}/page.html
+++ b/src/elbysodic/web/pages/world/{material_slug}/page.html
@@ -1,10 +1,11 @@
 {% imports %}
+  {% from "chirpui/chip_group.html" import chip, chip_group %}
   {% from "chirpui/detail_header.html" import detail_header %}
   {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "chirpui/surface.html" import surface %}
   {% from "_components/boards.html" import board_signal %}
   {% from "_components/facets.html" import facet_pills %}
-  {% from "_components/ui.html" import cast_faces, continuity_timeline, counter, inline_nav, inline_nav_link, scene_state_badges, studio_facts %}
+  {% from "_components/ui.html" import cast_faces, continuity_timeline, counter, scene_state_badges, studio_facts %}
   {% from "_components/wanted.html" import wanted_card %}
 {% end %}
 
@@ -60,27 +61,29 @@
     {% end %}
   {% end %}
 
-  {% call inline_nav("Guide sections", cls="elbysodic-section-jump") %}
+  <nav aria-label="Guide sections">
+  {% call chip_group(cls="elbysodic-section-jump") %}
     {% if material.event_actions %}
-    {{ inline_nav_link("Write now", "#event-actions") }}
+    {{ chip("Write now", href="#event-actions") }}
     {% end %}
-    {{ inline_nav_link("Canon", "#canon") }}
+    {{ chip("Canon", href="#canon") }}
     {% if material.continuity_beats %}
-    {{ inline_nav_link("Progression", "#event-progression") }}
+    {{ chip("Progression", href="#event-progression") }}
     {% end %}
     {% if material.related_wanted_ads %}
-    {{ inline_nav_link("Wanted", "#wanted-hooks") }}
+    {{ chip("Wanted", href="#wanted-hooks") }}
     {% end %}
     {% if material.related_scenes %}
-    {{ inline_nav_link("Scenes", "#active-scenes") }}
+    {{ chip("Scenes", href="#active-scenes") }}
     {% end %}
     {% if material.related_locations %}
-    {{ inline_nav_link("Locations", "#locations") }}
+    {{ chip("Locations", href="#locations") }}
     {% end %}
     {% if material.related_materials %}
-    {{ inline_nav_link("Related", "#related-materials") }}
+    {{ chip("Related", href="#related-materials") }}
     {% end %}
   {% end %}
+  </nav>
 
   {% if material.event_actions %}
   <section id="event-actions" class="elbysodic-event-actions" aria-labelledby="event-actions-title">

--- a/src/elbysodic/web/static/elbysodic-theme/41-boards-places.css
+++ b/src/elbysodic/web/static/elbysodic-theme/41-boards-places.css
@@ -798,13 +798,6 @@
     vertical-align: baseline;
 }
 
-.elbysodic-filter-bar {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    margin-top: -0.35rem;
-}
-
 .elbysodic-section-jump {
     border-block: 1px solid var(--chirpui-border-subtle);
     margin-top: 0;
@@ -829,35 +822,6 @@
 #nearby,
 #board-thread-region {
     scroll-margin-top: 5.5rem;
-}
-
-.elbysodic-filter-link {
-    border-bottom: 2px solid transparent;
-    color: var(--chirpui-text-muted);
-    font-size: var(--chirpui-font-sm);
-    font-weight: 800;
-    padding: 0.15rem 0;
-    text-decoration: none;
-}
-
-.elbysodic-filter-link + .elbysodic-filter-link {
-    margin-left: 0.55rem;
-}
-
-.elbysodic-filter-link.chirpui-chip {
-    border-bottom-width: 1px;
-    padding: var(--chirpui-spacing-xs) var(--chirpui-spacing-sm);
-}
-
-.elbysodic-filter-link.chirpui-chip + .elbysodic-filter-link.chirpui-chip {
-    margin-left: 0;
-}
-
-.elbysodic-filter-link:hover,
-.elbysodic-filter-link:focus-visible,
-.elbysodic-filter-link--active {
-    border-bottom-color: color-mix(in srgb, var(--chirpui-accent) 72%, transparent);
-    color: var(--chirpui-text);
 }
 
 .elbysodic-scene-filter-bar {

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -3178,7 +3178,8 @@ def test_forum_pages_render_seeded_boards_and_thread() -> None:
             assert 'hx-sync="closest nav:replace"' in board.text
             assert 'hx-swap="outerHTML show:none"' in board.text
             assert "chirpui-breadcrumbs" in board.text
-            assert "chirpui-saved-view-strip" in board.text
+            assert "chirpui-filter-group" in board.text
+            assert "chirpui-filter-chip" in board.text
             assert "chirpui-facet-chip" in board.text
             assert "First unread" in board.text
             assert "#post-" in board.text
@@ -7494,7 +7495,7 @@ def test_world_materials_render_pillars_events_and_application_guides() -> None:
             assert event.status == 200
             assert "elbysodic-material-hero--event" in event.text
             assert "chirpui-detail-header" in event.text
-            assert "chirpui-saved-view-strip" in event.text
+            assert "chirpui-chip-group" in event.text
             assert "elbysodic-material-detail-shell--event" in event.text
             assert "Iceman is infected with B-24" in event.text
             assert "Evil Lab" in event.text

--- a/tests/test_frontend_surface_contracts.py
+++ b/tests/test_frontend_surface_contracts.py
@@ -144,3 +144,18 @@ def test_access_and_search_surfaces_keep_labelled_controls() -> None:
         text = (PAGES / template_path).read_text(encoding="utf-8")
         for snippet in required_snippets:
             assert snippet in text, f"{template_path} is missing {snippet!r}"
+
+
+def test_filter_navigation_uses_chirp_ui_components() -> None:
+    shared_ui = (PAGES / "_components/ui.html").read_text(encoding="utf-8")
+    board = (PAGES / "boards/{board_slug}/page.html").read_text(encoding="utf-8")
+    world_material = (PAGES / "world/{material_slug}/page.html").read_text(encoding="utf-8")
+    writer_queue = (PAGES / "my/threads/page.html").read_text(encoding="utf-8")
+
+    assert "def inline_nav(" not in shared_ui
+    assert "def inline_nav_link(" not in shared_ui
+    assert 'from "chirpui/filter_chips.html" import filter_group' in board
+    assert "def thread_filter_chip(option)" in board
+    assert 'hx-disinherit="hx-select hx-target hx-swap"' in board
+    assert 'from "chirpui/chip_group.html" import chip, chip_group' in world_material
+    assert 'from "chirpui/filter_chips.html" import filter_chip, filter_group' in writer_queue


### PR DESCRIPTION
## Summary

- remove the shared hand-rolled `inline_nav` and `inline_nav_link` macros plus their duplicate CSS
- use Chirp-UI `filter_group`/filter-chip styling for board filters and writer queue lenses
- use Chirp-UI `chip_group`/`chip` for guidebook section jumps
- preserve the board region's exact HTMX target, selection, history, synchronization, and disinheritance contract
- add rendered/static regression proof and a user-facing changelog fragment

Progress on #231.

## Why

Chirp-UI 0.11 now owns the generic chip grouping, selected-state, hover, and wrapping presentation. Keeping those patterns in Elbysodic duplicated library behavior and left the writer queue lens on button styling. The board request remains a tiny page-local interaction macro because Chirp-UI's `filter_chip` API does not yet expose the required `hx-sync` and `hx-disinherit` attributes; presentation still comes from Chirp-UI classes.

## Surface parity

| Contract | Board threads | Guidebook material | Writer queue |
|---|---|---|---|
| Library-owned grouping | `filter_group` | `chip_group` | `filter_group` |
| Selected state | active filter | n/a (section jumps) | active face/roster lens |
| Keyboard order | verified | verified | verified |
| Mobile wrapping | verified | verified | verified |
| Navigation behavior | targeted HTMX region swap | same-page anchor | server-rendered query navigation |

## Validation

- 20 focused rendered/static tests pass
- Chirp app check: all clear
- focused Ruff check and format check pass
- Playwright desktop/mobile QA passed for HTMX swaps, selected state, keyboard order, anchors, and wrapping
- `git diff --check` passes
- full gates remain red on unchanged `origin/main` failures tracked by #213:
  - Ruff: `app.py` I001 and `test_chirp_hypermedia_contract.py` S603
  - Ruff format: `app.py` and `test_forum_slice.py`
  - pytest: first failure is `test_create_app_closes_internally_created_services_on_shutdown` (`FakeAppServices._database`)
  - ty: 208 existing diagnostics around `DrainingAwareApp`/Pounce monkeypatch typing

## Steward notes

- Consulted: Rendering/UI, Tests, Changelog, and the product user panel.
- Accepted: library ownership for generic chip presentation; semantic nav labels; exact board HTMX behavior; active-face clarity; mobile wrapping; rendered and static proof.
- Deferred: the existing Chirp debug-only inherited `hx-select` diagnostic, reproduced unchanged on `origin/main`; no behavior regression and production-style QA is clean.
- Collateral: changelog fragment added; no product docs change because routes, vocabulary, privacy, and workflow behavior are unchanged.
