### PR TITLE
Upgrade CI actions to Node.js 24-native releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.14t"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
@@ -63,15 +63,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.14t"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}

--- a/changelog.d/+node24-ci-actions.changed.md
+++ b/changelog.d/+node24-ci-actions.changed.md
@@ -1,0 +1,1 @@
+GitHub Actions now use Node.js 24-native checkout, dependency cache, and uv setup releases, removing the Node.js 20 deprecation warnings from CI.


### PR DESCRIPTION
Closes #269.

## What changed

- upgrade `actions/checkout` from v4 to v5 in both CI jobs
- upgrade `actions/cache` from v4 to v5 in both CI jobs
- upgrade `astral-sh/setup-uv` from v5 to v7 in both CI jobs
- document the CI runtime change in the required Towncrier fragment

The selected majors are the first Node.js 24-native releases published by each action. Checkout depth, Python 3.14t selection, cache paths and keys, job commands, and `contents: read` permissions are unchanged.

## Why

The previous Node.js 20 action releases emit deprecation warnings on GitHub-hosted runners, obscuring actionable CI annotations.

## Validation

- `make check`
- `make contract-diff`
- `make changelog-check`
- optimized local coverage split: 600 parallel-safe tests plus 3 process tests, 86.38% total coverage
- `git diff --check`
- GitHub Actions run 29335803643: `gate` and `Test suite with coverage` passed
- both hosted jobs restored the unchanged uv cache key and used CPython 3.14.6 freethreaded for `3.14t`
- both hosted check runs reported zero warning or failure annotations

GitHub CI proves that both jobs execute on the upgraded actions without Node.js 20 warnings and retain cache/Python behavior.

## Steward Notes

- Consulted: root Agent Constitution build/config guard and changelog steward
- Accepted: preserve action inputs, permissions, cache keys, and job commands exactly; add the required release fragment
- Proof: local gates above plus green GitHub-hosted PR CI with empty warning annotations
- Collateral: added `changelog.d/+node24-ci-actions.changed.md`; no docs, examples, or product steward updates because this is an internal CI runtime-pin change
