### PR TITLE
Complete upgrade browser QA and staging smoke

### DIFF
--- a/changelog.d/+upgrade-browser-qa.fixed.md
+++ b/changelog.d/+upgrade-browser-qa.fixed.md
@@ -1,0 +1,1 @@
+Upgrade browser QA now follows current CSRF and cookie behavior, detects real text collisions without flagging intentional overflow, and keeps Director Studio readable in narrow shell columns.

--- a/docs/operations/railway-production-smoke-record.md
+++ b/docs/operations/railway-production-smoke-record.md
@@ -10,6 +10,42 @@ Production smoke has not been run yet.
 ## Attempt Log
 
 ```text
+Railway staging upgrade smoke:
+- Date: 2026-07-14
+- Operator: Codex local workspace
+- URL: https://elbysodic-staging.up.railway.app
+- Deployment: 7fd9bb62-a214-438e-baf8-b0ea3952d776 (SUCCESS)
+- Commit: 1f1d5f84c80a7c79f82daaa985327ceae3e79b9e, deployed from the
+  verified local branch through Railway CLI
+- Railway project/service/environment: Elbysodic / elbysodic / staging
+- Deploy posture: one replica, /ready healthcheck, 5-second overlap,
+  15-second drain, and /app/var volume mount
+- Local Pounce check: pounce 0.9.1; app import, config validation, and
+  127.0.0.1:8765 port availability all passed
+- Staging runtime: startup log reported Pounce 0.9.1, Python 3.14.2, GIL
+  enabled, and process-worker mode. Do not treat this run as free-threaded
+  runtime proof.
+- Probe smoke: HEAD /health, /livez, /ready, and /readyz had correct bodyless
+  semantics; GET /ready and /readyz passed. /_pounce/info redirected to the
+  app login boundary, so no public build-id or gil_enabled assertion was made.
+- Seed/login smoke: the public catalog rendered Jurassic Park Universe,
+  RL NYC, and X-Men Apocalypse; X-Men seed media returned 200; a seeded writer
+  login resolved the intended X-Men Apocalypse membership and face. No
+  credentials, cookies, or account identifiers beyond the seed class are
+  recorded here.
+- Browser QA: browser-qa-deep, rapid-click-qa, latest-click-wins-qa, and
+  writer-activation-qa passed. The accepted visual fix stacks the Director
+  Studio hero before tablet shell columns collide; no privacy or service
+  contract changed.
+- Password rehash evidence: aggregate-only SSH inspection found 11 demo-seed
+  hashes and zero scrypt or argon2id hashes. A scrypt-to-argon2 staging login
+  is therefore not executable against the current seed corpus. Elbysodic #273
+  owns application integration and a safe legacy fixture; upstream Chirp #751
+  owns the verify_and_upgrade opt-in/documentation mismatch.
+- Result: staging deploy, runtime, public probes, and visual/interaction QA
+  passed. The password-rehash acceptance criterion remains blocked on #273
+  and lbliii/chirp#751; production smoke remains unrun.
+
 Chirp/Pounce 0.8 production-check adoption:
 - Date: 2026-06-15
 - Operator: Codex local workspace

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -24,7 +24,7 @@ path.
 Current staging posture:
 
 - URL: `https://elbysodic-staging.up.railway.app`
-- Railway project: `intuitive-friendship`
+- Railway project: `Elbysodic`
 - Railway service: `elbysodic`
 - Railway environment: `staging`
 - SQLite volume mount: `/app/var`
@@ -225,6 +225,36 @@ production run so staging proof and production proof stay distinct.
 Latest known staging smoke:
 
 ```text
+Railway smoke:
+- Date: 2026-07-14
+- URL: https://elbysodic-staging.up.railway.app
+- Deployment: 7fd9bb62-a214-438e-baf8-b0ea3952d776 (SUCCESS)
+- Commit: 1f1d5f84c80a7c79f82daaa985327ceae3e79b9e
+- Railway project: Elbysodic
+- Railway service: elbysodic
+- Railway environment: staging
+- Volume path: /app/var
+- Replica count: 1
+- Deploy posture: /ready healthcheck, 5-second overlap, 15-second drain
+- Auto seed: startup log reported the configured /app/var database path
+- Pounce: local `pounce check` passed on 0.9.1; staging startup reported
+  Pounce 0.9.1 on Python 3.14.2 with the GIL enabled and process workers
+- Public probes: HEAD /health, /livez, /ready, and /readyz passed with
+  bodyless semantics; GET /ready and /readyz passed
+- Seed/login smoke: seeded public realms and X-Men seed media passed; a seeded
+  writer login resolved the intended X-Men Apocalypse membership and face
+- Introspection: /_pounce/info redirected to the app login boundary, so this
+  run did not assert public build-id or free-threaded runtime posture
+- Browser QA: deep viewport, rapid-click, latest-click-wins, and writer
+  activation packs passed after one Director Studio tablet collision fix
+- Password hash posture: aggregate-only inspection reported 11 demo-seed
+  hashes and no scrypt or argon2id rows. The requested rehash proof is blocked
+  on Elbysodic #273 and lbliii/chirp#751.
+- Result: staging deployment, probes, and browser QA passed; this is not a
+  complete production or password-migration sign-off
+
+Previous complete staging smoke:
+
 Railway smoke:
 - Date: 2026-06-15
 - URL: https://elbysodic-staging.up.railway.app

--- a/scripts/browser_qa.py
+++ b/scripts/browser_qa.py
@@ -279,7 +279,6 @@ async def _check_page(page: Page) -> list[str]:
           const mediaSelector = [
             '.elbysodic-board-stage',
             '.elbysodic-board-poster',
-            '.elbysodic-current-event-card',
             '.elbysodic-material-hero',
             '.elbysodic-thread-card__poster',
             '.elbysodic-wanted-card',
@@ -319,10 +318,28 @@ async def _check_page(page: Page) -> list[str]:
           }
 
           for (const el of Array.from(document.querySelectorAll('h1, h2, h3, .elbysodic-copy-lead, .elbysodic-prose-body'))) {
+            if (el.classList.contains('elbysodic-visually-hidden')) continue;
             const rect = el.getBoundingClientRect();
             if (rect.width > 0 && el.scrollWidth > el.clientWidth + 2) {
-              issues.push(`text overflow: ${el.tagName.toLowerCase()}.${el.className}`);
-              break;
+              const range = document.createRange();
+              range.selectNodeContents(el);
+              const textRect = range.getBoundingClientRect();
+              const branch = el.parentElement;
+              const layout = branch?.parentElement;
+              const collides = Array.from(layout?.children || []).some(sibling => {
+                if (sibling === branch) return false;
+                const siblingRange = document.createRange();
+                siblingRange.selectNodeContents(sibling);
+                const siblingRect = siblingRange.getBoundingClientRect();
+                return textRect.left < siblingRect.right - 2
+                  && textRect.right > siblingRect.left + 2
+                  && textRect.top < siblingRect.bottom - 2
+                  && textRect.bottom > siblingRect.top + 2;
+              });
+              if (collides) {
+                issues.push(`text collision: ${el.tagName.toLowerCase()}.${el.className}`);
+                break;
+              }
             }
           }
 

--- a/scripts/rapid_click_qa.py
+++ b/scripts/rapid_click_qa.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import re
 from dataclasses import dataclass
+from http.cookies import SimpleCookie
 from time import perf_counter
 from urllib.parse import urlencode
 
@@ -14,6 +16,7 @@ from elbysodic.web.state import get_services
 
 FORM_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
 ROUTE_TIME_HEADER = "x-elbysodic-route-time-ms"
+CSRF_INPUT_RE = re.compile(r'name="_csrf_token" value="([^"]+)"')
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,23 +48,45 @@ def _header(response: object, name: str) -> str | None:
     return None
 
 
-def _cookie_pair(response: object, name: str) -> str | None:
-    header = _header(response, "set-cookie")
-    if header is None:
-        return None
-    pair = header.split(";", 1)[0]
-    return pair if pair.startswith(f"{name}=") else None
+def _cookie_values(response: object) -> dict[str, str]:
+    headers = getattr(response, "headers", ())
+    if isinstance(headers, dict):
+        set_cookie_headers = [
+            str(value) for key, value in headers.items() if str(key).lower() == "set-cookie"
+        ]
+    else:
+        set_cookie_headers = [
+            str(value) for key, value in headers if str(key).lower() == "set-cookie"
+        ]
+
+    values: dict[str, str] = {}
+    for header in set_cookie_headers:
+        parsed = SimpleCookie()
+        parsed.load(header)
+        values.update({name: morsel.value for name, morsel in parsed.items()})
+    return values
+
+
+def _cookie_header(cookies: dict[str, str]) -> str:
+    return "; ".join(f"{name}={value}" for name, value in cookies.items())
+
+
+def _csrf_token(html: str) -> str:
+    match = CSRF_INPUT_RE.search(html)
+    if match is None:
+        raise RuntimeError("development login page rendered no CSRF token")
+    return match.group(1)
 
 
 async def _timed_get(
     client: TestClient,
     label: str,
     path: str,
-    cookie: str | None,
+    cookies: dict[str, str],
     *,
     expected_text: str | None = None,
 ) -> CheckResult:
-    headers = {"Cookie": cookie} if cookie else None
+    headers = {"Cookie": _cookie_header(cookies)} if cookies else None
     started = perf_counter()
     response = await client.get(path, headers=headers)
     wall_ms = (perf_counter() - started) * 1000
@@ -84,11 +109,13 @@ async def _timed_switch(
     label: str,
     membership_id: int,
     next_url: str,
-    cookie: str | None,
-) -> tuple[CheckResult, str | None]:
+    cookies: dict[str, str],
+    csrf_token: str,
+) -> CheckResult:
     headers = dict(FORM_HEADERS)
-    if cookie:
-        headers["Cookie"] = cookie
+    if cookies:
+        headers["Cookie"] = _cookie_header(cookies)
+    before = dict(cookies)
     started = perf_counter()
     response = await client.post(
         "/identity",
@@ -98,24 +125,22 @@ async def _timed_switch(
                 "membership_id": str(membership_id),
                 "character_id": "0",
                 "next": next_url,
+                "_csrf_token": csrf_token,
             }
         ).encode(),
         headers=headers,
     )
     wall_ms = (perf_counter() - started) * 1000
-    next_cookie = _cookie_pair(response, "elbysodic_dev_identity") or cookie
-    return (
-        CheckResult(
-            label=label,
-            method="POST",
-            path="/identity",
-            status=response.status,
-            wall_ms=wall_ms,
-            route_ms=_header(response, ROUTE_TIME_HEADER) or "",
-            expected_status=302,
-            cookie_changed=next_cookie != cookie,
-        ),
-        next_cookie,
+    cookies.update(_cookie_values(response))
+    return CheckResult(
+        label=label,
+        method="POST",
+        path="/identity",
+        status=response.status,
+        wall_ms=wall_ms,
+        route_ms=_header(response, ROUTE_TIME_HEADER) or "",
+        expected_status=302,
+        cookie_changed=cookies != before,
     )
 
 
@@ -140,7 +165,11 @@ async def run(iterations: int) -> list[CheckResult]:
         ("enter-xmen", "x-men-apocalypse", "/boards/danger-room", "X-Men Apocalypse"),
     )
     route_targets = (
-        ("network", "/network", "Studio Network"),
+        (
+            "network",
+            "/network",
+            "Find a realm that fits the story you want to write.",
+        ),
         ("nyc-claims", "/c/rl-nyc/claims", "RL NYC"),
         ("nyc-my-threads", "/c/rl-nyc/my/threads", "RL NYC"),
         ("small-town-mine", "/c/rl-small-town/boards/town-hall?filter=mine", "RL Small Town"),
@@ -155,16 +184,20 @@ async def run(iterations: int) -> list[CheckResult]:
     }
 
     results: list[CheckResult] = []
-    cookie: str | None = None
+    cookies: dict[str, str] = {}
     async with TestClient(app) as client:
+        login_page = await client.get("/login")
+        cookies.update(_cookie_values(login_page))
+        csrf_token = _csrf_token(login_page.text)
         for index in range(iterations):
             for label, slug, next_url, expected_text in switch_targets:
-                result, cookie = await _timed_switch(
+                result = await _timed_switch(
                     client,
                     f"{label}-{index + 1}",
                     memberships[slug],
                     next_url,
-                    cookie,
+                    cookies,
+                    csrf_token,
                 )
                 results.append(result)
                 results.append(
@@ -172,7 +205,7 @@ async def run(iterations: int) -> list[CheckResult]:
                         client,
                         f"{label}-landing-{index + 1}",
                         next_url,
-                        cookie,
+                        cookies,
                         expected_text=expected_text,
                     )
                 )
@@ -182,7 +215,7 @@ async def run(iterations: int) -> list[CheckResult]:
                         client,
                         f"{label}-{index + 1}",
                         path,
-                        cookie,
+                        cookies,
                         expected_text=expected_text,
                     )
                 )

--- a/src/elbysodic/web/static/elbysodic-theme/60-studio.css
+++ b/src/elbysodic/web/static/elbysodic-theme/60-studio.css
@@ -1751,6 +1751,10 @@
 }
 
 @media (max-width: 64rem) {
+    .elbysodic-director-hero {
+        grid-template-columns: 1fr;
+    }
+
     .elbysodic-director-grid--content-index,
     .elbysodic-director-queue--open-work {
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1758,7 +1762,6 @@
 }
 
 @media (max-width: 48rem) {
-    .elbysodic-director-hero,
     .elbysodic-operations-hero {
         grid-template-columns: 1fr;
     }

--- a/tests/test_theme_css.py
+++ b/tests/test_theme_css.py
@@ -70,3 +70,16 @@ def test_cluster_alignment_modifiers_have_owned_layout_rules() -> None:
         )
     }
     assert modifiers <= {"between", "end"}
+
+
+def test_director_hero_stacks_before_shell_columns_cramp_it() -> None:
+    css = (check_theme_css.THEME_DIR / "60-studio.css").read_text(encoding="utf-8")
+
+    tablet_rules = re.search(r"@media \(max-width: 64rem\)\s*\{(?P<body>.*?)\n\}", css, re.DOTALL)
+
+    assert tablet_rules is not None
+    assert re.search(
+        r"\.elbysodic-director-hero\s*\{[^}]*grid-template-columns:\s*1fr",
+        tablet_rules.group("body"),
+        re.DOTALL,
+    )


### PR DESCRIPTION
## Summary

- repair the rapid-click QA harness for current CSRF/session-cookie behavior and current Network copy
- make browser overflow checks distinguish real sibling collisions from intentional text overflow and hidden accessibility copy
- stack the Director Studio hero before the tablet shell compresses its title and metrics into each other
- record the successful Railway staging deployment, Pounce 0.9.1 runtime, browser packs, probes, seed catalog/media, and demo-login result
- document the blocked scrypt-to-argon2 criterion and link its actionable downstream/upstream dependencies

Progresses #239. This deliberately does not close it: the current staging corpus contains only demo-seed password hashes, and Elbysodic's active login path does not yet use Chirp's password primitives. #273 and lbliii/chirp#751 make that remaining criterion workable.

## Why

The upstream 0.10/0.11 QA wave exposed one real tablet regression in Director Studio and two stale QA assumptions. The QA harness posted identity switches without the now-required CSRF/session state, treated any `scrollWidth` delta as a visible collision, and expected old Network copy. The staging rehash step also assumed a scrypt corpus and an application integration that do not exist.

## Impact

Directors get a readable Studio overview at tablet widths. The regression packs once again exercise real application behavior instead of failing on stale harness assumptions. Operators get a dated, redacted staging record that distinguishes passed deployment evidence from the auth work that still requires security review.

## Validation

- `uv run pytest -q --tb=short` — 604 passed
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- app check — 56 routes, 313 templates, all clear
- `make changelog-check`
- `pounce 0.9.1`; app import/config/port checks passed
- deep browser QA, rapid-click QA, latest-click-wins QA, and writer-activation QA passed
- Railway staging deployment `7fd9bb62-a214-438e-baf8-b0ea3952d776` succeeded
- staging readiness/HEAD probes, seeded catalog/media, and demo-login identity smoke passed

## Steward Notes

- Consulted: Web, Tests, Docs, Changelog, Surface Contract, and the Director/Modern Design Skeptic user-panel perspectives.
- Accepted: stack the existing Director Studio hero at `64rem`; add narrow CSS proof; correct QA cookie/CSRF handling; use content-range collision evidence.
- Deferred: password hashing integration to #273 and Chirp algorithm-upgrade API/docs alignment to lbliii/chirp#751 because auth changes require a dedicated security-boundary review.
- Proof: full local gates, four browser packs, screenshot review, Railway deployment/probes, and aggregate-only staging hash-format inspection.
- Collateral: changelog fragment plus both Railway smoke records.
- Remaining risk: Railway currently reports Python 3.14.2 with the GIL enabled, and `/_pounce/info` is behind the app login boundary; this PR records those facts rather than claiming free-threaded/build-id introspection proof.
