### PR TITLE
Upgrade legacy passwords to argon2id

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,9 @@ host list; values are comma-separated hostnames without `https://`.
 When demo mode is enabled, seed users can log in with password `password`,
 including `writer@example.com`, `moira@example.com`, and `alex@example.com`.
 Without `ELBYSODIC_DEMO_MODE=1`, production rejects those seed password hashes.
+New real accounts use argon2id password hashes. A successful login upgrades
+legacy Elbysodic PBKDF2 or Chirp scrypt hashes to argon2id with a compare-and-swap
+write; failed logins and demo-seed hashes never trigger that write.
 
 Post-deploy smoke for the shared Railway host:
 

--- a/changelog.d/+argon2-login-upgrades.security.md
+++ b/changelog.d/+argon2-login-upgrades.security.md
@@ -1,0 +1,1 @@
+New real accounts now use argon2id password hashes, while successful logins atomically upgrade legacy PBKDF2 or scrypt hashes without rewriting failed, current, or demo-seed credentials.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -263,6 +263,17 @@ Production also requires `ELBYSODIC_SECRET_KEY` with at least 32 characters.
 Seed `dev-password-hash` accounts are accepted in production only when
 `ELBYSODIC_DEMO_MODE=1` is set; otherwise those hashes are rejected.
 
+New real accounts store argon2id hashes through Chirp's password primitives.
+The login service can verify the previous Elbysodic PBKDF2 format and Chirp's
+scrypt PHC format, then derives an argon2id replacement only after the password
+has verified. The repository persists that replacement with a compare-and-swap
+against the exact hash that was verified, so concurrent successful logins may
+both establish sessions but only one can replace the legacy value. A failed
+password never writes, a current argon2id hash is not rewritten, and a
+`dev-password-hash` seed account stays on the explicit demo-mode boundary.
+Password hashes remain global login-account material; the upgrade does not
+change community membership, role, active face, or tenant ownership.
+
 Production mutating requests are protected by Chirp session-backed CSRF.
 Rendered POST form templates include the active CSRF field explicitly, and
 unsafe methods are rejected when the token is missing or invalid.

--- a/docs/operations/auth-trust-posture.md
+++ b/docs/operations/auth-trust-posture.md
@@ -40,6 +40,19 @@ Local development may report:
 Those are acceptable for local fixture work only. They are not evidence that a
 shared Railway, staging, or production deployment is safe.
 
+## Password Hash Lifecycle
+
+- New real accounts use argon2id through the installed `bengal-chirp[auth]`
+  extra.
+- Successful logins accept legacy Elbysodic PBKDF2 and Chirp scrypt hashes and
+  replace them with argon2id through an atomic compare-and-swap.
+- Failed passwords, current argon2id hashes, and `dev-password-hash` demo
+  accounts do not trigger replacement writes.
+- The compare-and-swap is global-user scoped. It does not modify a writer's
+  community memberships, roles, default faces, or active session identity.
+- Smoke records name hash formats only. Never record hashes, passwords, email
+  addresses, session cookies, or reset material.
+
 ## Production Readiness
 
 A launch-readiness record should treat `production_blocking: yes` as a blocker

--- a/docs/operations/railway-production-smoke-record.md
+++ b/docs/operations/railway-production-smoke-record.md
@@ -10,6 +10,32 @@ Production smoke has not been run yet.
 ## Attempt Log
 
 ```text
+Railway staging password-rehash smoke:
+- Date: 2026-07-20
+- Operator: Codex local workspace
+- URL: https://elbysodic-staging.up.railway.app
+- Deployment: 2611569d-2ce6-4a02-8af0-784f87d4f607 (SUCCESS)
+- Commit: a13832d2df6e3cf00065b4c6a236e9da83b3f091, deployed from the
+  verified local branch through Railway CLI
+- Railway project/service/environment: Elbysodic / elbysodic / staging
+- Deploy posture: one replica, /ready healthcheck, 5-second overlap,
+  15-second drain, and /app/var volume mount
+- Staging runtime: startup log reported Pounce 0.9.1, Python 3.14.2, GIL
+  enabled, and process-worker mode.
+- Fixture preparation: the fixed seeded-writer demo account began with a
+  demo-seed hash. The staging-only helper replaced it with a scrypt hash after
+  an explicit staging-write confirmation.
+- Negative login proof: a wrong password was rejected by the rendered login
+  route, created no authenticated session, and left the stored hash as scrypt.
+- Upgrade proof: the correct password through the rendered login route resolved
+  the intended seeded-writer identity and persisted an argon2id replacement.
+- Public probes: the standard Railway readiness probe passed after the login
+  smoke.
+- Privacy: no credentials, cookies, email addresses, or raw password hashes
+  were printed or recorded.
+- Result: Elbysodic #273 staging acceptance passed. Production smoke remains
+  unrun.
+
 Railway staging upgrade smoke:
 - Date: 2026-07-14
 - Operator: Codex local workspace

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -251,6 +251,32 @@ production run so staging proof and production proof stay distinct.
 Latest known staging smoke:
 
 ```text
+Railway password-rehash smoke:
+- Date: 2026-07-20
+- URL: https://elbysodic-staging.up.railway.app
+- Deployment: 2611569d-2ce6-4a02-8af0-784f87d4f607 (SUCCESS)
+- Commit: a13832d2df6e3cf00065b4c6a236e9da83b3f091
+- Railway project: Elbysodic
+- Railway service: elbysodic
+- Railway environment: staging
+- Volume path: /app/var
+- Replica count: 1
+- Deploy posture: /ready healthcheck, 5-second overlap, 15-second drain
+- Pounce: staging startup reported Pounce 0.9.1 on Python 3.14.2 with the GIL
+  enabled and process workers
+- Fixture preparation: a fixed seeded-writer demo hash was explicitly replaced
+  with a staging-only scrypt fixture; the helper printed no credential or raw
+  hash material
+- Negative login proof: a wrong password was rejected and the hash remained
+  scrypt
+- Upgrade proof: a correct rendered login resolved the intended seeded-writer
+  identity and persisted argon2id
+- Public probes: the standard readiness smoke passed after the upgrade
+- Result: Elbysodic #273 staging password-rehash acceptance passed; this does
+  not constitute production sign-off
+
+Previous complete staging smoke:
+
 Railway smoke:
 - Date: 2026-07-14
 - URL: https://elbysodic-staging.up.railway.app
@@ -276,10 +302,10 @@ Railway smoke:
 - Password hash posture: aggregate-only inspection reported 11 demo-seed
   hashes and no scrypt or argon2id rows. The requested rehash proof is blocked
   on Elbysodic #273 and lbliii/chirp#751.
-- Result: staging deployment, probes, and browser QA passed; this is not a
-  complete production or password-migration sign-off
+- Result: staging deployment, probes, and browser QA passed; the password
+  migration criterion was subsequently proven by the 2026-07-20 smoke above
 
-Previous complete staging smoke:
+Earlier complete staging smoke:
 
 Railway smoke:
 - Date: 2026-06-15

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -166,6 +166,32 @@ uv run python scripts/railway_probe_smoke.py \
   --build-id <deployment-sha>
 ```
 
+### Staging Password Rehash Smoke
+
+Run this only against the seeded staging/demo database. The helper refuses
+production or non-demo environments, targets only the fixed seeded-writer
+fixture, requires an explicit write confirmation, and prints format labels
+without the account email, plaintext password, or stored hash.
+
+```bash
+railway ssh --service elbysodic python scripts/password_rehash_smoke.py status
+railway ssh --service elbysodic python scripts/password_rehash_smoke.py prepare \
+  --confirm-staging-write
+```
+
+After `prepare` reports `after=scrypt`, complete one normal seeded-writer login
+through the rendered staging login form. Then verify the persisted replacement:
+
+```bash
+railway ssh --service elbysodic python scripts/password_rehash_smoke.py verify
+```
+
+The final command must report `format=argon2id`. A wrong password must leave
+`status` at `scrypt`; do not record the credential, cookie, account email, or
+raw PHC strings in the smoke record. The helper may reset a prior argon2id
+fixture back to scrypt only when the operator explicitly reruns `prepare` in
+staging demo mode.
+
 ## Smoke Script
 
 Record the date, Railway deployment ID, public URL, and tester account used.

--- a/scripts/password_rehash_smoke.py
+++ b/scripts/password_rehash_smoke.py
@@ -1,0 +1,106 @@
+"""Prepare and verify a redacted scrypt-to-argon2 staging login smoke."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from chirp.security import passwords as chirp_passwords
+
+from elbysodic.db.repository import ForumRepository
+from elbysodic.db.schema import connect
+from elbysodic.services.auth import SEED_LOGIN_PHRASE
+from elbysodic.services.forum import default_database_path
+
+STAGING_ENV = "staging"
+TARGET_ACCOUNT = "writer@example.com"
+DEMO_HASH = "-".join(("dev", "password", "hash"))
+
+
+def _hash_format(password_hash: str) -> str:
+    if password_hash == DEMO_HASH:
+        return "demo-seed"
+    if password_hash.startswith("pbkdf2_sha256$"):
+        return "pbkdf2-sha256"
+    if password_hash.startswith("$scrypt$"):
+        return "scrypt"
+    if password_hash.startswith("$argon2id$"):
+        return "argon2id"
+    return "unknown"
+
+
+def _require_staging_demo() -> None:
+    environment = (os.environ.get("ELBYSODIC_ENV") or "").strip().lower()
+    demo_mode = (os.environ.get("ELBYSODIC_DEMO_MODE") or "").strip().lower()
+    if environment != STAGING_ENV or demo_mode not in {"1", "true", "yes", "on"}:
+        raise RuntimeError("password rehash smoke requires staging demo mode")
+
+
+def _repository(database_path: Path) -> tuple[ForumRepository, object]:
+    if not database_path.is_file():
+        raise RuntimeError("password rehash smoke database does not exist")
+    connection = connect(database_path, check_same_thread=False)
+    return ForumRepository(connection), connection
+
+
+def _status(database_path: Path) -> str:
+    repo, connection = _repository(database_path)
+    try:
+        return _hash_format(repo.get_user_by_email(TARGET_ACCOUNT).password_hash)
+    finally:
+        connection.close()
+
+
+def _prepare(database_path: Path) -> tuple[str, str]:
+    repo, connection = _repository(database_path)
+    try:
+        user = repo.get_user_by_email(TARGET_ACCOUNT)
+        before = _hash_format(user.password_hash)
+        if before == "scrypt":
+            return before, before
+        if before not in {"demo-seed", "argon2id"}:
+            raise RuntimeError(f"refusing to replace unexpected fixture format: {before}")
+        legacy_hash = chirp_passwords._hash_scrypt(SEED_LOGIN_PHRASE)
+        if not repo.update_user_password_hash(
+            user.id,
+            expected_hash=user.password_hash,
+            new_hash=legacy_hash,
+        ):
+            raise RuntimeError("fixture account changed concurrently; retry from status")
+        return before, "scrypt"
+    finally:
+        connection.close()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("status", "prepare", "verify"))
+    parser.add_argument("--db-path", type=Path, default=default_database_path())
+    parser.add_argument(
+        "--confirm-staging-write",
+        action="store_true",
+        help="Required for prepare; confirms one seeded staging hash may be replaced.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    _require_staging_demo()
+    if args.action == "prepare":
+        if not args.confirm_staging_write:
+            raise RuntimeError("prepare requires --confirm-staging-write")
+        before, after = _prepare(args.db_path)
+        print(f"rehash smoke prepared: account=seeded-writer before={before} after={after}")
+        return 0
+
+    current = _status(args.db_path)
+    if args.action == "verify" and current != "argon2id":
+        raise RuntimeError(f"password rehash smoke expected argon2id, found {current}")
+    print(f"rehash smoke {args.action}: account=seeded-writer format={current}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/elbysodic/db/repositories/identity.py
+++ b/src/elbysodic/db/repositories/identity.py
@@ -777,6 +777,26 @@ class IdentityRepositoryMixin(RepositoryBase):
             raise LookupError(f"user not found: {email}")
         return _user_from_row(row)
 
+    def update_user_password_hash(
+        self,
+        user_id: int,
+        *,
+        expected_hash: str,
+        new_hash: str,
+    ) -> bool:
+        """Replace one global account hash only if the caller verified this version."""
+
+        cursor = self.connection.execute(
+            """
+            UPDATE users
+            SET password_hash = ?
+            WHERE id = ? AND password_hash = ?
+            """,
+            (new_hash, user_id, expected_hash),
+        )
+        self._commit()
+        return cursor.rowcount == 1
+
     def get_or_create_user(self, email: str, password_hash: str) -> User:
         try:
             return self.get_user_by_email(email)

--- a/src/elbysodic/services/auth.py
+++ b/src/elbysodic/services/auth.py
@@ -11,6 +11,10 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Protocol
 
+from chirp.security.passwords import hash_password as _hash_current_password
+from chirp.security.passwords import needs_rehash as _current_password_needs_rehash
+from chirp.security.passwords import verify_password as _verify_current_password
+
 from elbysodic.domain.models import User, UserSession
 
 SESSION_COOKIE = "elbysodic_session"
@@ -28,6 +32,14 @@ class AuthRepository(Protocol):
     def get_user_by_email(self, email: str) -> User: ...
 
     def get_user(self, user_id: int) -> User: ...
+
+    def update_user_password_hash(
+        self,
+        user_id: int,
+        *,
+        expected_hash: str,
+        new_hash: str,
+    ) -> bool: ...
 
     def create_user_session(
         self,
@@ -283,7 +295,20 @@ def format_auth_trust_posture(posture: AuthTrustPosture) -> str:
     return "\n".join(lines) + "\n"
 
 
-def hash_password(password: str, *, salt: str | None = None) -> str:
+def hash_password(password: str) -> str:
+    """Hash a new real password with argon2id."""
+
+    return _hash_argon2id(password)
+
+
+def _hash_argon2id(password: str) -> str:
+    password_hash = _hash_current_password(password)
+    if not password_hash.startswith("$argon2id$"):
+        raise RuntimeError("argon2id password hashing is unavailable")
+    return password_hash
+
+
+def _hash_legacy_pbkdf2(password: str, *, salt: str | None = None) -> str:
     normalized_salt = salt or secrets.token_urlsafe(16)
     derived = hashlib.pbkdf2_hmac(
         "sha256",
@@ -300,6 +325,29 @@ def verify_password(password: str, stored_hash: str) -> bool:
         if not seed_passwords_enabled():
             return False
         return hmac.compare_digest(password, SEED_LOGIN_PHRASE)
+    if stored_hash.startswith(f"{HASH_SCHEME}$"):
+        return _verify_legacy_pbkdf2(password, stored_hash)
+    if not stored_hash.startswith(("$argon2", "$scrypt$")):
+        return False
+    try:
+        return _verify_current_password(password, stored_hash)
+    except RuntimeError, ValueError:
+        return False
+
+
+def _verify_password_and_upgrade(password: str, stored_hash: str) -> tuple[bool, str | None]:
+    if not verify_password(password, stored_hash):
+        return False, None
+    if stored_hash == "dev-password-hash":
+        return True, None
+    if stored_hash.startswith(f"{HASH_SCHEME}$"):
+        return True, _hash_argon2id(password)
+    if _current_password_needs_rehash(stored_hash, upgrade_algorithm=True):
+        return True, _hash_argon2id(password)
+    return True, None
+
+
+def _verify_legacy_pbkdf2(password: str, stored_hash: str) -> bool:
     parts = stored_hash.split("$")
     if len(parts) != 4 or parts[0] != HASH_SCHEME:
         return False
@@ -333,8 +381,18 @@ def create_login_session(repo: AuthRepository, email: str, password: str) -> Log
         user = repo.get_user_by_email(normalized_email)
     except LookupError as exc:
         raise PermissionError("email or password is incorrect") from exc
-    if not verify_password(password, user.password_hash):
+    verified, replacement = _verify_password_and_upgrade(password, user.password_hash)
+    if not verified:
         raise PermissionError("email or password is incorrect")
+    if replacement is not None:
+        updated = repo.update_user_password_hash(
+            user.id,
+            expected_hash=user.password_hash,
+            new_hash=replacement,
+        )
+        user = repo.get_user(user.id)
+        if not updated and not verify_password(password, user.password_hash):
+            raise PermissionError("email or password is incorrect")
     return _create_session_for_user(repo, user)
 
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -4943,6 +4943,7 @@ def test_director_invites_writer_through_first_face_handoff() -> None:
         assert desk.status == 200
         assert "playing as First Face" in desk.text
         assert replay.status == 403
+        assert user.password_hash.startswith("$argon2id$")
         assert membership.username == "new-writer"
         assert membership.default_character_id == character.id
         assert character.membership_id == membership.id

--- a/tests/test_password_hash_upgrades.py
+++ b/tests/test_password_hash_upgrades.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from threading import Barrier, Lock
+
+import pytest
+from chirp.security import passwords as chirp_passwords
+
+from elbysodic.domain.models import User, UserSession
+from elbysodic.services import auth
+from elbysodic.services.auth import (
+    _hash_legacy_pbkdf2,
+    create_login_session,
+    hash_password,
+    verify_password,
+)
+from elbysodic.services.forum import create_services
+
+PASSWORD = "-".join(("writer", "password"))
+EMAIL = "writer@example.com"
+DEMO_HASH = "-".join(("dev", "password", "hash"))
+
+
+class RecordingAuthRepository:
+    def __init__(
+        self,
+        password_hash: str,
+        *,
+        login_barrier: Barrier | None = None,
+        concurrent_replacement: str | None = None,
+    ) -> None:
+        self.user = User(1, EMAIL, password_hash, "2026-07-20T00:00:00+00:00")
+        self.login_barrier = login_barrier
+        self.concurrent_replacement = concurrent_replacement
+        self.update_attempts = 0
+        self.update_results: list[bool] = []
+        self.sessions: dict[int, UserSession] = {}
+        self._lock = Lock()
+
+    def get_user_by_email(self, email: str) -> User:
+        if email != EMAIL:
+            raise LookupError(email)
+        with self._lock:
+            user = self.user
+        if self.login_barrier is not None:
+            self.login_barrier.wait(timeout=10)
+        return user
+
+    def get_user(self, user_id: int) -> User:
+        if user_id != self.user.id:
+            raise LookupError(user_id)
+        with self._lock:
+            return self.user
+
+    def update_user_password_hash(
+        self,
+        user_id: int,
+        *,
+        expected_hash: str,
+        new_hash: str,
+    ) -> bool:
+        with self._lock:
+            self.update_attempts += 1
+            if self.concurrent_replacement is not None:
+                self.user = replace(self.user, password_hash=self.concurrent_replacement)
+                self.concurrent_replacement = None
+            updated = user_id == self.user.id and self.user.password_hash == expected_hash
+            if updated:
+                self.user = replace(self.user, password_hash=new_hash)
+            self.update_results.append(updated)
+            return updated
+
+    def create_user_session(
+        self,
+        user_id: int,
+        token_hash: str,
+        *,
+        expires_at: str | None = None,
+    ) -> UserSession:
+        with self._lock:
+            session_id = len(self.sessions) + 1
+            session = UserSession(
+                session_id,
+                user_id,
+                token_hash,
+                None,
+                None,
+                "2026-07-20T00:00:00+00:00",
+                "2026-07-20T00:00:00+00:00",
+                expires_at,
+                None,
+            )
+            self.sessions[session_id] = session
+            return session
+
+    def update_user_session_identity(
+        self,
+        session_id: int,
+        *,
+        community_id: int,
+        membership_id: int,
+    ) -> UserSession:
+        with self._lock:
+            session = replace(
+                self.sessions[session_id],
+                selected_community_id=community_id,
+                selected_membership_id=membership_id,
+            )
+            self.sessions[session_id] = session
+            return session
+
+    def get_user_session_by_token_hash(self, token_hash: str) -> UserSession:
+        with self._lock:
+            return next(
+                session for session in self.sessions.values() if session.token_hash == token_hash
+            )
+
+    def touch_user_session(self, session_id: int) -> UserSession:
+        return self.sessions[session_id]
+
+    def revoke_user_session_by_token_hash(self, token_hash: str) -> None:
+        with self._lock:
+            session = next(
+                session for session in self.sessions.values() if session.token_hash == token_hash
+            )
+            self.sessions[session.id] = replace(
+                session,
+                selected_community_id=None,
+                selected_membership_id=None,
+                revoked_at="2026-07-20T00:00:01+00:00",
+            )
+
+
+def test_new_real_passwords_use_argon2id() -> None:
+    password_hash = hash_password(PASSWORD)
+
+    assert password_hash.startswith("$argon2id$")
+    assert verify_password(PASSWORD, password_hash) is True
+    assert verify_password("wrong-password", password_hash) is False
+
+
+def test_new_real_passwords_fail_closed_without_argon2id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(auth, "_hash_current_password", lambda _password: "$scrypt$fixture")
+
+    with pytest.raises(RuntimeError, match="argon2id password hashing is unavailable"):
+        hash_password(PASSWORD)
+
+
+def test_successful_legacy_pbkdf2_login_upgrades_exactly_once() -> None:
+    legacy_hash = _hash_legacy_pbkdf2(PASSWORD, salt="stable-legacy-fixture")
+    repo = RecordingAuthRepository(legacy_hash)
+
+    first = create_login_session(repo, EMAIL, PASSWORD)
+    upgraded_hash = repo.user.password_hash
+    second = create_login_session(repo, EMAIL, PASSWORD)
+
+    assert legacy_hash.startswith("pbkdf2_sha256$")
+    assert upgraded_hash.startswith("$argon2id$")
+    assert first.user.password_hash == upgraded_hash
+    assert second.user.password_hash == upgraded_hash
+    assert repo.update_attempts == 1
+
+
+def test_successful_scrypt_login_upgrades_to_argon2id() -> None:
+    legacy_hash = chirp_passwords._hash_scrypt(PASSWORD)
+    repo = RecordingAuthRepository(legacy_hash)
+
+    session = create_login_session(repo, EMAIL, PASSWORD)
+
+    assert legacy_hash.startswith("$scrypt$")
+    assert repo.user.password_hash.startswith("$argon2id$")
+    assert session.user.password_hash == repo.user.password_hash
+    assert repo.update_attempts == 1
+
+
+def test_failed_legacy_login_never_writes_or_creates_a_session() -> None:
+    legacy_hash = _hash_legacy_pbkdf2(PASSWORD, salt="failed-login-fixture")
+    repo = RecordingAuthRepository(legacy_hash)
+
+    with pytest.raises(PermissionError, match="email or password is incorrect"):
+        create_login_session(repo, EMAIL, "wrong-password")
+
+    assert repo.user.password_hash == legacy_hash
+    assert repo.update_attempts == 0
+    assert repo.sessions == {}
+
+
+def test_current_argon2id_login_does_not_rewrite_the_hash() -> None:
+    current_hash = hash_password(PASSWORD)
+    repo = RecordingAuthRepository(current_hash)
+
+    session = create_login_session(repo, EMAIL, PASSWORD)
+
+    assert session.user.password_hash == current_hash
+    assert repo.user.password_hash == current_hash
+    assert repo.update_attempts == 0
+
+
+def test_demo_seed_hash_remains_environment_gated_and_is_never_upgraded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ELBYSODIC_ENV", "staging")
+    monkeypatch.delenv("ELBYSODIC_DEMO_MODE", raising=False)
+    disabled_repo = RecordingAuthRepository(DEMO_HASH)
+
+    with pytest.raises(PermissionError, match="email or password is incorrect"):
+        create_login_session(disabled_repo, EMAIL, "password")
+
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+    enabled_repo = RecordingAuthRepository(DEMO_HASH)
+    session = create_login_session(enabled_repo, EMAIL, "password")
+
+    assert session.user.password_hash == DEMO_HASH
+    assert enabled_repo.user.password_hash == DEMO_HASH
+    assert enabled_repo.update_attempts == 0
+
+
+def test_concurrent_successful_legacy_logins_compare_and_swap_safely() -> None:
+    legacy_hash = _hash_legacy_pbkdf2(PASSWORD, salt="concurrent-login-fixture")
+    repo = RecordingAuthRepository(legacy_hash, login_barrier=Barrier(2))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        sessions = list(
+            executor.map(
+                lambda _index: create_login_session(repo, EMAIL, PASSWORD),
+                range(2),
+            )
+        )
+
+    assert repo.user.password_hash.startswith("$argon2id$")
+    assert repo.update_attempts == 2
+    assert sorted(repo.update_results) == [False, True]
+    assert len(sessions) == 2
+    assert all(session.user.password_hash == repo.user.password_hash for session in sessions)
+
+
+def test_concurrent_unrelated_password_change_fails_closed() -> None:
+    legacy_hash = _hash_legacy_pbkdf2(PASSWORD, salt="concurrent-reset-fixture")
+    reset_hash = hash_password("new-" + PASSWORD)
+    repo = RecordingAuthRepository(legacy_hash, concurrent_replacement=reset_hash)
+
+    with pytest.raises(PermissionError, match="email or password is incorrect"):
+        create_login_session(repo, EMAIL, PASSWORD)
+
+    assert repo.user.password_hash == reset_hash
+    assert repo.update_results == [False]
+    assert repo.sessions == {}
+
+
+def test_repository_password_hash_update_is_compare_and_swap() -> None:
+    services = create_services(path=":memory:", seed_demo=False)
+    repo = services.repo
+    old_hash = "old-" + "hash"
+    first_replacement = "first-" + "replacement"
+    stale_replacement = "stale-" + "replacement"
+    user = repo.create_user(EMAIL, old_hash)
+
+    assert repo.update_user_password_hash(
+        user.id,
+        expected_hash=old_hash,
+        new_hash=first_replacement,
+    )
+    assert not repo.update_user_password_hash(
+        user.id,
+        expected_hash=old_hash,
+        new_hash=stale_replacement,
+    )
+    assert repo.get_user(user.id).password_hash == first_replacement

--- a/tests/test_password_rehash_smoke.py
+++ b/tests/test_password_rehash_smoke.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from elbysodic.db.repository import ForumRepository
+from elbysodic.db.schema import connect
+from elbysodic.services.auth import create_login_session
+from elbysodic.services.forum import initialize_database
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "password_rehash_smoke.py"
+
+
+def _load_smoke_module():
+    spec = importlib.util.spec_from_file_location("password_rehash_smoke", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["password_rehash_smoke"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_staging_fixture_prepares_login_upgrade_and_reports_labels_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database_path = initialize_database(tmp_path / "staging.sqlite3", seed_demo=True)
+    monkeypatch.setenv("ELBYSODIC_ENV", "staging")
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+    smoke = _load_smoke_module()
+
+    assert smoke.main(["prepare", "--db-path", str(database_path), "--confirm-staging-write"]) == 0
+    assert smoke.main(["status", "--db-path", str(database_path)]) == 0
+
+    connection = connect(database_path, check_same_thread=False)
+    try:
+        repo = ForumRepository(connection)
+        before_login = repo.get_user_by_email("writer@example.com")
+        assert before_login.password_hash.startswith("$scrypt$")
+        login_phrase = "".join(("pass", "word"))
+        create_login_session(repo, "writer@example.com", login_phrase)
+        assert repo.get_user(before_login.id).password_hash.startswith("$argon2id$")
+    finally:
+        connection.close()
+
+    assert smoke.main(["verify", "--db-path", str(database_path)]) == 0
+    output = capsys.readouterr().out
+    assert "before=demo-seed after=scrypt" in output
+    assert "format=scrypt" in output
+    assert "format=argon2id" in output
+    assert "writer@example.com" not in output
+    assert "$scrypt$" not in output
+    assert "$argon2" not in output
+    assert login_phrase not in output
+
+
+def test_staging_fixture_refuses_non_staging_or_unconfirmed_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_path = initialize_database(tmp_path / "staging.sqlite3", seed_demo=True)
+    smoke = _load_smoke_module()
+
+    monkeypatch.setenv("ELBYSODIC_ENV", "production")
+    monkeypatch.setenv("ELBYSODIC_DEMO_MODE", "1")
+    with pytest.raises(RuntimeError, match="requires staging demo mode"):
+        smoke.main(["status", "--db-path", str(database_path)])
+
+    monkeypatch.setenv("ELBYSODIC_ENV", "staging")
+    with pytest.raises(RuntimeError, match="requires --confirm-staging-write"):
+        smoke.main(["prepare", "--db-path", str(database_path)])

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -708,6 +708,9 @@ def test_production_backstage_realm_stays_out_of_public_network(monkeypatch) -> 
         assert "No public-ready realms are open yet." in director_network.text
         assert "Starter Director" in director_network.text
         assert "Director in Starter Realm" in director_network.text
+        assert services.repo.get_user_by_email("director@example.com").password_hash.startswith(
+            "$argon2id$"
+        )
         assert (
             'class="elbysodic-network-card__realm-link" href="/c/starter-realm"'
             not in director_network.text


### PR DESCRIPTION
## Summary

- use Chirp's argon2id password hashing for newly stored credentials and fail closed if argon2id is unavailable
- verify legacy PBKDF2 and scrypt hashes, then upgrade them after successful login with a compare-and-swap repository write
- distinguish a concurrent same-password upgrade from a concurrent password reset by re-verifying the winning hash before creating a session
- add a redacted, staging-only legacy fixture helper and record the successful Railway rehash smoke

## Why

Elbysodic still created PBKDF2 hashes locally and had no application-owned path for upgrading legacy credentials during login. Chirp exposes the required public primitives, but its combined helper does not yet expose the algorithm-upgrade opt-in tracked by lbliii/chirp#751. This change composes `verify_password`, `needs_rehash(..., upgrade_algorithm=True)`, and `hash_password` locally so the product can migrate safely without waiting on that helper.

## Security and tenancy

- replacement hashes are derived only after successful verification
- failed verification never writes a hash or creates a session
- the compare-and-swap write prevents lost updates; a concurrent password reset fails the login closed
- the demo seed sentinel remains environment-gated and is never silently persisted as a real hash
- password hashes remain global-user authentication state; community membership, character ownership, permissions, routes, and schema are unchanged
- the smoke helper is staging/demo-only, requires explicit write confirmation, uses one fixed seeded account, and does not print credentials, emails, cookies, or raw hashes

## Staging proof

Railway deployment `2611569d-2ce6-4a02-8af0-784f87d4f607` succeeded against the source tree recorded as `a13832d2df6e3cf00065b4c6a236e9da83b3f091` before the unpushed commit author email was rewritten to GitHub's noreply form. The code tree is identical to branch commit `98e66f36`.

- initial fixed account state: demo seed
- prepared legacy state: scrypt
- wrong rendered login: rejected; hash remained scrypt
- correct rendered login: accepted for the intended seeded-writer identity; hash became argon2id
- readiness probe: passed
- runtime: Pounce 0.9.1, Python 3.14.2, GIL enabled, process workers, one replica, `/app/var` volume

Production smoke remains explicitly unrun.

## Verification

- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run pytest -q --tb=short` — 616 passed
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"` — 56 routes, 313 templates, all clear
- `make changelog-check`
- `git diff --check`

## Steward Notes

- consulted: service, storage, tests, docs, and changelog stewards
- accepted: fail-closed argon2 availability, compare-and-swap updates, winning-hash re-verification, focused concurrency proof, staging-only redacted fixture, and operations/security documentation
- collateral: README, security boundary docs, auth trust posture, Railway smoke runbook and record, changelog fragment, repository/service tests, rendered-flow tests
- no schema/migration collateral: the existing `users.password_hash` storage contract is unchanged
- no route/API/CLI parity matrix: no public entrypoint signature or route changed; login behavior is exercised through the rendered route and service boundary
- deferred: lbliii/chirp#751 remains the upstream helper ergonomics/documentation issue; it no longer blocks Elbysodic's migration
- remaining risk: argon2 and scrypt verification are intentionally expensive; no throughput benchmark was added because this change is bounded to login and preserves Chirp's configured primitives

Closes #273
Closes #239
