### PR TITLE
Harden login enumeration handling

### DIFF
--- a/changelog.d/+enumeration-safe-login.security.md
+++ b/changelog.d/+enumeration-safe-login.security.md
@@ -1,0 +1,1 @@
+Unknown-account and wrong-password logins now share Chirp's enumeration-safe verification posture, while malformed stored password hashes fail closed without creating sessions or mutating credentials.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -274,6 +274,13 @@ password never writes, a current argon2id hash is not rewritten, and a
 Password hashes remain global login-account material; the upgrade does not
 change community membership, role, active face, or tenant ownership.
 
+An unknown login account still runs Chirp's process-wide decoy password
+verification and returns the same generic rendered failure as a known account
+with a wrong password. Malformed legacy or PHC hashes fail closed without
+creating a session or mutating credentials. This credential check remains a
+global-user authentication boundary; membership and active-face resolution
+still happen only after authentication succeeds.
+
 Production mutating requests are protected by Chirp session-backed CSRF.
 Rendered POST form templates include the active CSRF field explicitly, and
 unsafe methods are rejected when the token is missing or invalid.

--- a/docs/operations/auth-trust-posture.md
+++ b/docs/operations/auth-trust-posture.md
@@ -53,6 +53,19 @@ shared Railway, staging, or production deployment is safe.
 - Smoke records name hash formats only. Never record hashes, passwords, email
   addresses, session cookies, or reset material.
 
+Login lookup uses Chirp's enumeration-safe verification contract. An unknown
+email still performs one password verification against Chirp's process-wide
+decoy hash before returning the same rendered error as a known account with a
+wrong password. Elbysodic keeps its legacy PBKDF2 and demo-seed adapters around
+that contract until those stored formats disappear. Malformed PBKDF2, scrypt,
+argon2, and unsupported hashes fail closed without a session or password write.
+
+Elbysodic does not currently register Chirp `AuditMiddleware` or consume
+`authz.permission.denied` events, so the upstream `details["missing"]`
+sorted-list shape has no downstream consumer in this release. Issue #277 owns
+the metadata-audit adopt/defer decision, and #104 owns any future persistent
+staff capability audit trail.
+
 ## Production Readiness
 
 A launch-readiness record should treat `production_blocking: yes` as a blocker

--- a/src/elbysodic/services/auth.py
+++ b/src/elbysodic/services/auth.py
@@ -13,6 +13,7 @@ from typing import Protocol
 
 from chirp.security.passwords import hash_password as _hash_current_password
 from chirp.security.passwords import needs_rehash as _current_password_needs_rehash
+from chirp.security.passwords import verify_login as _verify_current_login
 from chirp.security.passwords import verify_password as _verify_current_password
 
 from elbysodic.domain.models import User, UserSession
@@ -335,8 +336,29 @@ def verify_password(password: str, stored_hash: str) -> bool:
         return False
 
 
-def _verify_password_and_upgrade(password: str, stored_hash: str) -> tuple[bool, str | None]:
-    if not verify_password(password, stored_hash):
+def _verify_login_password(password: str, stored_hash: str | None) -> bool:
+    """Verify one login attempt, including Chirp's unknown-user decoy path."""
+
+    if stored_hash is None:
+        try:
+            return _verify_current_login(password, None)
+        except RuntimeError, ValueError:
+            return False
+    if stored_hash == "dev-password-hash" or stored_hash.startswith(f"{HASH_SCHEME}$"):
+        return verify_password(password, stored_hash)
+    if not stored_hash.startswith(("$argon2", "$scrypt$")):
+        return False
+    try:
+        return _verify_current_login(password, stored_hash)
+    except RuntimeError, ValueError:
+        return False
+
+
+def _verify_password_and_upgrade(
+    password: str,
+    stored_hash: str | None,
+) -> tuple[bool, str | None]:
+    if not _verify_login_password(password, stored_hash) or stored_hash is None:
         return False, None
     if stored_hash == "dev-password-hash":
         return True, None
@@ -354,14 +376,14 @@ def _verify_legacy_pbkdf2(password: str, stored_hash: str) -> bool:
     _scheme, raw_iterations, salt, expected = parts
     try:
         iterations = int(raw_iterations)
-    except ValueError:
+        derived = hashlib.pbkdf2_hmac(
+            "sha256",
+            password.encode("utf-8"),
+            salt.encode("utf-8"),
+            iterations,
+        )
+    except OverflowError, ValueError:
         return False
-    derived = hashlib.pbkdf2_hmac(
-        "sha256",
-        password.encode("utf-8"),
-        salt.encode("utf-8"),
-        iterations,
-    )
     actual = base64.urlsafe_b64encode(derived).decode("ascii").rstrip("=")
     return hmac.compare_digest(actual, expected)
 
@@ -378,11 +400,14 @@ def create_login_session(repo: AuthRepository, email: str, password: str) -> Log
     if not normalized_email or not password:
         raise PermissionError("email and password are required")
     try:
-        user = repo.get_user_by_email(normalized_email)
-    except LookupError as exc:
-        raise PermissionError("email or password is incorrect") from exc
-    verified, replacement = _verify_password_and_upgrade(password, user.password_hash)
-    if not verified:
+        user: User | None = repo.get_user_by_email(normalized_email)
+    except LookupError:
+        user = None
+    verified, replacement = _verify_password_and_upgrade(
+        password,
+        user.password_hash if user is not None else None,
+    )
+    if not verified or user is None:
         raise PermissionError("email or password is incorrect")
     if replacement is not None:
         updated = repo.update_user_password_hash(

--- a/tests/test_password_hash_upgrades.py
+++ b/tests/test_password_hash_upgrades.py
@@ -188,6 +188,70 @@ def test_failed_legacy_login_never_writes_or_creates_a_session() -> None:
     assert repo.sessions == {}
 
 
+def test_unknown_user_runs_chirp_decoy_and_creates_no_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = RecordingAuthRepository(hash_password(PASSWORD))
+    verifier_calls: list[tuple[str, str | None]] = []
+
+    def record_verify_login(password: str, stored_hash: str | None) -> bool:
+        verifier_calls.append((password, stored_hash))
+        return False
+
+    monkeypatch.setattr(auth, "_verify_current_login", record_verify_login)
+
+    with pytest.raises(PermissionError, match="email or password is incorrect"):
+        create_login_session(repo, "missing@example.com", PASSWORD)
+
+    assert verifier_calls == [(PASSWORD, None)]
+    assert repo.update_attempts == 0
+    assert repo.sessions == {}
+
+
+def test_known_argon2_wrong_password_uses_the_same_login_verifier_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current_hash = hash_password(PASSWORD)
+    repo = RecordingAuthRepository(current_hash)
+    verifier_calls: list[tuple[str, str | None]] = []
+
+    def record_verify_login(password: str, stored_hash: str | None) -> bool:
+        verifier_calls.append((password, stored_hash))
+        return False
+
+    monkeypatch.setattr(auth, "_verify_current_login", record_verify_login)
+
+    with pytest.raises(PermissionError, match="email or password is incorrect"):
+        create_login_session(repo, EMAIL, "wrong-password")
+
+    assert verifier_calls == [("wrong-password", current_hash)]
+    assert repo.update_attempts == 0
+    assert repo.sessions == {}
+
+
+@pytest.mark.parametrize(
+    "corrupt_hash",
+    [
+        "pbkdf2_sha256$not-an-integer$salt$digest",
+        "pbkdf2_sha256$-1$salt$digest",
+        "$argon2id$malformed",
+        "$scrypt$malformed",
+        "unsupported-password-hash",
+    ],
+)
+def test_corrupt_or_unsupported_hash_fails_closed_without_mutation(
+    corrupt_hash: str,
+) -> None:
+    repo = RecordingAuthRepository(corrupt_hash)
+
+    with pytest.raises(PermissionError, match="email or password is incorrect"):
+        create_login_session(repo, EMAIL, PASSWORD)
+
+    assert repo.user.password_hash == corrupt_hash
+    assert repo.update_attempts == 0
+    assert repo.sessions == {}
+
+
 def test_current_argon2id_login_does_not_rewrite_the_hash() -> None:
     current_hash = hash_password(PASSWORD)
     repo = RecordingAuthRepository(current_hash)

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -261,6 +261,49 @@ def test_production_seed_password_requires_demo_mode(monkeypatch) -> None:
     asyncio.run(run())
 
 
+def test_unknown_account_and_wrong_password_share_rendered_failure_posture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch, demo_mode=True)
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+
+        async with TestClient(app) as client:
+            known_page = await client.get("/login")
+            known = await client.post(
+                "/login",
+                body=urlencode(
+                    {
+                        "email": "writer@example.com",
+                        "password": "wrong-password",
+                        "next": "/",
+                        "_csrf_token": _csrf_token(known_page.text),
+                    }
+                ).encode(),
+                headers={**_FORM, "Cookie": _cookie_header(_cookie_values(known_page))},
+            )
+            unknown_page = await client.get("/login")
+            unknown = await client.post(
+                "/login",
+                body=urlencode(
+                    {
+                        "email": "missing@example.com",
+                        "password": "wrong-password",
+                        "next": "/",
+                        "_csrf_token": _csrf_token(unknown_page.text),
+                    }
+                ).encode(),
+                headers={**_FORM, "Cookie": _cookie_header(_cookie_values(unknown_page))},
+            )
+
+        assert known.status == unknown.status == 200
+        for response in (known, unknown):
+            assert response.text.count("email or password is incorrect") == 1
+            assert "elbysodic_session=" not in "\n".join(_response_headers(response, "set-cookie"))
+
+    asyncio.run(run())
+
+
 def test_production_routes_require_session(monkeypatch) -> None:
     async def run() -> None:
         _set_production_env(monkeypatch)


### PR DESCRIPTION
## What changed

- route unknown accounts through Chirp's process-wide decoy verifier
- keep repository lookup and session creation application-owned
- preserve the legacy PBKDF2/demo adapters while using Chirp's login contract for current PHC hashes
- fail closed for malformed PBKDF2, argon2, scrypt, and unsupported stored hashes
- prove the service and rendered login failure posture without timing assertions
- document the authentication boundary and the absence of any current `authz.permission.denied` consumer

## Why

The login service previously returned immediately after an unknown email lookup. That skipped password verification and left account-existence behavior structurally different from a known account with a wrong password. Malformed legacy PBKDF2 iteration values could also raise outside the intended fail-closed path.

## User and developer impact

Unknown-account and wrong-password attempts now return the same generic rendered status/copy and both execute the login verification contract. Corrupt or unsupported hashes create no session and perform no password-hash mutation. The global user remains the credential owner; community membership and active-face selection still happen only after successful authentication.

## Validation

- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run pytest -q --tb=short` (624 passed)
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `make changelog-check`
- `git diff --check`

## Steward Notes

- Consulted: service, web, tests, docs, and changelog contracts under the repository constitution.
- Accepted: enumeration-safe unknown-user verification, generic rendered failure parity, malformed-hash fail-closed proof, and explicit global-user/membership boundary documentation.
- Audit evidence: Elbysodic does not register Chirp `AuditMiddleware` or consume `authz.permission.denied`; issue #277 retains the upstream metadata-audit adopt/defer decision and #104 owns any persistent staff audit trail.
- Collateral: security architecture, operations trust posture, regression tests, and security changelog fragment updated.
- No collateral: route, schema, migration, dependency, role, membership, and face contracts are unchanged.
- Remaining risk: legacy PBKDF2 and demo-seed verification remain compatibility adapters until those stored formats are retired.

Closes #278
