### PR TITLE
Adopt request-native session identity

### DIFF
--- a/changelog.d/+request-native-session-identity.security.md
+++ b/changelog.d/+request-native-session-identity.security.md
@@ -1,0 +1,1 @@
+Database-backed global accounts now flow through Chirp's request identity, legacy SHA-1 Chirp sessions are reissued with SHA-256, and untouched anonymous catalog reads no longer emit session cookies.

--- a/docs/architecture/request-identity-and-command-protocol.md
+++ b/docs/architecture/request-identity-and-command-protocol.md
@@ -19,6 +19,13 @@ The request tenant prefix wins before session-selected identity. A selected
 membership is usable only when it belongs to the resolved community, belongs to
 the resolved user, is active, and has a role in the same community.
 
+Authentication resolves first and remains global-account scoped. The existing
+database-backed `elbysodic_session` is validated once and exposed through
+Chirp's `request.user` accessor; the request tenant resolver then derives the
+community-local membership and face from that same cached login. Code reading
+`request.user` must not infer a membership, role, staff capability, current
+community, or active face from the global account adapter.
+
 Malformed session-backed identity must be auditable and fail closed or recover
 deterministically. Development cookie fallback can recover stale local state, but
 production session corruption must not silently become an unrelated identity.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -91,6 +91,27 @@ Production request identity is session-backed:
 - logout revokes the stored session and clears its selected community and
   membership so stale cookies cannot carry forward active realm identity state
 
+The web stack resolves that database-backed session once per request and adapts
+its global `User` through Chirp `AuthMiddleware`. `request.user` therefore names
+only the authenticated login account. The tenant resolver consumes the same
+cached request login before it selects a community membership, role, or active
+face; none of those community-local identities are added to Chirp's global-user
+adapter. Revoked, expired, missing, or orphaned app sessions resolve as
+anonymous even when a Chirp session cookie still contains an older user id.
+
+Chirp session cookies are newly signed with SHA-256. The SHA-1 fallback remains
+read-only for cookies issued before this rollout: a readable SHA-1 cookie is
+reissued with SHA-256 on its next request, and no new cookie is SHA-1-signed.
+Review removal on or after **2026-08-20**, once the 30-day app-session window has
+elapsed and production evidence shows no pre-rollout Chirp sessions remain.
+
+Anonymous public catalog `GET`/`HEAD` requests that do not arrive with a Chirp
+session do not emit `Set-Cookie` or vary on cookies, so `/`, `/network`, health,
+static assets, and public tenant preview reads remain eligible for shared
+caching. `/login`, `/login/passkeys/*`, `/invite/*`, and tenant or global
+`/request-access` intentionally touch Chirp session state for CSRF or passkey
+ceremonies and are not part of that cacheable catalog contract.
+
 `auth_trust_posture()` in `src/elbysodic/services/auth.py` provides a redacted
 operations diagnostic for this posture. It reports environment, production
 mode, demo-mode seed password posture, secret-key presence/minimum status,

--- a/docs/operations/auth-trust-posture.md
+++ b/docs/operations/auth-trust-posture.md
@@ -66,6 +66,31 @@ sorted-list shape has no downstream consumer in this release. Issue #277 owns
 the metadata-audit adopt/defer decision, and #104 owns any future persistent
 staff capability audit trail.
 
+## Request Identity And Session Signing
+
+- `elbysodic_session` remains the database-backed revocation, expiry, and
+  selected-identity authority. Its cookie name, schema, and 30-day TTL are
+  unchanged.
+- One request adapter validates that app session, caches its global account,
+  and exposes the account through Chirp `request.user` before membership and
+  active-face resolution.
+- Chirp signs every newly issued `chirp_session` with SHA-256. Its temporary
+  SHA-1 fallback reads a pre-rollout cookie and immediately reissues it with
+  SHA-256. Review fallback removal on or after **2026-08-20**, after the 30-day
+  app-session window and a production check for remaining legacy cookies.
+- Untouched anonymous catalog reads do not receive a Chirp session cookie or
+  `Vary: Cookie`. Login, passkey, invite-acceptance, and access-request pages
+  intentionally establish CSRF or ceremony session state.
+
+Chirp `AuditMiddleware(level="metadata")` is **deferred** for Studio/director
+mutations. Its HTTP event identifies only the global `request.user` plus request
+metadata; it does not provide #104's required `community_id`, actor membership,
+capability, target family/id, action outcome, durable retention, or
+capability-scoped reads. Enabling it now would create a second, non-durable
+trail that could be mistaken for the product audit contract. Issue #104 remains
+the owner of the tenant-scoped persistent event design; generic request
+metadata can be reconsidered there as optional operational telemetry.
+
 ## Production Readiness
 
 A launch-readiness record should treat `production_blocking: yes` as a blocker

--- a/src/elbysodic/services/access.py
+++ b/src/elbysodic/services/access.py
@@ -7,7 +7,7 @@ from typing import Protocol
 
 from elbysodic.domain.context import RequestIdentityContext
 from elbysodic.domain.models import Community, CommunityMembership, User, UserSession
-from elbysodic.services.auth import SESSION_COOKIE, session_for_session_token
+from elbysodic.services.auth import request_login
 
 DEV_COMMUNITY_HEADER = "x-elbysodic-community"
 DEV_MEMBERSHIP_HEADER = "x-elbysodic-membership-id"
@@ -346,16 +346,8 @@ def _selected_membership_id(session: UserSession | None, community_id: int) -> i
 
 
 def _session_for_request(repo: AccessRepository, request: object | None) -> UserSession | None:
-    cookies = getattr(request, "cookies", None)
-    if cookies is None:
-        return None
-    getter = getattr(cookies, "get", None)
-    if getter is None:
-        return None
-    raw_value = getter(SESSION_COOKIE)
-    if raw_value is None:
-        return None
-    return session_for_session_token(repo, str(raw_value))
+    login = request_login(repo, request)
+    return None if login is None else login.session
 
 
 def _user_id(user: User | None) -> int | None:

--- a/src/elbysodic/services/auth.py
+++ b/src/elbysodic/services/auth.py
@@ -19,6 +19,7 @@ from chirp.security.passwords import verify_password as _verify_current_password
 from elbysodic.domain.models import User, UserSession
 
 SESSION_COOKIE = "elbysodic_session"
+REQUEST_LOGIN_CACHE_KEY = "elbysodic.request_login"
 SESSION_TTL = timedelta(days=30)
 HASH_SCHEME = "pbkdf2_sha256"
 HASH_ITERATIONS = 210_000
@@ -79,6 +80,15 @@ class LoginSession:
     user: User
     token: str
     expires_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class RequestLogin:
+    """One validated global-account login bound to the current request."""
+
+    session: UserSession
+    user: User
+    token: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -461,6 +471,45 @@ def user_for_session_token(repo: SessionLookupRepository, token: str) -> User | 
     if session is None:
         return None
     return repo.get_user(session.user_id)
+
+
+def request_login(
+    repo: SessionLookupRepository,
+    request: object | None,
+) -> RequestLogin | None:
+    """Resolve and cache the DB-backed global account for one request."""
+
+    cache = getattr(request, "_cache", None)
+    if isinstance(cache, dict) and REQUEST_LOGIN_CACHE_KEY in cache:
+        cached = cache[REQUEST_LOGIN_CACHE_KEY]
+        return cached if isinstance(cached, RequestLogin) else None
+
+    token = request_session_token(request)
+    resolved: RequestLogin | None = None
+    if token is not None:
+        session = session_for_session_token(repo, token)
+        if session is not None:
+            try:
+                user = repo.get_user(session.user_id)
+            except LookupError:
+                pass
+            else:
+                resolved = RequestLogin(session=session, user=user, token=token)
+
+    if isinstance(cache, dict):
+        cache[REQUEST_LOGIN_CACHE_KEY] = resolved
+    return resolved
+
+
+def request_session_token(request: object | None) -> str | None:
+    """Return the app-session token from the request without validating it."""
+
+    cookies = getattr(request, "cookies", None)
+    getter = getattr(cookies, "get", None)
+    if getter is None:
+        return None
+    value = getter(SESSION_COOKIE)
+    return str(value) if value is not None else None
 
 
 def session_for_session_token(

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -92,12 +92,13 @@ from elbysodic.services.applications import (
 from elbysodic.services.applications import update_application_draft as _update_application_draft
 from elbysodic.services.applications import update_application_review as _update_application_review
 from elbysodic.services.auth import (
-    SESSION_COOKIE,
     SESSION_TTL,
     LoginSession,
+    RequestLogin,
     create_login_session,
     create_passkey_login_session,
     hash_password,
+    request_login,
     session_for_session_token,
     session_token_hash,
     verify_password,
@@ -561,6 +562,14 @@ class AppServices:
             owns_repo=False,
         )
 
+    def request_login(self, request: object | None) -> RequestLogin | None:
+        """Resolve the request's global account without selecting a membership."""
+
+        if self._database is None or self._repo_context is not None:
+            return request_login(self.repo, request)
+        with self._database.repository() as repo:
+            return request_login(repo, request)
+
     def with_request_auth(self, *, production: bool) -> AppServices:
         """Return a facade with request identity rules for the runtime mode."""
 
@@ -722,17 +731,11 @@ class AppServices:
     ) -> AccountVisitorView | None:
         """Return signed-in account posture without requiring a local membership."""
 
-        cookies = getattr(request, "cookies", None)
-        getter = getattr(cookies, "get", None)
-        if getter is None:
+        login = self.request_login(request)
+        if login is None:
             return None
-        token = getter(SESSION_COOKIE)
-        if token is None:
-            return None
-        session = session_for_session_token(self.repo, str(token))
-        if session is None:
-            return None
-        user = self.repo.get_user(session.user_id)
+        session = login.session
+        user = login.user
         contexts = self._membership_contexts_for_user(user.id)
         return AccountVisitorView(
             user=user,

--- a/src/elbysodic/web/app.py
+++ b/src/elbysodic/web/app.py
@@ -28,8 +28,11 @@ from elbysodic.web.routes import (
 )
 from elbysodic.web.security import (
     PRODUCTION_CONTENT_SECURITY_POLICY,
+    AnonymousCatalogSessionMiddleware,
+    AppSessionIdentityMiddleware,
     IdentityFailureMiddleware,
     RequireLoginMiddleware,
+    request_auth_config,
     resolve_web_security_config,
 )
 from elbysodic.web.shell import sidebar_is_hidden
@@ -162,21 +165,28 @@ def create_app(
         ),
         priority=-10,
     )
-    # secure_stack wires SessionMiddleware -> CSRFMiddleware ->
-    # SecurityHeadersMiddleware in contract-passing order in ALL envs. The
+    # secure_stack wires SessionMiddleware -> AuthMiddleware ->
+    # CSRFMiddleware -> SecurityHeadersMiddleware in contract-passing order in
+    # ALL envs. The app-session adapter sits between Session and Auth so the
+    # existing DB-backed global account is exposed through request.user before
+    # any community membership or active-face selection. The
     # session cookie's Secure flag stays at SessionConfig's "auto" default,
     # resolved at freeze from AppConfig.env (True for production/staging,
     # False for local development) — never from debug. The all-env Chirp
     # session also carries the single-use WebAuthn challenge between the
     # passkey begin and finish ceremonies; app auth still rides the
     # elbysodic_session cookie.
-    for middleware in secure_stack(
+    security_stack = secure_stack(
         config,
+        auth=request_auth_config(),
         headers=SecurityHeadersConfig(
             content_security_policy=PRODUCTION_CONTENT_SECURITY_POLICY,
             strict_transport_security=security.strict_transport_security,
         ),
-    ):
+    )
+    security_stack.insert(1, AppSessionIdentityMiddleware())
+    security_stack.insert(-1, AnonymousCatalogSessionMiddleware())
+    for middleware in security_stack:
         app.add_middleware(middleware, priority=0)
     app.add_middleware(RequireLoginMiddleware(security), priority=10)
     app.add_middleware(IdentityFailureMiddleware(), priority=20)

--- a/src/elbysodic/web/errors.py
+++ b/src/elbysodic/web/errors.py
@@ -91,7 +91,7 @@ def _scenario(request: Request, status: int, detail: str) -> ErrorScenario:
         if (
             "login required" in normalized
             or "login is required" in normalized
-            or request.cookies.get("elbysodic_session") is None
+            or not request.user.is_authenticated
         ):
             return ErrorScenario(
                 title="Log in to keep writing.",

--- a/src/elbysodic/web/pages/identity/page.py
+++ b/src/elbysodic/web/pages/identity/page.py
@@ -12,7 +12,7 @@ from chirp.templating.returns import Page
 
 from elbysodic.services import AppServices
 from elbysodic.services.access import DEV_IDENTITY_COOKIE, dev_identity_cookie_value
-from elbysodic.services.auth import SESSION_COOKIE
+from elbysodic.services.auth import request_session_token
 from elbysodic.web.recovery import recover_next_url
 from elbysodic.web.security import session_cookie
 from elbysodic.web.state import get_services, get_web_security_config
@@ -54,7 +54,7 @@ async def post(request: Request) -> Redirect:
         if security.production:
             try:
                 identity = services.switch_session_identity(
-                    _cookie_value(request, SESSION_COOKIE) or "",
+                    request_session_token(request) or "",
                     membership_id,
                 )
             except PermissionError as exc:
@@ -112,11 +112,6 @@ def _safe_next(next_url: str) -> str:
     if not next_url.startswith("/") or next_url.startswith("//"):
         return "/"
     return next_url
-
-
-def _cookie_value(request: Request, name: str) -> str | None:
-    value = request.cookies.get(name)
-    return str(value) if value is not None else None
 
 
 def _form_int(value: object, field_name: str) -> int:

--- a/src/elbysodic/web/pages/invite/{invite_token}/page.py
+++ b/src/elbysodic/web/pages/invite/{invite_token}/page.py
@@ -11,7 +11,7 @@ from chirp.http.response import Response
 from chirp.templating.returns import Page
 
 from elbysodic.services.auth import SESSION_COOKIE
-from elbysodic.web.security import session_cookie
+from elbysodic.web.security import expose_global_account, session_cookie
 from elbysodic.web.state import get_services, get_web_security_config
 
 
@@ -48,6 +48,7 @@ async def post(
         return _render_invite(request, invite_token, error=str(exc), form=form)
     except ValueError as exc:
         return _render_invite(request, invite_token, error=str(exc), form=form)
+    expose_global_account(accepted.session.user)
     security = get_web_security_config()
     return Response(
         "",

--- a/src/elbysodic/web/pages/login/page.py
+++ b/src/elbysodic/web/pages/login/page.py
@@ -11,7 +11,7 @@ from chirp.templating.returns import Page
 
 from elbysodic.services.access import DEV_IDENTITY_COOKIE, dev_identity_cookie_value
 from elbysodic.services.auth import SESSION_COOKIE, seed_passwords_enabled
-from elbysodic.web.security import session_cookie
+from elbysodic.web.security import expose_global_account, session_cookie
 from elbysodic.web.state import get_services, get_web_security_config
 
 
@@ -34,6 +34,7 @@ async def post(request: Request, form: LoginForm) -> Page | Response:
         session, identity = services.login(form.email, form.password)
     except PermissionError as exc:
         return _render_login(request, email=form.email, next_url=next_url, error=str(exc))
+    expose_global_account(session.user)
     security = get_web_security_config()
     cookies = [
         session_cookie(

--- a/src/elbysodic/web/pages/login/passkeys/finish/page.py
+++ b/src/elbysodic/web/pages/login/passkeys/finish/page.py
@@ -19,7 +19,7 @@ from chirp.security.passkeys import PasskeyChallengeError, PasskeyVerificationEr
 from elbysodic.services.access import DEV_IDENTITY_COOKIE, dev_identity_cookie_value
 from elbysodic.services.auth import SESSION_COOKIE
 from elbysodic.web import passkeys as passkey_rp
-from elbysodic.web.security import session_cookie
+from elbysodic.web.security import expose_global_account, session_cookie
 from elbysodic.web.state import get_services, get_web_security_config
 
 logger = logging.getLogger(__name__)
@@ -68,6 +68,7 @@ async def post(request: Request) -> JSONResponse:
     except PermissionError as exc:
         return _rejected(str(exc))
 
+    expose_global_account(session.user)
     security = get_web_security_config()
     # The same SetCookie material password login attaches in login/page.py.
     cookies = [

--- a/src/elbysodic/web/pages/logout/page.py
+++ b/src/elbysodic/web/pages/logout/page.py
@@ -6,8 +6,8 @@ from chirp.http.request import Request
 from chirp.http.response import Response
 
 from elbysodic.services.access import DEV_IDENTITY_COOKIE
-from elbysodic.services.auth import SESSION_COOKIE
-from elbysodic.web.security import clear_session_cookie
+from elbysodic.services.auth import SESSION_COOKIE, request_session_token
+from elbysodic.web.security import clear_global_account, clear_session_cookie
 from elbysodic.web.state import get_services, get_web_security_config
 
 
@@ -22,9 +22,10 @@ async def post(request: Request) -> Response:
 
 def _logout(request: Request) -> Response:
     services = get_services()
-    token = _cookie_value(request, SESSION_COOKIE)
+    token = request_session_token(request)
     if token is not None:
         services.logout(token)
+    clear_global_account()
     security = get_web_security_config()
     return Response(
         "",
@@ -35,8 +36,3 @@ def _logout(request: Request) -> Response:
             clear_session_cookie(DEV_IDENTITY_COOKIE, security=security),
         ),
     )
-
-
-def _cookie_value(request: Request, name: str) -> str | None:
-    value = request.cookies.get(name)
-    return str(value) if value is not None else None

--- a/src/elbysodic/web/security.py
+++ b/src/elbysodic/web/security.py
@@ -10,9 +10,13 @@ from urllib.parse import quote
 from chirp.http.cookies import SetCookie
 from chirp.http.request import Request
 from chirp.http.response import Response
+from chirp.middleware.auth import AuthConfig
+from chirp.middleware.auth import login as chirp_login
+from chirp.middleware.auth import logout as chirp_logout
 from chirp.middleware.protocol import AnyResponse, Next
+from chirp.middleware.sessions import get_session
 
-from elbysodic.services.auth import SESSION_COOKIE, user_for_session_token
+from elbysodic.domain.models import User
 from elbysodic.web.errors import error_response
 
 ELBYSODIC_ENV = "ELBYSODIC_ENV"
@@ -20,6 +24,9 @@ ELBYSODIC_SECRET_KEY = "ELBYSODIC_SECRET_KEY"  # noqa: S105
 ELBYSODIC_ALLOWED_HOSTS = "ELBYSODIC_ALLOWED_HOSTS"
 ELBYSODIC_HSTS = "ELBYSODIC_HSTS"
 MIN_SECRET_KEY_LENGTH = 32
+CHIRP_GLOBAL_USER_SESSION_KEY = "elbysodic_global_user_id"
+CHIRP_SESSION_COOKIE = "chirp_session"
+CHIRP_CSRF_SESSION_KEY = "_csrf_token"
 PRODUCTION_ENVS = frozenset({"production", "prod", "staging"})
 DEFAULT_PRODUCTION_ALLOWED_HOSTS = (".up.railway.app", ".railway.app")
 PUBLIC_PATHS = frozenset(
@@ -51,6 +58,92 @@ class WebSecurityConfig:
     @property
     def production(self) -> bool:
         return self.env in PRODUCTION_ENVS
+
+
+@dataclass(frozen=True, slots=True)
+class ChirpGlobalAccount:
+    """Chirp auth adapter for an Elbysodic global login account."""
+
+    account: User
+
+    @property
+    def id(self) -> str:
+        return str(self.account.id)
+
+    @property
+    def is_authenticated(self) -> bool:
+        return True
+
+
+def request_auth_config() -> AuthConfig:
+    """Build Chirp auth around the existing DB-backed app session."""
+
+    return AuthConfig(
+        session_key=CHIRP_GLOBAL_USER_SESSION_KEY,
+        load_user=_load_request_global_account,
+        login_url=None,
+    )
+
+
+def expose_global_account(user: User) -> None:
+    """Rotate Chirp's session and expose a newly authenticated account."""
+
+    chirp_login(ChirpGlobalAccount(user))
+
+
+def clear_global_account() -> None:
+    """Rotate Chirp's session and clear its request-global auth account."""
+
+    chirp_logout()
+
+
+class AppSessionIdentityMiddleware:
+    """Bridge one validated app login into Chirp's request auth context."""
+
+    __slots__ = ()
+
+    async def __call__(self, request: Request, call_next: Next) -> AnyResponse:
+        from elbysodic.web.state import get_services
+
+        login = get_services().request_login(request)
+        session = get_session()
+        if login is None:
+            session.pop(CHIRP_GLOBAL_USER_SESSION_KEY, None)
+        else:
+            session[CHIRP_GLOBAL_USER_SESSION_KEY] = str(login.user.id)
+        return await call_next(request)
+
+
+class AnonymousCatalogSessionMiddleware:
+    """Keep untouched anonymous public reads free of session cookies."""
+
+    __slots__ = ()
+
+    async def __call__(self, request: Request, call_next: Next) -> AnyResponse:
+        had_session_cookie = CHIRP_SESSION_COOKIE in request.cookies
+        response = await call_next(request)
+        if (
+            not had_session_cookie
+            and not request.user.is_authenticated
+            and _is_public_request(request)
+            and not _public_request_requires_session(request)
+        ):
+            # Chirp CSRF eagerly provisions a token. Catalog reads render no
+            # mutating form, so remove that untouched token before the outer
+            # SessionMiddleware decides whether a cookie must be written.
+            get_session().pop(CHIRP_CSRF_SESSION_KEY, None)
+        return response
+
+
+async def _load_request_global_account(user_id: str) -> ChirpGlobalAccount | None:
+    from chirp.context import get_request
+
+    from elbysodic.web.state import get_services
+
+    login = get_services().request_login(get_request())
+    if login is None or str(login.user.id) != user_id:
+        return None
+    return ChirpGlobalAccount(login.user)
 
 
 def resolve_web_security_config(*, debug: bool) -> WebSecurityConfig:
@@ -122,7 +215,7 @@ class RequireLoginMiddleware:
         if not self._security.production or _is_public_request(request):
             return await call_next(request)
 
-        if _session_is_valid(request):
+        if request.user.is_authenticated:
             return await call_next(request)
 
         if request.method in {"GET", "HEAD"}:
@@ -185,10 +278,17 @@ def _is_public_request(request: Request) -> bool:
     )
 
 
-def _session_is_valid(request: Request) -> bool:
-    from elbysodic.web.state import get_services
+def _public_request_requires_session(request: Request) -> bool:
+    """Return whether a public route intentionally needs CSRF/session state."""
 
-    token = request.cookies.get(SESSION_COOKIE)
-    if token is None:
-        return False
-    return user_for_session_token(get_services().repo, str(token)) is not None
+    from elbysodic.web.tenant import request_tenant_slug, split_tenant_path
+
+    if request.path in {"/login", "/request-access"} or request.path.startswith(
+        ("/invite/", "/login/passkeys/")
+    ):
+        return True
+    tenant_local_path = request.path if request_tenant_slug(request) is not None else None
+    split = split_tenant_path(request.path)
+    if split is not None:
+        _community_slug, tenant_local_path = split
+    return tenant_local_path == "/request-access"

--- a/src/elbysodic/web/state.py
+++ b/src/elbysodic/web/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from elbysodic.services import AppServices
+from elbysodic.services.auth import REQUEST_LOGIN_CACHE_KEY
 from elbysodic.web.security import WebSecurityConfig
 
 _services: AppServices | None = None
@@ -46,6 +47,7 @@ def close_request_services(request: object) -> None:
     if not isinstance(cache, dict):
         return
     services = cache.pop(_REQUEST_SERVICES_CACHE_KEY, None)
+    cache.pop(REQUEST_LOGIN_CACHE_KEY, None)
     if isinstance(services, AppServices):
         services.close()
 

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import re
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -9,6 +10,7 @@ from urllib.parse import urlencode
 
 import pytest
 from chirp.testing import TestClient
+from itsdangerous import BadData, URLSafeTimedSerializer
 
 from elbysodic.db.repositories.discovery import DiscoveryTagInput
 from elbysodic.services import create_services
@@ -20,6 +22,7 @@ from elbysodic.services.network import (
     search_studio_network,
 )
 from elbysodic.web import create_app
+from elbysodic.web.security import CHIRP_GLOBAL_USER_SESSION_KEY
 from elbysodic.web.state import get_services
 
 _FORM = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -409,6 +412,100 @@ def test_production_routes_require_session(monkeypatch) -> None:
         assert "Log in to keep writing." in post.text
         assert "/login?next=/identity" in post.text
         assert personas.status == 302
+
+    asyncio.run(run())
+
+
+def test_anonymous_public_catalog_gets_do_not_issue_or_vary_on_session_cookie(
+    monkeypatch,
+) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        app = create_app(debug=False, services=create_services(path=":memory:"))
+
+        responses = []
+        for path in ("/", "/network", "/c/x-men-apocalypse/world"):
+            async with TestClient(app) as client:
+                responses.append((path, await client.get(path)))
+
+        for path, response in responses:
+            assert response.status == 200
+            assert _response_headers(response, "set-cookie") == [], path
+            assert "cookie" not in str(dict(response.headers).get("vary", "")).lower()
+
+    asyncio.run(run())
+
+
+def test_request_user_exposes_global_account_before_membership_resolution(monkeypatch) -> None:
+    async def run() -> None:
+        _set_production_env(monkeypatch)
+        services = create_services(path=":memory:")
+        app = create_app(debug=False, services=services)
+        seen_users: list[Any] = []
+
+        class RequestUserProbe:
+            async def __call__(self, request, call_next):
+                if request.path == "/studio":
+                    seen_users.append(request.user)
+                return await call_next(request)
+
+        app.add_middleware(RequestUserProbe(), priority=5)
+
+        async with TestClient(app) as client:
+            _login, cookies = await _production_login(client, email="writer@example.com")
+            studio = await client.get(
+                "/studio",
+                headers={"Cookie": _cookie_header(cookies)},
+            )
+
+        assert studio.status == 200
+        assert len(seen_users) == 1
+        request_user = seen_users[0]
+        assert request_user.is_authenticated is True
+        assert request_user.id == str(services.seed.user.id)
+        assert request_user.account.email == "writer@example.com"
+        assert not hasattr(request_user, "membership_id")
+
+    asyncio.run(run())
+
+
+def test_sha1_chirp_session_is_read_and_reissued_with_sha256(monkeypatch) -> None:
+    async def run() -> None:
+        secret_key = "x" * 32
+        _set_production_env(monkeypatch)
+        services = create_services(path=":memory:")
+        login, _identity = services.login("writer@example.com", "password")
+        app = create_app(debug=False, services=services)
+        sha1 = URLSafeTimedSerializer(
+            secret_key,
+            signer_kwargs={"digest_method": hashlib.sha1},
+        )
+        legacy_cookie = sha1.dumps(
+            {
+                "compatibility_marker": "sha1-cookie-loaded",
+                CHIRP_GLOBAL_USER_SESSION_KEY: str(login.user.id),
+            }
+        )
+
+        async with TestClient(app) as client:
+            response = await client.get(
+                "/network",
+                headers={
+                    "Cookie": (f"elbysodic_session={login.token}; chirp_session={legacy_cookie}")
+                },
+            )
+
+        assert response.status == 200
+        reissued = _cookie_values(response)["chirp_session"]
+        sha256 = URLSafeTimedSerializer(
+            secret_key,
+            signer_kwargs={"digest_method": hashlib.sha256},
+        )
+        payload = sha256.loads(reissued)
+        assert payload["compatibility_marker"] == "sha1-cookie-loaded"
+        assert payload[CHIRP_GLOBAL_USER_SESSION_KEY] == str(login.user.id)
+        with pytest.raises(BadData):
+            sha1.loads(reissued)
 
     asyncio.run(run())
 
@@ -1244,7 +1341,13 @@ def test_development_and_production_resolve_the_same_middleware_chain(monkeypatc
 
     development_chain = resolved_chain(development)
     assert development_chain == resolved_chain(production)
-    assert development_chain.index("SessionMiddleware") < development_chain.index("CSRFMiddleware")
+    assert development_chain.index("SessionMiddleware") < development_chain.index(
+        "AppSessionIdentityMiddleware"
+    )
+    assert development_chain.index("AppSessionIdentityMiddleware") < development_chain.index(
+        "AuthMiddleware"
+    )
+    assert development_chain.index("AuthMiddleware") < development_chain.index("CSRFMiddleware")
     assert development_chain.index("CSRFMiddleware") < development_chain.index(
         "SecurityHeadersMiddleware"
     )


### PR DESCRIPTION
## What changed

- centralize `elbysodic_session` validation in one cached request-login adapter
- expose the validated global account through Chirp `AuthMiddleware`, `request.user`, and `get_user()`
- make login, passkey login, invite acceptance, and logout rotate Chirp auth/session state
- reuse the cached DB session in tenant identity and signed-in public account resolution
- replace raw app-cookie checks in login-required middleware, identity actions, logout, account visitors, and rendered error selection
- keep untouched anonymous catalog reads free of `Set-Cookie` and `Vary: Cookie`
- prove SHA-1 compatibility cookies are read and reissued as SHA-256-only cookies
- document the compatibility removal review date and the metadata-audit defer decision

## Why

Elbysodic previously validated its database-backed session independently in middleware and downstream helpers, so Chirp's request-native identity remained anonymous and session-cookie signing rollout behavior was unproven. Chirp CSRF also eagerly provisioned a token on every request, causing otherwise untouched public catalog reads to emit session cookies.

## User and developer impact

The global login account is now available consistently through `request.user` before any community membership, role, or active-face selection. The existing `elbysodic_session` remains the sole database-backed revocation/expiry authority; its cookie name, schema, and routes are unchanged. Anonymous public catalog reads remain eligible for shared caching, while login, passkey, invite, and access-request routes retain intentional CSRF/session state.

SHA-1 is read-only during the compatibility window. A legacy Chirp cookie is reissued with SHA-256 on its next request, and newly issued cookies cannot be verified by a SHA-1-only serializer. The documented removal review date is 2026-08-20, after the 30-day app-session window and production verification.

## Validation

- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run ty check src/elbysodic/ tests/`
- `uv run pytest -q --tb=short` (628 passed)
- `uv run pytest tests/test_web_security.py -q --tb=short` (50 passed)
- `uv run pytest tests/test_passkey_contracts.py -q --tb=short` (20 passed)
- `uv run pytest tests/test_auth_entry_surface_contracts.py tests/test_forum_slice.py tests/test_public_catalog_privacy_contract.py tests/test_public_preview_handoff_contracts.py -q --tb=short`
- `uv run pytest tests/test_backend_contracts.py -q --tb=short` (19 passed)
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`
- `make changelog-check`
- `git diff --check`

The existing production-mode core-login smoke, inactive/cross-community recovery, and dev/production middleware parity tests are included in the passing web-security/full suites. No live Railway write or restart was performed.

## Steward Notes

- Consulted: service, web, security, tests, docs, changelog, and the cross-cutting request-lifecycle/tenant identity contracts.
- Accepted: one request-global account adapter, DB-backed revocation/expiry preservation, membership/face separation, SHA-1 → SHA-256 rollout proof, anonymous catalog cacheability, and cache cleanup on success/failure paths.
- Audit decision: defer Chirp `AuditMiddleware(level="metadata")`. Its global-user HTTP metadata lacks #104's required `community_id`, actor membership, capability, target, action outcome, durable retention, and capability-scoped reads; adopting it here would create an ambiguous second trail.
- Collateral: security boundary, request identity protocol, auth operations posture, regression tests, and security changelog updated.
- No collateral: no schema, migration, route, dependency, role, membership, face, or public CLI/API contract changed.
- Remaining risk: Chirp's SHA-1 fallback remains enabled until the documented removal review; production evidence is still required before upstream fallback removal.

Closes #277
