### PR TITLE
Keep plotting streams alive through worker drain

### DIFF
--- a/changelog.d/+plotting-drain-lifecycle.fixed.md
+++ b/changelog.d/+plotting-drain-lifecycle.fixed.md
@@ -1,0 +1,1 @@
+Railway plotting streams now keep their request-scoped storage alive for the full stream and close cleanly when Pounce delivers its worker-draining lifecycle event.

--- a/docs/operations/railway-production-smoke-record.md
+++ b/docs/operations/railway-production-smoke-record.md
@@ -10,6 +10,37 @@ Production smoke has not been run yet.
 ## Attempt Log
 
 ```text
+Railway staging plotting-stream drain attempt:
+- Date: 2026-07-20
+- Operator: Codex local workspace
+- URL: https://elbysodic-staging.up.railway.app
+- Active deployment: 64120b47-4cc5-4e22-b1ed-823f376e0ae0 (SUCCESS)
+- Replacement: 1349d70f-fe0b-4311-89cf-213736285420 (SUCCESS)
+- Commit: c017ca6742af7cd41b8f24ffedb7ff6b5f23448e, deployed from the
+  verified local branch through Railway CLI
+- Railway project/service/environment: Elbysodic / elbysodic / staging
+- Deploy posture: one Railway replica, /app/var volume, /ready healthcheck,
+  5-second overlap, and 15-second drain
+- Staging runtime: Pounce 0.9.1, Python 3.14.2, GIL enabled, two process
+  workers for the diagnostic attempt. Both workers logged the immutable build
+  id and a zero active-stream baseline.
+- Authenticated stream/write proof: a seeded-writer plotting SSE opened with
+  aggregate gauge 1; a unique pre-deploy write returned 302, persisted, and
+  was acknowledged before the replacement accepted a reconnect.
+- Retiring readiness observation: an operator-only SSH loopback probe attached
+  to the exact retiring instance saw /readyz 200 ok until Railway disconnected
+  it. No 503 draining response or app worker-draining event was observed.
+- Root cause/follow-up: lbliii/pounce#316. Pounce 0.9.1 process-mode handles do
+  not receive start_draining(), so this run does not close Elbysodic #276. The
+  corrected deployment cb5e8924-1ba1-4167-a6e6-b75ecaa76036 (commit
+  c2cdb855e01358318df9b50fabd4f66cdf2f8c82) restored staging to one worker;
+  startup reported the matching build id, GIL enabled, and gauge 0.
+- Privacy: /_pounce/info remained behind the app login boundary; no
+  credentials, cookies, account identifiers, message bodies, or secrets were
+  recorded.
+- Result: partial staging evidence only. Production was not mutated or
+  restarted, and production smoke remains unrun.
+
 Railway staging password-rehash smoke:
 - Date: 2026-07-20
 - Operator: Codex local workspace

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -49,8 +49,11 @@ Railway deploy overlap/drain settings (Pounce 0.9 bundle, lbliii/pounce #248/#29
   `shutdown_timeout` is `10` seconds, leaving a five-second safety margin.
 - `healthcheckPath`: `/ready` — SQLite-backed Chirp readiness, not the app-owned
   `/health` alias.
-- Pounce built-in readiness: `/readyz` returns JSON `{"status":"ok"}` and flips to
-  `503 {"status":"draining"}` while the worker is draining.
+- Pounce built-in readiness: `/readyz` returns JSON `{"status":"ok"}`. Pounce
+  0.9.1 does not deliver its explicit drain command to GIL/process workers
+  (lbliii/pounce#316), so Elbysodic pins Railway to one worker until the
+  retiring-listener `503 {"status":"draining"}` contract is fixed upstream and
+  reproven here. Do not cite the current staging runtime as `503` drain proof.
 - `POUNCE_BUILD_ID`: set to the git SHA or immutable release fingerprint, for
   example `${{RAILWAY_GIT_COMMIT_SHA}}`. `/_pounce/info` reports this value with
   Pounce/Python versions and GIL state when `POUNCE_INTROSPECTION=1` is enabled
@@ -141,8 +144,9 @@ Staging smoke should include:
 - `HEAD /ready`, `HEAD /livez`, and `HEAD /health` return `200` with correct
   bodyless semantics (no Railway-edge 502).
 - `GET /readyz` returns JSON `{"status":"ok"}`.
-- When `POUNCE_INTROSPECTION=1` and `POUNCE_BUILD_ID` are set,
-  `GET /_pounce/info` reports the build id and `gil_enabled: false`.
+- When `POUNCE_INTROSPECTION=1` and `POUNCE_BUILD_ID` are set on an
+  operator-gated environment, `GET /_pounce/info` reports the build id and the
+  actual `gil_enabled` posture. Do not assume a free-threaded build.
 - During a redeploy overlap, the retiring instance should answer `/readyz` with
   `503 {"status":"draining"}` while in-flight requests finish inside the overlap
   window.
@@ -251,6 +255,39 @@ production run so staging proof and production proof stay distinct.
 Latest known staging smoke:
 
 ```text
+Railway plotting-stream drain attempt:
+- Date: 2026-07-20
+- URL: https://elbysodic-staging.up.railway.app
+- Active deployment: 64120b47-4cc5-4e22-b1ed-823f376e0ae0 (SUCCESS)
+- Replacement: 1349d70f-fe0b-4311-89cf-213736285420 (SUCCESS)
+- Commit: c017ca6742af7cd41b8f24ffedb7ff6b5f23448e
+- Railway project/service/environment: Elbysodic / elbysodic / staging
+- Deploy posture: one Railway replica, /app/var volume, /ready healthcheck,
+  5-second overlap, and 15-second drain
+- Runtime: Pounce 0.9.1, Python 3.14.2, GIL enabled, two process workers for
+  this diagnostic attempt; both workers logged the immutable build id and a
+  zero active-stream baseline
+- Authenticated stream: the seeded-writer plotting SSE opened with aggregate
+  gauge 1; a unique pre-deploy write returned 302, persisted, and was
+  acknowledged by the stream; the replacement accepted a reconnect
+- Operator readiness observation: an exact-instance SSH loopback probe saw
+  /readyz 200 ok until Railway disconnected the retiring instance. It did not
+  observe 503 draining.
+- Drain lifecycle: failed. The retiring process emitted no worker-draining
+  event and could not prove a lifecycle-driven return to gauge 0.
+- Root cause/follow-up: lbliii/pounce#316. Pounce 0.9.1 process handles do not
+  receive start_draining(), so this attempt does not satisfy Elbysodic #276.
+  Corrected deployment cb5e8924-1ba1-4167-a6e6-b75ecaa76036 (commit
+  c2cdb855e01358318df9b50fabd4f66cdf2f8c82) restored staging to one worker;
+  startup reported the matching build id, GIL enabled, and gauge 0.
+- Privacy: /_pounce/info remained behind the application login boundary; no
+  credentials, cookies, account identifiers, message bodies, or secrets were
+  printed or recorded
+- Production: untouched; production smoke remains unrun
+- Result: partial staging evidence only. Build/runtime identity, authenticated
+  pre-deploy acknowledgement, persistence, and reconnect passed; retiring 503
+  and lifecycle-driven stream close remain blocked on lbliii/pounce#316.
+
 Railway password-rehash smoke:
 - Date: 2026-07-20
 - URL: https://elbysodic-staging.up.railway.app

--- a/scripts/railway_drain_smoke.py
+++ b/scripts/railway_drain_smoke.py
@@ -1,0 +1,374 @@
+"""Prove an authenticated plotting-stream handoff on Railway staging.
+
+The helper is deliberately pinned to the public staging host. It uses only
+rendered login, wanted, plotting, and CSRF-protected form contracts; it never
+prints credentials, cookies, account identifiers, message bodies, or tokens.
+Run it before triggering a separate staging redeploy. It stays attached until
+the retiring worker sends ``pounce.worker.draining``, reconnects, and verifies
+one acknowledged write on each side of the handoff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import re
+import ssl
+import threading
+import time
+from dataclasses import dataclass, field
+from http.cookiejar import CookieJar
+from urllib.error import HTTPError
+from urllib.parse import urlencode, urljoin, urlsplit
+from urllib.request import HTTPCookieProcessor, Request, build_opener
+
+from elbysodic.services.auth import SEED_LOGIN_PHRASE, SESSION_COOKIE
+
+STAGING_ORIGIN = "https://elbysodic-staging.up.railway.app"
+COMMUNITY_PATH = "/c/x-men-apocalypse"
+WANTED_PATH = f"{COMMUNITY_PATH}/wanted/human-un-liaison-for-b24"
+APPLICANT_ACCOUNT = "writer@example.com"
+OWNER_ACCOUNT = "charlie@example.com"
+CSRF_RE = re.compile(r'name="_csrf_token" value="([^"]+)"')
+FORM_RE = re.compile(r"<form\b.*?</form>", re.DOTALL)
+PLOTTING_PATH_RE = re.compile(r'href="([^"]*/plotting/(\d+))"')
+
+
+@dataclass(frozen=True, slots=True)
+class Response:
+    status: int
+    url: str
+    text: str
+
+
+class BrowserSession:
+    def __init__(self, origin: str) -> None:
+        self.origin = origin.rstrip("/")
+        self.cookies = CookieJar()
+        self.opener = build_opener(HTTPCookieProcessor(self.cookies))
+
+    def request(
+        self,
+        path: str,
+        *,
+        form: dict[str, str] | None = None,
+        timeout: float = 30.0,
+    ) -> Response:
+        data = urlencode(form).encode() if form is not None else None
+        request = Request(  # noqa: S310 -- the origin is pinned to HTTPS staging
+            urljoin(f"{self.origin}/", path.lstrip("/")),
+            data=data,
+            method="POST" if data is not None else "GET",
+            headers={
+                "User-Agent": "elbysodic-railway-drain-smoke/1",
+                **(
+                    {"Content-Type": "application/x-www-form-urlencoded"}
+                    if data is not None
+                    else {}
+                ),
+            },
+        )
+        try:
+            with self.opener.open(request, timeout=timeout) as raw:
+                body = raw.read().decode("utf-8", errors="replace")
+                return Response(int(raw.status), raw.geturl(), body)
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            return Response(int(exc.code), exc.geturl(), body)
+
+    def cookie_header(self) -> str:
+        return "; ".join(f"{cookie.name}={cookie.value}" for cookie in self.cookies)
+
+
+@dataclass(slots=True)
+class StreamEvidence:
+    ready_count: int = 0
+    draining_count: int = 0
+    message_markers: set[str] = field(default_factory=set)
+    reconnect_failures: int = 0
+    failure: str | None = None
+
+
+class PlottingStreamMonitor:
+    def __init__(self, origin: str, path: str, cookie_header: str) -> None:
+        parsed = urlsplit(origin)
+        if parsed.hostname is None:
+            raise ValueError("stream origin needs a hostname")
+        self.host = parsed.hostname
+        self.port = parsed.port or 443
+        self.path = path
+        self.cookie_header = cookie_header
+        self.evidence = StreamEvidence()
+        self._condition = threading.Condition()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+    def wait_for(self, predicate, *, timeout: float, label: str) -> None:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while not predicate(self.evidence):
+                if self.evidence.failure is not None:
+                    raise RuntimeError(self.evidence.failure)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(f"timed out waiting for {label}")
+                self._condition.wait(timeout=min(remaining, 1.0))
+
+    def _record_event(self, name: str, data: str) -> None:
+        with self._condition:
+            if name == "plotting-room-ready":
+                self.evidence.ready_count += 1
+            elif name == "pounce.worker.draining":
+                self.evidence.draining_count += 1
+            elif name == "plotting-room-message":
+                for marker in ("before-deploy", "after-deploy"):
+                    if marker in data:
+                        self.evidence.message_markers.add(marker)
+            self._condition.notify_all()
+
+    def _record_reconnect_failure(self) -> None:
+        with self._condition:
+            self.evidence.reconnect_failures += 1
+            self._condition.notify_all()
+
+    def _fail(self, exc: BaseException) -> None:
+        with self._condition:
+            self.evidence.failure = f"plotting stream failed: {type(exc).__name__}"
+            self._condition.notify_all()
+
+    def _run(self) -> None:
+        context = ssl.create_default_context()
+        try:
+            while not self._stop.is_set():
+                connection = http.client.HTTPSConnection(
+                    self.host,
+                    self.port,
+                    timeout=45,
+                    context=context,
+                )
+                try:
+                    connection.request(
+                        "GET",
+                        self.path,
+                        headers={
+                            "Accept": "text/event-stream",
+                            "Cache-Control": "no-cache",
+                            "Cookie": self.cookie_header,
+                            "User-Agent": "elbysodic-railway-drain-smoke/1",
+                        },
+                    )
+                    response = connection.getresponse()
+                    if response.status != 200:
+                        self._record_reconnect_failure()
+                        continue
+                    event_name = "message"
+                    data_lines: list[str] = []
+                    while not self._stop.is_set():
+                        raw_line = response.readline()
+                        if not raw_line:
+                            break
+                        line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+                        if not line:
+                            self._record_event(event_name, "\n".join(data_lines))
+                            if event_name == "pounce.worker.draining":
+                                break
+                            event_name = "message"
+                            data_lines = []
+                        elif line.startswith("event:"):
+                            event_name = line[6:].strip()
+                        elif line.startswith("data:"):
+                            data_lines.append(line[5:].lstrip())
+                except OSError, TimeoutError:
+                    self._record_reconnect_failure()
+                finally:
+                    connection.close()
+                if not self._stop.wait(0.5):
+                    continue
+        except BaseException as exc:  # pragma: no cover - defensive thread boundary
+            self._fail(exc)
+
+
+def _require_staging(origin: str, *, confirmed: bool) -> str:
+    normalized = origin.rstrip("/")
+    if normalized != STAGING_ORIGIN:
+        raise RuntimeError(f"drain smoke is pinned to {STAGING_ORIGIN}")
+    if not confirmed:
+        raise RuntimeError("drain smoke requires --confirm-staging-write")
+    return normalized
+
+
+def _csrf_token(html: str) -> str:
+    match = CSRF_RE.search(html)
+    if match is None:
+        raise RuntimeError("rendered form did not include a CSRF token")
+    return match.group(1)
+
+
+def _login(origin: str, account: str) -> BrowserSession:
+    session = BrowserSession(origin)
+    page = session.request("/login")
+    if page.status != 200:
+        raise RuntimeError(f"login page returned HTTP {page.status}")
+    response = session.request(
+        "/login",
+        form={
+            "_csrf_token": _csrf_token(page.text),
+            "email": account,
+            "password": SEED_LOGIN_PHRASE,
+            "next": WANTED_PATH,
+        },
+    )
+    if response.status != 200 or not any(
+        cookie.name == SESSION_COOKIE for cookie in session.cookies
+    ):
+        raise RuntimeError("seeded login did not establish an authenticated session")
+    return session
+
+
+def _plotting_path(html: str) -> str | None:
+    matches = PLOTTING_PATH_RE.findall(html)
+    return matches[0][0] if matches else None
+
+
+def _form_for_intent(html: str, intent: str) -> str | None:
+    needle = f'name="intent" value="{intent}"'
+    return next((form for form in FORM_RE.findall(html) if needle in form), None)
+
+
+def _hidden_value(form: str, name: str) -> str:
+    match = re.search(rf'name="{re.escape(name)}" value="([^"]+)"', form)
+    if match is None:
+        raise RuntimeError(f"rendered form omitted {name}")
+    return match.group(1)
+
+
+def _prepare_room(origin: str) -> tuple[BrowserSession, str]:
+    applicant = _login(origin, APPLICANT_ACCOUNT)
+    wanted = applicant.request(WANTED_PATH)
+    room_path = _plotting_path(wanted.text)
+    if room_path is None:
+        interest_form = _form_for_intent(wanted.text, "express_interest")
+        if interest_form is not None:
+            wanted = applicant.request(
+                WANTED_PATH,
+                form={
+                    "_csrf_token": _csrf_token(interest_form),
+                    "intent": "express_interest",
+                },
+            )
+            if wanted.status != 200:
+                raise RuntimeError(f"interest write returned HTTP {wanted.status}")
+
+    owner = _login(origin, OWNER_ACCOUNT)
+    wanted = owner.request(WANTED_PATH)
+    room_path = _plotting_path(wanted.text)
+    if room_path is None:
+        room_form = _form_for_intent(wanted.text, "start_plotting_room")
+        if room_form is None:
+            raise RuntimeError("no seeded plotting-room handoff is available")
+        room = owner.request(
+            WANTED_PATH,
+            form={
+                "_csrf_token": _csrf_token(room_form),
+                "intent": "start_plotting_room",
+                "interest_id": _hidden_value(room_form, "interest_id"),
+            },
+        )
+        if room.status != 200:
+            raise RuntimeError(f"plotting-room creation returned HTTP {room.status}")
+        room_path = urlsplit(room.url).path
+    if not re.fullmatch(r"/c/x-men-apocalypse/plotting/\d+", room_path):
+        raise RuntimeError("rendered plotting-room path was outside the staging fixture")
+    return owner, room_path
+
+
+def _post_message(session: BrowserSession, room_path: str, marker: str) -> None:
+    room = session.request(room_path)
+    composer = _form_for_intent(room.text, "post_message")
+    if room.status != 200 or composer is None:
+        raise RuntimeError("seeded writer cannot open the plotting composer")
+    response = session.request(
+        room_path,
+        form={
+            "_csrf_token": _csrf_token(composer),
+            "intent": "post_message",
+            "body": f"[staging drain smoke] {marker}",
+        },
+    )
+    if response.status != 200:
+        raise RuntimeError(f"plotting write returned HTTP {response.status}")
+
+
+def run(origin: str, *, timeout: float) -> None:
+    session, room_path = _prepare_room(origin)
+    stream_path = f"{room_path}/stream"
+    monitor = PlottingStreamMonitor(origin, stream_path, session.cookie_header())
+    monitor.start()
+    try:
+        monitor.wait_for(lambda item: item.ready_count >= 1, timeout=30, label="initial stream")
+        _post_message(session, room_path, "before-deploy")
+        monitor.wait_for(
+            lambda item: "before-deploy" in item.message_markers,
+            timeout=30,
+            label="pre-deploy acknowledged write",
+        )
+        print("drain smoke armed: authenticated_stream=1 acknowledged_writes=1")
+        print("trigger one staging-only redeploy now; the helper will wait for worker drain")
+        monitor.wait_for(
+            lambda item: item.draining_count >= 1,
+            timeout=timeout,
+            label="pounce.worker.draining",
+        )
+        monitor.wait_for(
+            lambda item: item.ready_count >= 2,
+            timeout=180,
+            label="replacement stream",
+        )
+        _post_message(session, room_path, "after-deploy")
+        monitor.wait_for(
+            lambda item: "after-deploy" in item.message_markers,
+            timeout=30,
+            label="post-deploy acknowledged write",
+        )
+        persisted = session.request(room_path)
+        if persisted.status != 200 or not all(
+            marker in persisted.text for marker in ("before-deploy", "after-deploy")
+        ):
+            raise RuntimeError("acknowledged plotting writes did not persist across redeploy")
+        evidence = monitor.evidence
+        print(
+            "drain smoke passed: drain_events=1 reconnect_ready=1 "
+            f"acknowledged_writes=2 persisted_writes=2 reconnect_failures={evidence.reconnect_failures}"
+        )
+    finally:
+        monitor.stop()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--origin", default=STAGING_ORIGIN)
+    parser.add_argument("--timeout", type=float, default=900.0)
+    parser.add_argument(
+        "--confirm-staging-write",
+        action="store_true",
+        help="Required; permits fixture-room setup and two staging plotting messages.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    origin = _require_staging(args.origin, confirmed=args.confirm_staging_write)
+    run(origin, timeout=max(args.timeout, 60.0))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/elbysodic/web/pages/plotting/{room_id}/stream/page.py
+++ b/src/elbysodic/web/pages/plotting/{room_id}/stream/page.py
@@ -13,9 +13,16 @@ from chirp.realtime.events import EventStream, SSEEvent
 from chirp.templating.returns import Fragment
 
 from elbysodic.services.read_models import PlottingRoomMessageView
-from elbysodic.web.state import get_services
+from elbysodic.web.state import close_request_services, get_services
 from elbysodic.web.tenant import request_scoped_path
-from elbysodic.web.worker_draining import is_worker_draining, wait_for_worker_draining
+from elbysodic.web.worker_draining import (
+    is_worker_draining,
+    plotting_stream_closed,
+    plotting_stream_opened,
+    wait_for_worker_draining,
+)
+
+_PLOTTING_POLL_INTERVAL = 0.25
 
 
 def get(request: Request, room_id: str) -> EventStream:
@@ -29,13 +36,24 @@ def get(request: Request, room_id: str) -> EventStream:
         raise HTTPError(status=403, detail=str(exc)) from exc
 
     async def generate() -> AsyncIterator[Any]:
-        queue = await services.subscribe_plotting_room_live(parsed_room_id)
+        # Pounce consumes streaming bodies after ordinary response middleware
+        # has returned. Reopen a request-scoped repository for the generator
+        # lifetime rather than retaining the already-cleaned handler facade.
+        stream_services = get_services(request)
+        queue = None
+        stream_opened = False
         try:
+            room = stream_services.read_plotting_room(parsed_room_id)
+            seen_message_ids = {item.message.id for item in room.messages}
+            queue = await stream_services.subscribe_plotting_room_live(parsed_room_id)
+            plotting_stream_opened()
+            stream_opened = True
             while not is_worker_draining():
                 get_task = asyncio.create_task(queue.get())
                 drain_task = asyncio.create_task(wait_for_worker_draining())
+                poll_task = asyncio.create_task(asyncio.sleep(_PLOTTING_POLL_INTERVAL))
                 done, pending = await asyncio.wait(
-                    {get_task, drain_task},
+                    {get_task, drain_task, poll_task},
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 for task in pending:
@@ -46,30 +64,63 @@ def get(request: Request, room_id: str) -> EventStream:
                     event = get_task.result()
                     if event.kind == "ready":
                         yield SSEEvent(event="plotting-room-ready", data="connected")
-                    elif event.kind == "message" and event.message is not None:
-                        yield Fragment(
-                            "plotting/{room_id}/page.html",
-                            "plotting_room_message_item",
-                            target="plotting-room-message",
-                            item=_ScopedPlottingRoomMessageView(request, event.message),
-                        )
+                    elif (
+                        event.kind == "message"
+                        and event.message is not None
+                        and event.message.message.id not in seen_message_ids
+                    ):
+                        seen_message_ids.add(event.message.message.id)
+                        yield _message_fragment(request, event.message)
+                if poll_task in done:
+                    for message in _unseen_messages(
+                        stream_services.read_plotting_room(parsed_room_id).messages,
+                        seen_message_ids,
+                    ):
+                        yield _message_fragment(request, message)
                 if drain_task in done:
                     while not queue.empty():
                         queued = queue.get_nowait()
                         if queued.kind == "ready":
                             yield SSEEvent(event="plotting-room-ready", data="connected")
-                        elif queued.kind == "message" and queued.message is not None:
-                            yield Fragment(
-                                "plotting/{room_id}/page.html",
-                                "plotting_room_message_item",
-                                target="plotting-room-message",
-                                item=_ScopedPlottingRoomMessageView(request, queued.message),
-                            )
+                        elif (
+                            queued.kind == "message"
+                            and queued.message is not None
+                            and queued.message.message.id not in seen_message_ids
+                        ):
+                            seen_message_ids.add(queued.message.message.id)
+                            yield _message_fragment(request, queued.message)
+                    for message in _unseen_messages(
+                        stream_services.read_plotting_room(parsed_room_id).messages,
+                        seen_message_ids,
+                    ):
+                        yield _message_fragment(request, message)
                     break
         finally:
-            await services.unsubscribe_plotting_room_live(parsed_room_id, queue)
+            if queue is not None:
+                await stream_services.unsubscribe_plotting_room_live(parsed_room_id, queue)
+            if stream_opened:
+                plotting_stream_closed()
+            close_request_services(request)
 
     return EventStream(generate())
+
+
+def _unseen_messages(
+    messages: list[PlottingRoomMessageView],
+    seen_message_ids: set[int],
+) -> list[PlottingRoomMessageView]:
+    unseen = [item for item in messages if item.message.id not in seen_message_ids]
+    seen_message_ids.update(item.message.id for item in unseen)
+    return unseen
+
+
+def _message_fragment(request: Request, message: PlottingRoomMessageView) -> Fragment:
+    return Fragment(
+        "plotting/{room_id}/page.html",
+        "plotting_room_message_item",
+        target="plotting-room-message",
+        item=_ScopedPlottingRoomMessageView(request, message),
+    )
 
 
 def _parse_room_id(value: str) -> int:

--- a/src/elbysodic/web/pounce_railway.py
+++ b/src/elbysodic/web/pounce_railway.py
@@ -1,9 +1,11 @@
 """Pounce 0.9 Railway bundle defaults for Elbysodic production launch.
 
 Aligns with lbliii/pounce ``examples/deploy/railway`` (#248, #291):
-``/readyz`` exposes JSON ``{"status":"draining"}`` during deploy overlap,
-``shutdown_timeout`` stays within Railway's ``drainingSeconds`` window, and
-``POUNCE_BUILD_ID`` surfaces through ``/_pounce/info`` when introspection is on.
+``shutdown_timeout`` stays within Railway's ``drainingSeconds`` window and
+``POUNCE_BUILD_ID`` surfaces through ``/_pounce/info`` when introspection is
+on. Pounce 0.9.1 process workers do not receive the explicit drain command
+(lbliii/pounce#316), so Railway stays on one worker until that upstream
+lifecycle contract is released and proven here.
 """
 
 from __future__ import annotations
@@ -25,8 +27,7 @@ def _railway_server_config_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     patched = dict(kwargs)
     patched["health_check_path"] = POUNCE_HEALTH_CHECK_PATH
     patched["shutdown_timeout"] = POUNCE_SHUTDOWN_TIMEOUT
-    if os.environ.get("ELBYSODIC_RAILWAY_PROBE_SMOKE") == "1":
-        patched["workers"] = 1
+    patched["workers"] = 1
     if _introspection_enabled():
         patched["introspection_enabled"] = True
         patched["introspection_bind"] = "0.0.0.0"  # noqa: S104 -- Railway public bind when introspection is explicitly enabled

--- a/src/elbysodic/web/worker_draining.py
+++ b/src/elbysodic/web/worker_draining.py
@@ -10,12 +10,19 @@ the worker exits.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+import logging
+import os
+import sys
+import threading
+from typing import Any, cast
 
 from chirp._internal.asgi import Receive, Scope, Send
 from chirp.app import App
 
 _DRAIN_EVENT: asyncio.Event | None = None
+_PLOTTING_STREAMS_ACTIVE = 0
+_PLOTTING_STREAMS_LOCK = threading.Lock()
+_LOGGER = logging.getLogger("pounce.elbysodic")
 
 
 def _drain_event() -> asyncio.Event:
@@ -28,11 +35,26 @@ def _drain_event() -> asyncio.Event:
 def reset_worker_draining() -> None:
     """Clear the draining flag at worker startup (TestClient + Pounce)."""
     global _DRAIN_EVENT
+    global _PLOTTING_STREAMS_ACTIVE
     _DRAIN_EVENT = asyncio.Event()
+    with _PLOTTING_STREAMS_LOCK:
+        _PLOTTING_STREAMS_ACTIVE = 0
+    gil_probe = getattr(sys, "_is_gil_enabled", None)
+    gil_enabled = bool(gil_probe()) if callable(gil_probe) else True
+    build_id = os.environ.get("POUNCE_BUILD_ID", "unset")
+    _LOGGER.info(
+        "event=worker_started plotting_streams_active=0 build_id=%s gil_enabled=%s",
+        build_id,
+        str(gil_enabled).lower(),
+    )
 
 
 def signal_worker_draining() -> None:
     """Mark the current worker as draining so SSE generators exit."""
+    _LOGGER.info(
+        "event=worker_draining plotting_streams_active=%d",
+        active_plotting_streams(),
+    )
     _drain_event().set()
 
 
@@ -42,6 +64,32 @@ def is_worker_draining() -> bool:
 
 async def wait_for_worker_draining() -> None:
     await _drain_event().wait()
+
+
+def active_plotting_streams() -> int:
+    """Return this worker's aggregate plotting-stream gauge."""
+    with _PLOTTING_STREAMS_LOCK:
+        return _PLOTTING_STREAMS_ACTIVE
+
+
+def plotting_stream_opened() -> int:
+    """Increment and report the aggregate plotting-stream gauge."""
+    global _PLOTTING_STREAMS_ACTIVE
+    with _PLOTTING_STREAMS_LOCK:
+        _PLOTTING_STREAMS_ACTIVE += 1
+        active = _PLOTTING_STREAMS_ACTIVE
+    _LOGGER.info("event=plotting_stream_opened plotting_streams_active=%d", active)
+    return active
+
+
+def plotting_stream_closed() -> int:
+    """Decrement and report the aggregate plotting-stream gauge."""
+    global _PLOTTING_STREAMS_ACTIVE
+    with _PLOTTING_STREAMS_LOCK:
+        _PLOTTING_STREAMS_ACTIVE = max(0, _PLOTTING_STREAMS_ACTIVE - 1)
+        active = _PLOTTING_STREAMS_ACTIVE
+    _LOGGER.info("event=plotting_stream_closed plotting_streams_active=%d", active)
+    return active
 
 
 async def _worker_lifecycle_receive() -> dict[str, Any]:
@@ -71,6 +119,22 @@ class DrainingAwareApp:
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._app, name)
+
+    def run(
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        *,
+        lifecycle_collector: Any | None = None,
+    ) -> None:
+        """Launch Pounce with this proxy as the runtime ASGI application."""
+        self._app._ensure_frozen()
+        self._app._server.run(
+            cast(App, self),
+            host=host,
+            port=port,
+            lifecycle_collector=lifecycle_collector,
+        )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope.get("type") == "pounce.worker.draining":

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -12,6 +12,7 @@ from elbysodic.db import ForumRepository, connect
 from elbysodic.services import create_services
 from elbysodic.web.state import close_request_services, configure_services, get_services
 from elbysodic.web.surface_contracts import SURFACE_CONTRACTS, validate_surface_contracts
+from elbysodic.web.worker_draining import DrainingAwareApp
 
 REPO_ROOT = Path(__file__).parents[1]
 WEB_DIR = REPO_ROOT / "src" / "elbysodic" / "web"
@@ -57,6 +58,35 @@ class TrackingDatabase:
         return self.context
 
 
+def test_draining_proxy_is_the_runtime_asgi_application() -> None:
+    captured: dict[str, object] = {}
+
+    class ServerStub:
+        def run(self, app: object, **kwargs: object) -> None:
+            captured["app"] = app
+            captured.update(kwargs)
+
+    class AppStub:
+        def __init__(self) -> None:
+            self._server = ServerStub()
+            self.frozen = False
+
+        def _ensure_frozen(self) -> None:
+            self.frozen = True
+
+    inner = AppStub()
+    proxy = DrainingAwareApp(cast(Any, inner))
+    proxy.run(host="127.0.0.1", port=8765)
+
+    assert inner.frozen is True
+    assert captured == {
+        "app": proxy,
+        "host": "127.0.0.1",
+        "port": 8765,
+        "lifecycle_collector": None,
+    }
+
+
 def test_file_backed_request_services_are_cached_and_closed(tmp_path: Path) -> None:
     root_services = create_services(path=tmp_path / "elbysodic.sqlite3")
     configure_services(root_services)
@@ -75,6 +105,15 @@ def test_file_backed_request_services_are_cached_and_closed(tmp_path: Path) -> N
         with pytest.raises(sqlite3.ProgrammingError, match="closed"):
             first.repo.connection.execute("SELECT 1")
         assert request._cache == {}
+
+        # Streaming response bodies begin after ordinary response middleware
+        # cleanup under Pounce, so the same request can open one fresh facade
+        # for the generator lifetime and close it explicitly afterward.
+        streaming = get_services(request)
+        assert streaming is not first
+        assert streaming.repo.connection.execute("SELECT 1").fetchone()[0] == 1
+        close_request_services(request)
+
         assert (
             root_services.repo.connection.execute("SELECT COUNT(*) FROM communities").fetchone()[0]
             > 0

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import sqlite3
 from pathlib import Path
@@ -42,7 +43,7 @@ from elbysodic.services.operations import (
 from elbysodic.web import create_app
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_scoped_path, scope_response_urls
-from elbysodic.web.worker_draining import emit_worker_draining
+from elbysodic.web.worker_draining import active_plotting_streams, emit_worker_draining
 from tests._db_lifecycle import preserve_test_connection, release_test_connection
 from tests._sql_probe import trace_sql
 
@@ -9728,7 +9729,9 @@ def test_plotting_room_sse_ready_event_uses_safe_channel() -> None:
     asyncio.run(run())
 
 
-def test_plotting_room_sse_closes_cleanly_on_worker_draining() -> None:
+def test_plotting_room_sse_closes_cleanly_on_worker_draining(caplog) -> None:
+    caplog.set_level(logging.INFO, logger="pounce.elbysodic")
+
     async def run() -> None:
         app = _app()
         async with TestClient(app) as client:
@@ -9769,6 +9772,7 @@ def test_plotting_room_sse_closes_cleanly_on_worker_draining() -> None:
                 charlie_client.sse(stream_path, max_events=5, disconnect_after=5.0)
             )
             await asyncio.sleep(0.1)
+            assert active_plotting_streams() == 1
 
             message = await charlie_client.post(
                 f"/plotting/{room.id}",
@@ -9785,6 +9789,7 @@ def test_plotting_room_sse_closes_cleanly_on_worker_draining() -> None:
 
             await emit_worker_draining(charlie_app)
             stream = await stream_task
+            assert active_plotting_streams() == 0
 
             room_page = await charlie_client.get(f"/plotting/{room.id}")
             assert 'sse-close="pounce.worker.draining"' in room_page.text
@@ -9800,6 +9805,9 @@ def test_plotting_room_sse_closes_cleanly_on_worker_draining() -> None:
         close_events = [event for event in stream.events if event.event == "pounce.worker.draining"]
         assert len(close_events) == 1
         assert close_events[0].data == "complete"
+        messages = [record.getMessage() for record in caplog.records]
+        assert "event=worker_draining plotting_streams_active=1" in messages
+        assert "event=plotting_stream_closed plotting_streams_active=0" in messages
 
     asyncio.run(run())
 

--- a/tests/test_railway_probe_smoke.py
+++ b/tests/test_railway_probe_smoke.py
@@ -8,6 +8,8 @@ from pounce._health import build_health_response
 from pounce._request_pipeline import maybe_build_builtin_response
 from pounce.config import ServerConfig
 
+from elbysodic.web.pounce_railway import _railway_server_config_kwargs
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RAILWAY_JSON = REPO_ROOT / "railway.json"
 
@@ -44,6 +46,13 @@ def test_readyz_draining_contract_returns_json_503() -> None:
     assert head is not None
     assert head.status == 503
     assert json.loads(head.body.decode("utf-8"))["status"] == "draining"
+
+
+def test_railway_bundle_uses_single_worker_until_process_drain_is_fixed() -> None:
+    config = _railway_server_config_kwargs({"workers": 48})
+
+    assert config["workers"] == 1
+    assert config["health_check_path"] == "/readyz"
 
 
 @pytest.mark.process


### PR DESCRIPTION
## Summary

- pass the drain-aware ASGI proxy itself to Pounce so `pounce.worker.draining` can reach Elbysodic
- keep request-scoped SQLite services alive for the full plotting SSE generator lifetime, then close them deterministically
- track aggregate per-worker plotting-stream opens/closes and log only build/runtime posture plus counts
- add a staging-only authenticated handoff probe that verifies acknowledged writes, persistence, reconnect, readiness, and privacy boundaries without printing credentials or message bodies
- pin Railway to one worker while Pounce 0.9.1 process-mode drain signaling is blocked on [lbliii/pounce#316](https://github.com/lbliii/pounce/issues/316)
- record the dated staging pass/fail evidence in both Railway smoke documents

Advances #276. This PR intentionally does **not** close it: the retiring-instance `503 {"status":"draining"}` acceptance remains blocked upstream.

## Live staging evidence

- diagnostic active deployment: `64120b47-4cc5-4e22-b1ed-823f376e0ae0`
- diagnostic replacement: `1349d70f-fe0b-4311-89cf-213736285420`
- corrected safe deployment: `cb5e8924-1ba1-4167-a6e6-b75ecaa76036`
- deployed code/build id: `c2cdb855e01358318df9b50fabd4f66cdf2f8c82`
- one Railway replica and `/app/var` volume
- Python 3.14.2 with GIL enabled; corrected deployment uses one async worker and started at aggregate stream gauge `0`
- authenticated seeded-writer SSE opened at gauge `1`; the pre-deploy marker returned `302`, persisted, and was acknowledged; the replacement accepted a reconnect
- exact-instance SSH observation saw `/readyz` `200 ok` until Railway retired the instance; it did not see `503 draining`, and the process worker emitted no app drain event
- public `/_pounce/info` remained behind the application login boundary
- production was not mutated or restarted

## Proof

- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run pytest -q --tb=short`
- `uv run ty check src/elbysodic/ tests/`
- `uv run python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check()"`

All passed on the PR tree. App check: 56 routes, 313 templates, all clear.

## Steward Notes

- Consulted: Web, Services, Tests, Docs, Changelog, and the Surface Contract Steward requirements from the root constitution.
- Accepted: runtime proxy ownership, generator-lifetime repository ownership, aggregate-only observability, staging-only write guard, explicit GIL/build evidence, public introspection privacy, accurate pass/fail smoke records, and a user-visible release fragment.
- Deferred: process-worker drain command and retiring-listener `503` proof to lbliii/pounce#316; issue #276 stays open until that upstream release is explicitly approved, adopted, and reproven.
- Proof: focused lifecycle/request-cleanup tests, full repository gate, two real staging promotions, exact-instance operator observation, and redacted Railway logs.
- Collateral: both Railway smoke records and `changelog.d/+plotting-drain-lifecycle.fixed.md` updated.
- No schema/migration collateral: no data model or migration changed.
- Remaining risk: merging auto-deploys production. Keep this PR draft and do not merge without separate production approval.

| Contract | Runtime | Service/repository | Rendered plotting surface | Docs | Changelog | Tests |
|---|---|---|---|---|---|---|
| Worker drain reaches app | proxy passed to Pounce | no change | stream closes on lifecycle event | partial live proof + upstream blocker | fixed fragment | runtime proxy + SSE drain regression |
| Stream storage lifetime | Pounce consumes body after middleware cleanup | generator owns fresh tenant-aware facade | acknowledged messages remain available | staging write/persistence record | fixed fragment | request cleanup + rendered SSE tests |
| Railway readiness | one worker pending upstream process fix | no change | no public introspection added | `503` claim explicitly withheld | no extra fragment | local Pounce readiness shape test |

## Merge boundary

Draft only. Merging this PR triggers both staging and production deployments in the current repository configuration. Production approval has not been granted for this change.

