### PR TITLE
Make passkey staging QA self-cleaning

### DIFF
--- a/changelog.d/+passkey-qa-cleanup.fixed.md
+++ b/changelog.d/+passkey-qa-cleanup.fixed.md
@@ -1,0 +1,1 @@
+Passkey browser QA now removes its timestamped virtual-authenticator credential and logs out its cleanup session after proving registration and sign-in.

--- a/docs/operations/onboarding-browser-qa.md
+++ b/docs/operations/onboarding-browser-qa.md
@@ -74,8 +74,9 @@ ELBYSODIC_ENV=development uv run python scripts/passkey_qa.py \
 ```
 
 The script registers a passkey, logs out, signs back in with the passkey, and
-checks browser-visible regressions for revoked credentials and unknown
-authenticator credentials. Wrong-origin rejection is covered by
+removes the exact timestamped QA credential before it exits. It also checks
+browser-visible regressions for revoked credentials and unknown authenticator
+credentials. Wrong-origin rejection is covered by
 `tests/test_passkey_contracts.py`; to exercise it in the browser, restart the
 server with a pinned localhost origin while browsing via `127.0.0.1`, then run:
 
@@ -91,6 +92,24 @@ PASSKEY_QA_WRONG_ORIGIN=1 \
 ELBYSODIC_ENV=development uv run python scripts/passkey_qa.py \
   --base-url http://localhost:8007 \
   --profile wrong-origin
+```
+
+Latest staging passkey smoke:
+
+```text
+- Date: 2026-07-20
+- URL: https://elbysodic-staging.up.railway.app
+- Deployment: cb5e8924-1ba1-4167-a6e6-b75ecaa76036 (SUCCESS)
+- Profile: happy, Playwright Chromium virtual authenticator
+- Account class: seeded staging writer
+- Registration: passed through the rendered identity-settings flow
+- Logout and passkey sign-in: passed; the writer returned to identity settings
+- Cleanup: passed; the exact timestamped QA credential was removed and the
+  cleanup session was logged out
+- Privacy: no credential id, public key, cookie, password, email address, or
+  WebAuthn challenge was printed or recorded
+- Production: untouched; this is staging proof only
+- Result: passkey staging acceptance for Elbysodic #223 passed
 ```
 
 ## Manual Inspection

--- a/scripts/passkey_qa.py
+++ b/scripts/passkey_qa.py
@@ -115,6 +115,19 @@ async def _remove_registered_passkey(page: Page, base_url: str, label: str) -> N
     )
 
 
+async def _cleanup_registered_passkey(page: Page, base_url: str, label: str) -> None:
+    """Remove the exact QA credential and revoke the cleanup session."""
+    await page.goto(urljoin(base_url, "/logout"), wait_until="domcontentloaded")
+    await _password_login(page, base_url, QA_EMAIL)
+    await page.goto(urljoin(base_url, "/identity"), wait_until="domcontentloaded")
+    item = page.locator(".elbysodic-passkey-list__item").filter(has_text=label)
+    if await item.count():
+        await item.get_by_role("button", name="Remove").click()
+        await page.wait_for_url("**/identity")
+        await item.wait_for(state="detached")
+    await _logout(page, base_url)
+
+
 def _bump_passkey_sign_count(db_path: str, label: str) -> None:
     connection = sqlite3.connect(db_path)
     try:
@@ -155,7 +168,10 @@ async def _run_happy_path(browser: Browser, base_url: str) -> None:
         await _passkey_login(page, base_url, next_path="/identity")
         await page.locator("strong", has_text=QA_EMAIL).wait_for()
     finally:
-        await context.close()
+        try:
+            await _cleanup_registered_passkey(page, base_url, label)
+        finally:
+            await context.close()
 
 
 async def _run_revoked_credential(browser: Browser, base_url: str) -> None:


### PR DESCRIPTION
## Summary

- make the Playwright passkey happy path remove its exact timestamped QA credential in a `finally` cleanup
- revoke the password-authenticated cleanup session before the browser closes
- record the successful HTTPS Railway staging ceremony without storing credential or account material

Completes the remaining live-staging acceptance evidence for #223. The passkey product implementation already shipped through #245–#248; this PR keeps future verification runs self-cleaning.

## Staging proof

- date: 2026-07-20
- deployment: `cb5e8924-1ba1-4167-a6e6-b75ecaa76036`
- environment: Railway staging only
- profile: Playwright Chromium virtual authenticator, `happy`
- passed: password login → passkey registration → logout → passkey sign-in → exact credential removal → cleanup logout
- privacy: no credential id, public key, challenge, cookie, password, or email address was printed or recorded
- production: untouched

## Local proof

- `uv run pytest -q tests/test_passkey_contracts.py --tb=short` — 20 passed
- `uv run ruff check scripts/passkey_qa.py`
- `uv run ruff format scripts/passkey_qa.py --check`
- `uv run python scripts/check_changelog_fragments.py`
- `git diff --check`

## Steward Notes

- Consulted: Web, Tests, Docs, Changelog, and onboarding privacy requirements.
- Accepted: exact-label cleanup, session revocation, aggregate-only staging record, and focused contract proof.
- No schema/service/product collateral: the passkey product contract is unchanged; this modifies only operator QA cleanup and its record.
- Remaining risk: merging triggers the repository's production deployment workflow even though runtime code is unchanged. Keep draft pending separate production approval.

