### PR TITLE
Enable structured production logging

### DIFF
--- a/changelog.d/+structured-production-logging.changed.md
+++ b/changelog.d/+structured-production-logging.changed.md
@@ -1,0 +1,1 @@
+Changed staging and production to emit Chirp/Pounce structured JSON logs with an allowlisted `CHIRP_LOG_LEVEL`, and documented request/trace correlation plus state-specific timeout alert codes.

--- a/docs/architecture/sqlite-request-lifecycle.md
+++ b/docs/architecture/sqlite-request-lifecycle.md
@@ -76,6 +76,11 @@ slowness:
 - Inspect the response `Server-Timing` header for server-side route duration.
   Use this when the browser timing is high and you need to separate template or
   SQLite work from client-side rendering and network overhead.
+- Production JSON access logs already carry Pounce's end-to-end
+  `duration_ms`. The app-owned timing middleware remains intentionally narrower:
+  it supplies the response `Server-Timing`/`X-Elbysodic-Route-Time-Ms` headers
+  used by browser QA and the local diagnostic harness. It does not emit a
+  second request log or replace the framework access-log clock.
 - Reproduce suspicious fanout with the query-budget tests in
   `tests/test_forum_slice.py`. Budgets are the regression contract; browser and
   `Server-Timing` captures explain where to look before changing them.

--- a/docs/operations/railway-smoke.md
+++ b/docs/operations/railway-smoke.md
@@ -39,6 +39,30 @@ Required staging variables:
 - `ELBYSODIC_AUTO_SEED_DEMO=1`
 - `ELBYSODIC_SECRET_KEY=<staging-only random secret>`
 - `ELBYSODIC_DB_PATH=/app/var/elbysodic.sqlite3`
+- `CHIRP_LOG_LEVEL=info` (or an allowlisted operational override: `debug`,
+  `warning`, `error`, or `critical`)
+
+Elbysodic forces Chirp/Pounce `log_format=json` whenever
+`ELBYSODIC_ENV` resolves to staging or production. Do not set a Railway
+`CHIRP_LOG_FORMAT` override: production JSON is an application contract, while
+local development keeps the framework's TTY-aware `auto` format.
+
+Structured framework records use the common `ts`, `level`, `logger`, and
+`message` envelope. Access records add `method`, `path`, `status`, `bytes`,
+`duration_ms`, `client`, and the full `req_id` when present, so Railway searches
+can correlate a response with its `X-Request-ID`. Chirp's structured log helper
+also adds `trace_id` and `span_id` when Pounce has an active OpenTelemetry span;
+the lookup is guarded, so Elbysodic does not add an OpenTelemetry runtime
+dependency merely to keep JSON logging enabled.
+
+Alert/runbook searches should distinguish Pounce 0.9 timeout states:
+
+- `POUNCE_TIMEOUT_REQUEST_BODY`: the client did not finish sending the request
+  body inside `request_timeout`; inspect client/proxy upload behavior before
+  raising the limit.
+- `POUNCE_TIMEOUT_WRITE`: the client did not accept response bytes inside the
+  write timeout and Pounce closed the connection; inspect slow readers, proxy
+  backpressure, and large/streamed responses before changing timeouts.
 
 Railway deploy overlap/drain settings (Pounce 0.9 bundle, lbliii/pounce #248/#291):
 

--- a/src/elbysodic/web/app.py
+++ b/src/elbysodic/web/app.py
@@ -52,6 +52,8 @@ from elbysodic.web.worker_draining import (
 PAGES_DIR = Path(__file__).parent / "pages"
 STATIC_DIR = Path(__file__).parent / "static"
 DEV_TOOLS_ENV = "ELBYSODIC_DEV_TOOLS"
+CHIRP_LOG_LEVEL_ENV = "CHIRP_LOG_LEVEL"
+_CHIRP_LOG_LEVELS = frozenset({"debug", "info", "warning", "error", "critical"})
 
 
 def create_app(
@@ -83,6 +85,13 @@ def create_app(
         # Worker lifecycle hooks (reset_worker_draining) require async workers
         # in production so Pounce emits pounce.worker.startup/shutdown scopes.
         worker_mode="async" if not debug else "auto",
+        # Railway log search depends on a stable JSON envelope. Development
+        # keeps Chirp/Pounce's TTY-aware auto format, while staging and
+        # production always emit structured records. The level remains an
+        # operator knob with the same allowlist/fallback semantics as
+        # AppConfig.from_env().
+        log_format="json" if security.production else "auto",
+        log_level=_chirp_log_level(),
     )
     app = App(config=config)
     app.on_worker_startup(reset_worker_draining)
@@ -209,6 +218,11 @@ def _resolve_dev_tools(*, debug: bool, dev_tools: bool | None, production: bool)
     if configured is not None:
         return configured.strip().lower() not in {"0", "false", "no", "off"}
     return debug
+
+
+def _chirp_log_level() -> str:
+    configured = (os.environ.get(CHIRP_LOG_LEVEL_ENV) or "").strip().lower()
+    return configured if configured in _CHIRP_LOG_LEVELS else "info"
 
 
 def community_initials(name: object) -> str:

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -173,6 +173,28 @@ def test_production_config_parses_allowed_hosts_and_hsts(monkeypatch) -> None:
     assert app.config.strict_transport_security == "max-age=31536000"
 
 
+def test_production_config_forces_json_logs_and_honors_chirp_log_level(monkeypatch) -> None:
+    _set_production_env(monkeypatch)
+    monkeypatch.setenv("CHIRP_LOG_LEVEL", "WARNING")
+
+    app = create_app(debug=False, services=create_services(path=":memory:"))
+
+    assert app.config.log_format == "json"
+    assert app.config.log_level == "warning"
+
+
+def test_invalid_chirp_log_level_falls_back_without_changing_development_format(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("ELBYSODIC_ENV", raising=False)
+    monkeypatch.setenv("CHIRP_LOG_LEVEL", "verbose")
+
+    app = create_app(debug=True, services=create_services(path=":memory:"))
+
+    assert app.config.log_format == "auto"
+    assert app.config.log_level == "info"
+
+
 def test_chirp_runtime_provisions_htmx_for_hypermedia_templates() -> None:
     async def run() -> None:
         app = create_app(debug=False, services=create_services(path=":memory:"))


### PR DESCRIPTION
## Summary

- force Chirp/Pounce structured JSON logging whenever Elbysodic resolves staging or production
- honor `CHIRP_LOG_LEVEL` through the framework-compatible debug/info/warning/error/critical allowlist, falling back to `info`
- document Railway JSON/access-log correlation, guarded OTel trace/span enrichment, and Pounce's request-body/write timeout codes
- retain the app timing middleware only for its distinct browser-facing `Server-Timing` contract

Closes #222

## Why

Railway log search needs stable fields rather than TTY-dependent formatting. Chirp 0.10 and Pounce 0.9 already own JSON envelopes, request IDs, access durations, and guarded OTel enrichment; Elbysodic was leaving their format in `auto` and had not documented the state-specific timeout codes. This slice activates and records those existing framework contracts without adding a logging/OTel dependency or duplicating access logs.

## Steward Notes

- Web/runtime: accepted config-only wiring in `create_app`; no route, middleware order, request context, or persistence behavior changed.
- Operations: accepted JSON as a staging/production application invariant and `CHIRP_LOG_LEVEL` as the only documented operator level knob. No Railway variable was written.
- Security/privacy: log docs name structural fields only; no credentials, cookies, request bodies, identity names, or private workflow content are added to logs.
- Performance: Pounce remains the single access-log duration owner. `RequestTimingMiddleware` stays because browser QA consumes response headers and it emits no second log.
- Dependencies: no dependency or lockfile change. Chirp's `trace_id`/`span_id` lookup stays guarded and activates only with an ambient Pounce OTel span.

## Validation

- `uv run ruff check .`
- `uv run ruff format . --check` — 248 files
- `uv run ty check src/elbysodic/ tests/`
- app check — 56 routes, 313 templates
- `uv run pytest -q --tb=short` — complete suite passed
- combined full gate: 642 seconds

## Deployment note

No staging or production variables, deploys, restarts, or live logs were changed or inspected. Once merged and deployed through the normal separately approved path, staging/production will use JSON automatically; operators may set `CHIRP_LOG_LEVEL` independently.
