### PR TITLE
Drain remaining design-essay Chirp-UI foundation language (#302)

### DIFF
--- a/changelog.d/+design-essays-chirp-ui-exit.changed.md
+++ b/changelog.d/+design-essays-chirp-ui-exit.changed.md
@@ -1,0 +1,1 @@
+Design essays now treat Chirp-UI as leftover under ADR 0002 rather than the component foundation.

--- a/design/component-inventory.md
+++ b/design/component-inventory.md
@@ -9,14 +9,19 @@ promoting page-local UI into `src/elbysodic/web/pages/_components/`.
 
 ## Current Product Layer
 
-Elbysodic already has a real product-design layer on top of Chirp-UI:
+Elbysodic already has a real product-design layer. Chirp-UI leftovers remain
+in templates and token aliases; they are an exit target (ADR 0002), not the
+foundation:
 
-- Chirp primitives provide structure: `surface`, `badge`, `avatar`,
-  `avatar_stack`, `timeline`, `description_list`, buttons, chips, fields,
-  clusters, stacks, breadcrumbs, and tooltips.
-- Elbysodic theme tokens map product colors, prose, focus, shell, media, card,
-  radius, and shadow behavior through Chirp token names in
-  `src/elbysodic/web/static/elbysodic-theme.css`.
+- Elbysodic primitives and `_components/` own structure going forward.
+  Leftover Chirp-UI names (`surface`, `badge`, `avatar`, `avatar_stack`,
+  `timeline`, `description_list`, buttons, chips, fields, clusters, stacks,
+  breadcrumbs, and tooltips) still appear in markup as a migration layer
+  to drain.
+- Elbysodic theme tokens map product colors, prose, focus, shell, media,
+  card, radius, and shadow behavior in
+  `src/elbysodic/web/static/elbysodic-theme.css`. Leftover `--chirpui-*`
+  names are aliases to drain, not new foundation tokens.
 - Shared PBP concepts are partially promoted into
   `src/elbysodic/web/pages/_components/`.
 - Ritual surfaces already exist for world, board/location, thread, character,
@@ -63,8 +68,9 @@ and some are repeated card patterns that need clearer product roles.
 
 ## Token Roles To Add Or Audit
 
-Current CSS already maps Chirp-UI core tokens. The next token pass should audit
-or introduce Elbysodic aliases for product meaning:
+Current CSS still maps leftover Chirp-UI core tokens. The next token pass
+should audit or introduce Elbysodic aliases for product meaning and stop
+adding `--chirpui-*` aliases:
 
 - `--elbysodic-key-dark`
 - `--elbysodic-key-light`
@@ -82,9 +88,9 @@ or introduce Elbysodic aliases for product meaning:
 - `--elbysodic-glass-border`
 - `--elbysodic-motion-*`
 
-These aliases should feed Chirp tokens or component CSS. They should not become
+These aliases should feed Elbysodic component CSS. They should not become
 director-editable contract fields until Appearance Studio and Blueprint
-contracts are explicitly reviewed.
+contracts are explicitly reviewed. Do not add new `--chirpui-*` aliases.
 
 ## First Canonical Proof Patterns
 

--- a/design/technicolor-futurism-roadmap.md
+++ b/design/technicolor-futurism-roadmap.md
@@ -7,31 +7,27 @@ runtime dependencies, or Appearance Studio behavior without an explicit human
 check-in and the relevant stewards.
 
 Target vision: technicolor futurism that feels luminescent, clean, striking,
-and editorially prestigious, with reading-first PBP flow and Chirp-UI as the
-structural library. Elbysodic personality should be layered through tokens,
-surface rules, repeated PBP components, media treatment, and safe art-direction
-programming.
+and editorially prestigious, with reading-first PBP flow. Chirp + Kida +
+HTMX + Alpine stay the hypermedia stack. Elbysodic owns primitives and
+tokens; Chirp-UI is leftover (ADR 0002), not the structural library.
+Personality should be layered through tokens, surface rules, repeated PBP
+components, media treatment, and safe art-direction programming.
 
 ## Current-State Assessment
 
 ### What Is Already Working
 
 - `src/elbysodic/web/static/elbysodic-theme.css` already behaves like a
-  product layer on top of Chirp-UI instead of replacing Chirp-UI. It maps
-  Elbysodic values into Chirp token names such as `--chirpui-bg`,
-  `--chirpui-surface`, `--chirpui-accent`, `--chirpui-text`,
-  `--chirpui-border`, focus, link, radius, shadow, and mode tokens.
+  product token layer. Named Elbysodic values exist for canvas, surface,
+  accent, text, border, focus, link, radius, shadow, and mode. Leftover
+  `--chirpui-*` aliases are a migration layer to drain (ADR 0002), not
+  the design-system foundation.
 - Shared PBP vocabulary has started moving into
   `src/elbysodic/web/pages/_components/`: boards, sidebar, facets, post
   frames, composer controls, wanted cards, plot hooks, thread summaries, and
   generic vocabulary components such as `local_rail`, `preview_row`,
   `metric_item`, `command_action`, `command_panel`, `lane_preview`,
   `production_room_card`, and `room_header`.
-- The app uses Chirp-UI primitives heavily and appropriately: `container`,
-  `stack`, `cluster`, `surface`, `badge`, `breadcrumbs`, `section_header`,
-  `tooltip`, `avatar_stack`, `timeline`, `stat`, buttons, chips, and
-  form-field classes. That keeps accessibility and structural behavior rooted
-  in the library.
 - Ritual surfaces already carry visual identity: world hero, network
   billboard, board stage, board posters, thread stage, character/profile
   posters, post profile rail variants, material heroes, event actions, and
@@ -60,11 +56,16 @@ programming.
   futurism. Current anchors are ink, paper, rose, moss, and gold. They are
   tasteful and readable, but not yet luminescent, clean, cool, or striking
   enough to establish the desired first impression.
-- Color roles are not yet a full color score. The theme has useful Chirp token
-  mappings, but Elbysodic-specific product roles are still incomplete:
-  identity dye, atmosphere dye, active face, staff/private state, queue states,
-  on-media overlays, material intensity, and surface intensity are not all
-  named as stable token purposes.
+- Templates still import leftover Chirp-UI primitives (`container`, `stack`,
+  `cluster`, `surface`, `badge`, `breadcrumbs`, `section_header`, `tooltip`,
+  `avatar_stack`, `timeline`, `stat`, buttons, chips, and form-field
+  classes). ADR 0002 treats those as an exit target. New UI uses Elbysodic
+  class names and `_components/`.
+- Color roles are not yet a full color score. The theme still has leftover
+  Chirp-UI token mappings, but Elbysodic-specific product roles are still
+  incomplete: identity dye, atmosphere dye, active face, staff/private
+  state, queue states, on-media overlays, material intensity, and surface
+  intensity are not all named as stable token purposes.
 - CSS is doing a lot of product-system work in one large file. That is allowed
   by the current architecture, but the meaning of major component families is
   easier to infer from selectors than to verify from a smaller token/component
@@ -100,7 +101,7 @@ programming.
 - Need a cooler default key system: blue-black or graphite dark mode, cool
   porcelain light mode, crisp borders, high-legibility text, and less warm
   paper dominance.
-- Need explicit dye roles layered over Chirp tokens:
+- Need explicit dye roles layered over Elbysodic tokens:
   `identity_dye`, `atmosphere_dye`, `state_dyes`, `active_face`,
   `private_state`, `staff_state`, `on_media`, `focus`, and `editorial_rule`.
 - Need state colors for PBP obligations beyond generic success/warning/error:
@@ -160,9 +161,10 @@ programming.
 1. Reading is the prestige surface. Thread prose, guidebook material,
    applications, and composer preview stay calmer than heroes and network
    cards.
-2. Chirp-UI remains the structural library. Elbysodic should extend through
-   product tokens, macros, composition, and vocabulary, not by forking Chirp
-   primitives.
+2. Elbysodic owns primitives and tokens (ADR 0002). Chirp supplies pages,
+   Kida, HTMX, and Alpine. Extend through product tokens, `_components/`,
+   composition, and vocabulary. Do not treat leftover Chirp-UI as the
+   structural library.
 3. Community art direction is safe and scoped. Directors get approved tokens,
    media slots, variants, density, texture, and warnings, not raw CSS,
    arbitrary HTML, scripts, external font URLs, or layout builders.
@@ -582,7 +584,9 @@ For future visual implementation:
   directors.
 - No SPA redesign.
 - No generic SaaS dashboard redesign.
-- No replacement of Chirp-UI primitives.
+- No replacement of Chirp, Kida, HTMX, or Alpine.
+- No new Chirp-UI adoption; leftovers drain toward `_components/` and
+  Elbysodic primitives (ADR 0002).
 - No pixel-perfect design system detached from rendered PBP workflows.
 
 ## Programmatic Art Direction Without Contract Changes

--- a/design/technicolor-futurism.md
+++ b/design/technicolor-futurism.md
@@ -64,10 +64,13 @@ saturation.
    material use, and restraint rules. This can help a director generate a
    coherent board without raw CSS or skin work.
 
-## Relationship To Chirp-UI
+## Relationship To Chirp
 
-Chirp-UI is the foundation. Elbysodic should use its primitives, accessibility
-contracts, and token system first. The design system layer adds:
+Keep Chirp + Kida + HTMX + Alpine. Chirp-UI is leftover, not the foundation
+(ADR 0002). Elbysodic owns primitives and PBP components in
+`src/elbysodic/web/pages/_components/` and
+`src/elbysodic/web/static/elbysodic-theme.css`. The design system layer
+adds:
 
 - product-specific token aliases and defaults
 - PBP component vocabulary
@@ -76,10 +79,11 @@ contracts, and token system first. The design system layer adds:
 - state language for writing workflows
 - Appearance Studio constraints and warnings
 
-When a visual decision cannot be expressed through existing Chirp-UI tokens,
-prefer adding a small Elbysodic token with product meaning in
-`src/elbysodic/web/static/elbysodic-theme.css`. Do not create page-local color
-systems that bypass the theme.
+When a visual decision cannot be expressed through existing Elbysodic
+tokens, prefer adding a small Elbysodic token with product meaning in
+`src/elbysodic/web/static/elbysodic-theme.css`. Do not create page-local
+color systems that bypass the theme. Do not add new `chirpui-*` classes
+or `--chirpui-*` aliases.
 
 ## Token Direction
 
@@ -215,7 +219,7 @@ Ask these before accepting a UI or theme change:
 - Does this feel purpose-built for PBP, or could it be any SaaS dashboard?
 - Can a writer read a long thread here without fighting the styling?
 - Is the active face, scene, queue state, or staff/privacy boundary clearer?
-- Are Chirp-UI tokens doing the structural work?
+- Are Elbysodic tokens and `_components/` doing the structural work?
 - Is any new visual language repeated enough to become a component?
 - Does the page still work on mobile as a designed surface?
 - Are color, glow, blur, media, or motion serving hierarchy rather than noise?


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #302 / #300
- Outcome: `design/technicolor-futurism.md`, `design/technicolor-futurism-roadmap.md`, and `design/component-inventory.md` now match ADR 0002: keep Chirp + Kida + HTMX + Alpine; Chirp-UI is leftover, not the foundation.

## Owned paths

- `design/technicolor-futurism.md`
- `design/technicolor-futurism-roadmap.md`
- `design/component-inventory.md`

## Decisions frozen (do not reopen in review)

- ADR 0002 (`docs/adr/0002-chirp-ui-exit.md`). Do not re-open adopt-vs-exit.

## Acceptance run

```bash
rg -n 'Chirp-UI is the foundation|Chirp-UI remains' design/technicolor-futurism.md design/technicolor-futurism-roadmap.md design/component-inventory.md
```

Empty (exit 1 / no matches).

```bash
uv run ruff check .
```

All checks passed.

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: `no steward swarm: docs-only process leaf` (design essays only; aligned to existing ADR 0002 / design steward doctrine)
- Accepted / deferred: accepted ADR 0002 framing; leftover `chirpui-*` markup and `--chirpui-*` aliases named as drain targets, not foundation
- Proof: `rg` empty on foundation phrases; `uv run ruff check .` clean
- Collateral: `no collateral: design-essay language only; no writer-facing product behavior`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no (cites ADR 0002)
- Orchestrator merges; worker leaves PR open unless `ship` said merge
- Out of scope: `src/`, `design/AGENTS.md`, `design/README.md`