### PR TITLE
Define Elbysodic primitive CSS for buttons, fields, cluster, and stack

### DIFF
--- a/changelog.d/+elbysodic-primitive-css.changed.md
+++ b/changelog.d/+elbysodic-primitive-css.changed.md
@@ -1,0 +1,1 @@
+Theme CSS now defines Elbysodic primitive classes for buttons, fields, cluster, and stack so pages can drain off Chirp-UI macros.

--- a/docs/architecture/theme-css-architecture.md
+++ b/docs/architecture/theme-css-architecture.md
@@ -68,6 +68,17 @@ existing Elbysodic primitive or `_components/` pattern:
   row, director queue) stay Elbysodic-named even while a leaf still maps old
   Chirp-UI classes underneath.
 
+Public primitive classes live in `10-chirp-primitives.css`:
+
+| Class | Job |
+|---|---|
+| `elbysodic-btn` | Buttons and button-styled links (`--primary`, `--secondary`, `--ghost`, `--danger`, `--sm`). |
+| `elbysodic-field` | Labels, inputs, hints, and errors (`__label`, `__input`, `__hint`, `__error`, `--error`). |
+| `elbysodic-cluster` | Horizontal wrapped groups (`--xs`–`--lg`, `--between`, `--end`). |
+| `elbysodic-stack` | Vertical stacks (`--xs`–`--xl`). |
+
+Page leaves should use these names instead of importing `chirpui/*` macros.
+
 ## Decomposition Rule
 
 Moving CSS is not enough. Every touched selector should be classified as one of:
@@ -92,6 +103,7 @@ Use this table before adding a new card, row, poster, metric, or editor shell:
 | Media poster/fallback/overlay | Product-family CSS until shared behavior repeats across three families | Board, thread, character, post, and Network posters currently have different content and interaction contracts. |
 | Metric/signal rows | `_components/vocabulary.html` plus product-family wrappers | Use `metric()` and Elbysodic badges/counts; keep wrappers for needs reply, waiting, caught up, staff, and director signal language. |
 | Page command, pulse, preview, empty policy | `30-page-patterns.css` | These are route-level page vocabulary, not product-family cards. |
+| Button / field / cluster / stack | `10-chirp-primitives.css` (`elbysodic-btn`, `elbysodic-field`, `elbysodic-cluster`, `elbysodic-stack`) | Public primitive API. Leftover `chirpui-*` selectors in that file are a drain bridge. |
 | Form primitive | Elbysodic field classes | Product CSS may arrange fields; labels/inputs/tone come from Elbysodic primitives, not new Chirp-UI field classes. |
 | Responsive override | Owning CSS file | Put the media query after the base selector in the same family file. |
 

--- a/src/elbysodic/web/static/elbysodic-theme/00-tokens.css
+++ b/src/elbysodic/web/static/elbysodic-theme/00-tokens.css
@@ -72,6 +72,25 @@
     --elbysodic-ratio-poster: 2 / 3;
     --elbysodic-ratio-tall: 1 / 2;
 
+    /* Elbysodic primitive tokens (#301). Public API for btn/field/cluster/stack. */
+    --elbysodic-space-2xs: 0.25rem;
+    --elbysodic-space-xs: 0.5rem;
+    --elbysodic-space-sm: 0.75rem;
+    --elbysodic-space: 1rem;
+    --elbysodic-space-md: 1.25rem;
+    --elbysodic-space-lg: 1.5rem;
+    --elbysodic-space-xl: 2rem;
+    --elbysodic-stack-gap: var(--elbysodic-space);
+    --elbysodic-cluster-gap: var(--elbysodic-space-xs);
+    --elbysodic-radius: 0.5rem;
+    --elbysodic-radius-sm: 0.25rem;
+    --elbysodic-font-xs: 0.75rem;
+    --elbysodic-font-sm: 0.875rem;
+    --elbysodic-control-padding-block: 0.5rem;
+    --elbysodic-control-padding-inline: 0.875rem;
+    --elbysodic-focus-outline: 2px solid var(--elbysodic-identity-dye);
+    --elbysodic-focus-offset: 2px;
+
     --chirpui-bg: var(--elbysodic-key-dark);
     --chirpui-bg-subtle: var(--elbysodic-key-dark-1);
     --chirpui-surface: var(--elbysodic-key-dark-2);

--- a/src/elbysodic/web/static/elbysodic-theme/10-chirp-primitives.css
+++ b/src/elbysodic/web/static/elbysodic-theme/10-chirp-primitives.css
@@ -1,8 +1,13 @@
-/* Elbysodic theming for Chirp-UI primitives.
+/* Elbysodic primitive CSS (ADR 0002).
  *
- * Keep this file narrow: use Chirp's tone and appearance classes before adding
- * custom selectors here.
+ * Public API: elbysodic-btn, elbysodic-field, elbysodic-cluster, elbysodic-stack.
+ * Leftover chirpui-* selectors are a drain bridge until page markup moves.
+ * Do not add new Chirp-UI class names here.
  */
+
+/* -------------------------------------------------------------------------- */
+/* Drain bridge — existing chirpui-* markup                                   */
+/* -------------------------------------------------------------------------- */
 
 .chirpui-surface {
     border-color: var(--chirpui-border-subtle);
@@ -30,6 +35,276 @@
 
 .chirpui-theme-toggle {
     border-color: var(--chirpui-border);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Stack                                                                      */
+/* -------------------------------------------------------------------------- */
+
+.elbysodic-stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--elbysodic-stack-gap);
+}
+
+.elbysodic-stack--xs {
+    gap: var(--elbysodic-space-xs);
+}
+
+.elbysodic-stack--sm {
+    gap: var(--elbysodic-space-sm);
+}
+
+.elbysodic-stack--md {
+    gap: var(--elbysodic-space-md);
+}
+
+.elbysodic-stack--lg {
+    gap: var(--elbysodic-space-lg);
+}
+
+.elbysodic-stack--xl {
+    gap: var(--elbysodic-space-xl);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Cluster                                                                    */
+/* -------------------------------------------------------------------------- */
+
+.elbysodic-cluster {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--elbysodic-cluster-gap);
+}
+
+.elbysodic-cluster--xs {
+    gap: var(--elbysodic-space-xs);
+}
+
+.elbysodic-cluster--sm {
+    gap: var(--elbysodic-space-sm);
+}
+
+.elbysodic-cluster--md {
+    gap: var(--elbysodic-space-md);
+}
+
+.elbysodic-cluster--lg {
+    gap: var(--elbysodic-space-lg);
+}
+
+.elbysodic-cluster--between,
+.chirpui-cluster.elbysodic-cluster--between {
+    justify-content: space-between;
+}
+
+.elbysodic-cluster--end,
+.chirpui-cluster.elbysodic-cluster--end {
+    justify-content: flex-end;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Field                                                                      */
+/* -------------------------------------------------------------------------- */
+
+.elbysodic-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--elbysodic-space-xs);
+    margin-bottom: var(--elbysodic-space);
+}
+
+.elbysodic-field__label {
+    display: block;
+    font-size: var(--elbysodic-font-sm);
+    font-weight: 500;
+}
+
+.elbysodic-field__input {
+    display: block;
+    width: 100%;
+    padding: var(--elbysodic-space-sm);
+    border: 1px solid var(--chirpui-border);
+    border-radius: var(--elbysodic-radius-sm);
+    font: inherit;
+    background: var(--chirpui-surface);
+    color: var(--chirpui-text);
+    transition:
+        border-color var(--elbysodic-motion-feedback),
+        box-shadow var(--elbysodic-motion-feedback);
+}
+
+.elbysodic-field__input:focus {
+    outline: none;
+    border-color: var(--elbysodic-identity-dye);
+    box-shadow: 0 0 0 3px var(--chirpui-focus-ring);
+}
+
+.elbysodic-field__input:focus-visible {
+    outline: var(--elbysodic-focus-outline);
+    outline-offset: var(--elbysodic-focus-offset);
+}
+
+.elbysodic-field__input:disabled,
+.elbysodic-field__input[readonly] {
+    background: var(--chirpui-bg-subtle);
+    color: var(--chirpui-text-muted);
+    border-color: var(--chirpui-border);
+}
+
+.elbysodic-field__input[readonly] {
+    cursor: default;
+    opacity: 1;
+}
+
+.elbysodic-field__input:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.elbysodic-field__input[type="checkbox"],
+.elbysodic-field__input[type="radio"] {
+    width: auto;
+    accent-color: var(--elbysodic-identity-dye);
+}
+
+.elbysodic-field--error .elbysodic-field__input {
+    border-color: var(--elbysodic-state-error);
+}
+
+.elbysodic-field__hint {
+    display: block;
+    font-size: var(--elbysodic-font-sm);
+    color: var(--chirpui-text-muted);
+}
+
+.elbysodic-field__error {
+    display: block;
+    font-size: var(--elbysodic-font-sm);
+    color: var(--elbysodic-state-error);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Button                                                                     */
+/* -------------------------------------------------------------------------- */
+
+button.elbysodic-btn,
+a.elbysodic-btn {
+    cursor: pointer;
+}
+
+.elbysodic-btn {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--elbysodic-space-xs);
+    padding: var(--elbysodic-control-padding-block) var(--elbysodic-control-padding-inline);
+    font-size: var(--elbysodic-font-sm);
+    font-weight: 500;
+    line-height: 1.25;
+    text-decoration: none;
+    border: 1px solid var(--chirpui-border);
+    border-radius: var(--elbysodic-radius);
+    background: var(--chirpui-surface);
+    color: var(--chirpui-text);
+    cursor: pointer;
+    box-shadow: var(--chirpui-shadow-sm);
+    transition:
+        background var(--elbysodic-motion-feedback),
+        border-color var(--elbysodic-motion-feedback),
+        color var(--elbysodic-motion-feedback),
+        transform var(--elbysodic-motion-feedback),
+        box-shadow var(--elbysodic-motion-feedback);
+}
+
+.elbysodic-btn:hover:not(:disabled) {
+    background: var(--chirpui-bg-subtle);
+}
+
+.elbysodic-btn:active:not(:disabled) {
+    background: var(--chirpui-border);
+}
+
+.elbysodic-btn:focus-visible {
+    outline: var(--elbysodic-focus-outline);
+    outline-offset: var(--elbysodic-focus-offset);
+}
+
+.elbysodic-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.elbysodic-btn--primary {
+    background: var(--elbysodic-identity-dye);
+    border-color: var(--elbysodic-identity-dye);
+    color: var(--chirpui-on-accent);
+}
+
+.elbysodic-btn--primary:hover:not(:disabled) {
+    background: var(--elbysodic-identity-dye-hover);
+    border-color: var(--elbysodic-identity-dye-hover);
+}
+
+.elbysodic-btn--primary:active:not(:disabled) {
+    background: var(--elbysodic-identity-dye-hover);
+    border-color: var(--elbysodic-identity-dye-hover);
+}
+
+.elbysodic-btn--secondary {
+    background: var(--chirpui-bg-subtle);
+    border-color: var(--chirpui-border);
+}
+
+.elbysodic-btn--secondary:hover:not(:disabled) {
+    background: var(--chirpui-border);
+}
+
+.elbysodic-btn--ghost {
+    background: transparent;
+    border-color: var(--chirpui-border);
+    box-shadow: none;
+}
+
+.elbysodic-btn--ghost:hover:not(:disabled) {
+    background: var(--chirpui-bg-subtle);
+}
+
+.elbysodic-btn--danger {
+    background: var(--elbysodic-state-error);
+    border-color: var(--elbysodic-state-error);
+    color: var(--chirpui-on-accent);
+}
+
+.elbysodic-btn--danger:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--elbysodic-state-error) 85%, black);
+    border-color: color-mix(in srgb, var(--elbysodic-state-error) 85%, black);
+}
+
+.elbysodic-btn--sm {
+    padding: var(--elbysodic-space-xs) var(--elbysodic-space-sm);
+    font-size: var(--elbysodic-font-xs);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .elbysodic-btn:hover:not(:disabled) {
+        transform: translateY(-2px);
+        box-shadow: var(--chirpui-shadow-md);
+    }
+
+    .elbysodic-btn:active:not(:disabled) {
+        transition: none;
+        transform: scale(0.98) translateY(0);
+        box-shadow: var(--chirpui-shadow-sm);
+    }
+
+    .elbysodic-btn--ghost:hover:not(:disabled),
+    .elbysodic-btn--ghost:active:not(:disabled) {
+        box-shadow: none;
+    }
 }
 
 @layer app.overrides {


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #301 / #300
- Outcome: Theme CSS defines Elbysodic primitive classes (`elbysodic-btn`, `elbysodic-field`, `elbysodic-cluster`, `elbysodic-stack`) so a later page leaf can stop importing `chirpui/*` macros without restyling in page-local CSS.

## Owned paths

- `src/elbysodic/web/static/elbysodic-theme/10-chirp-primitives.css`
- `src/elbysodic/web/static/elbysodic-theme/00-tokens.css` (new Elbysodic primitive custom properties only)
- `docs/architecture/theme-css-architecture.md` (primitive class table)

## Decisions frozen (do not reopen in review)

- ADR 0002; design #293 (exit Chirp-UI)
- Do not wrap Chirp-UI appearance/tone as the public API. New classes are `elbysodic-*`.
- Existing `chirpui-*` selectors in `10-chirp-primitives.css` remain as a drain bridge until page markup moves.

## Acceptance run

```bash
rg -n 'elbysodic-btn|elbysodic-field|elbysodic-cluster|elbysodic-stack' src/elbysodic/web/static/elbysodic-theme/10-chirp-primitives.css
git diff origin/main -- src/elbysodic/web/static/elbysodic-theme/00-tokens.css | rg '^\+.*--chirpui-' || echo 'no new --chirpui- alias lines'
uv run ruff check .
```

- Primitive class `rg` matches `elbysodic-btn`, `elbysodic-field`, `elbysodic-cluster`, and `elbysodic-stack` in `10-chirp-primitives.css`
- No new `--chirpui-` alias lines in `00-tokens.css` (added `--elbysodic-*` primitive tokens only)
- Ruff: All checks passed

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: web (rendering/UI), docs (theme CSS architecture), changelog (no writer-visible restyle)
- Accepted: public API is `elbysodic-*`; leftover `chirpui-*` selectors stay as a drain bridge; primitive tokens are Elbysodic-named, not new Chirp-UI aliases
- Deferred: template markup still uses `chirpui-*` until a later page leaf; color still reads existing drain tokens (`--chirpui-surface`, `--chirpui-text`, `--chirpui-border`) until a token-drain leaf
- Proof: acceptance `rg` + `00-tokens.css` diff + `uv run ruff check .`
- Collateral: architecture doc row for the four class names; `no collateral: changelog` (CSS is unused by current markup; no writer-facing restyle)

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge