### PR TITLE
Migrate notifications POST to Chirp page actions (#303)

### DIFF
--- a/changelog.d/+design-essays-chirp-ui-exit.changed.md
+++ b/changelog.d/+design-essays-chirp-ui-exit.changed.md
@@ -1,1 +1,0 @@
-Design essays now treat Chirp-UI as leftover under ADR 0002 rather than the component foundation.

--- a/changelog.d/+design-essays-chirp-ui-exit.changed.md
+++ b/changelog.d/+design-essays-chirp-ui-exit.changed.md
@@ -1,0 +1,1 @@
+Design essays now treat Chirp-UI as leftover under ADR 0002 rather than the component foundation.

--- a/changelog.d/+notifications-page-actions.changed.md
+++ b/changelog.d/+notifications-page-actions.changed.md
@@ -1,0 +1,1 @@
+The notification inbox now dispatches mark-all-read and open through Chirp page actions instead of intent-form handlers.

--- a/src/elbysodic/web/pages/notifications/_actions.py
+++ b/src/elbysodic/web/pages/notifications/_actions.py
@@ -1,0 +1,41 @@
+"""Page actions for /notifications — Chirp 0.10 ``_actions.py`` (#303).
+
+Follows the recipe in ``pages/characters/_actions.py``. Mutations dispatch
+on the hidden ``_action`` form field. ``page.py`` ``post()`` is only the
+no-``_action`` fallback.
+"""
+
+from __future__ import annotations
+
+from chirp.errors import HTTPError
+from chirp.pages.actions import action
+from chirp.templating.returns import FormAction
+
+from elbysodic.services import AppServices
+
+
+def _parse_notification_id(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise HTTPError(status=400, detail="notification_id must be an integer") from exc
+
+
+@action("mark_all_read")
+async def mark_all_read(services: AppServices) -> FormAction:
+    services.mark_all_notifications_read()
+    return FormAction("/notifications", status=302)
+
+
+@action("open")
+async def open_notification(
+    services: AppServices,
+    notification_id: str = "",
+) -> FormAction:
+    try:
+        href = services.open_notification(_parse_notification_id(notification_id))
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    return FormAction(href, status=302)

--- a/src/elbysodic/web/pages/notifications/page.html
+++ b/src/elbysodic/web/pages/notifications/page.html
@@ -24,7 +24,7 @@
     {% if inbox.unread_count %}
     <form method="post" hx-boost="false">
       {{ csrf_field() }}
-      <input type="hidden" name="intent" value="mark_all_read">
+      <input type="hidden" name="_action" value="mark_all_read">
       <button type="submit" class="chirpui-btn chirpui-btn--secondary">Mark all read</button>
     </form>
     {% end %}
@@ -49,7 +49,7 @@
       </div>
       <form method="post" hx-boost="false" class="elbysodic-notification-card__action">
         {{ csrf_field() }}
-        <input type="hidden" name="intent" value="open">
+        <input type="hidden" name="_action" value="open">
         <input type="hidden" name="notification_id" value="{{ item.notification.id }}">
         <button type="submit" class="chirpui-btn chirpui-btn--primary">Open</button>
       </form>

--- a/src/elbysodic/web/pages/notifications/page.py
+++ b/src/elbysodic/web/pages/notifications/page.py
@@ -1,23 +1,26 @@
-"""Notification inbox for watched threads and mentions."""
+"""Notification inbox for watched threads and mentions.
+
+Mutations live in ``_actions.py`` (Chirp page actions, dispatched on the
+hidden ``_action`` form field). ``post()`` below is only the no-``_action``
+fallback that keeps the POST method registered on this path.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
 from chirp.contracts import FormContract, contract
-from chirp.errors import HTTPError
-from chirp.http.forms import FormData
 from chirp.http.request import Request
-from chirp.http.response import Redirect
 from chirp.templating.returns import Page
 
-from elbysodic.web.actions import dispatch_form_action
 from elbysodic.web.state import get_services
+
+NOTIFICATIONS_TEMPLATE = "notifications/page.html"
 
 
 @dataclass(frozen=True, slots=True)
 class NotificationActionForm:
-    intent: str
+    _action: str
     notification_id: str = ""
 
 
@@ -25,18 +28,10 @@ def get(request: Request) -> Page:
     return _render_notifications(request)
 
 
-@contract(form=FormContract(NotificationActionForm, "notifications/page.html"))
-async def post(request: Request) -> Page | Redirect:
-    form = await request.form()
-    return await dispatch_form_action(
-        request,
-        form,
-        {
-            "mark_all_read": _mark_all_read,
-            "open": _open_notification,
-        },
-        unknown_detail="unknown notification intent",
-    )
+@contract(form=FormContract(NotificationActionForm, NOTIFICATIONS_TEMPLATE))
+async def post(request: Request) -> Page:
+    """Fallback — mutations dispatch via ``pages/notifications/_actions.py``."""
+    return _render_notifications(request)
 
 
 def _render_notifications(request: Request) -> Page:
@@ -44,32 +39,8 @@ def _render_notifications(request: Request) -> Page:
     viewer = services.viewer()
     notification_center = services.notification_center()
     return Page.mounted(
-        "notifications/page.html",
+        NOTIFICATIONS_TEMPLATE,
         current_path=request.url,
         viewer=viewer,
         inbox=notification_center.inbox,
     )
-
-
-def _parse_notification_id(value: object) -> int:
-    try:
-        return int(str(value or ""))
-    except ValueError as exc:
-        raise HTTPError(status=400, detail="notification_id must be an integer") from exc
-
-
-def _mark_all_read(request: Request, _form: FormData) -> Redirect:
-    get_services(request).mark_all_notifications_read()
-    return Redirect("/notifications")
-
-
-def _open_notification(request: Request, form: FormData) -> Redirect:
-    try:
-        href = get_services(request).open_notification(
-            _parse_notification_id(form.get("notification_id"))
-        )
-    except LookupError as exc:
-        raise HTTPError(status=404, detail=str(exc)) from exc
-    except PermissionError as exc:
-        raise HTTPError(status=403, detail=str(exc)) from exc
-    return Redirect(href)

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -9598,14 +9598,14 @@ def test_character_plot_hooks_render_create_and_notify_interest() -> None:
                 leak_inbox = await leak_client.get("/notifications")
                 leak_mark_all = await leak_client.post(
                     "/notifications",
-                    body=b"intent=mark_all_read",
+                    body=b"_action=mark_all_read",
                     headers=_FORM,
                 )
                 leak_open = await leak_client.post(
                     "/notifications",
                     body=urlencode(
                         {
-                            "intent": "open",
+                            "_action": "open",
                             "notification_id": str(leak_notification.id),
                         }
                     ).encode(),
@@ -9796,7 +9796,7 @@ def test_wanted_hooks_accept_prospective_character_interest() -> None:
                 "/notifications",
                 body=urlencode(
                     {
-                        "intent": "open",
+                        "_action": "open",
                         "notification_id": str(notification.id),
                     }
                 ).encode(),
@@ -10545,7 +10545,7 @@ def test_plotting_room_notifications_do_not_leak_to_non_participants() -> None:
                 "/notifications",
                 body=urlencode(
                     {
-                        "intent": "open",
+                        "_action": "open",
                         "notification_id": str(notification.id),
                     }
                 ).encode(),
@@ -11001,11 +11001,13 @@ def test_notifications_track_watched_thread_replies_and_open_read_state() -> Non
             assert "A watched reply arrives." in notifications.text
             assert "Notify Face" in notifications.text
             assert "new" in notifications.text
+            assert 'name="_action" value="mark_all_read"' in notifications.text
+            assert 'name="_action" value="open"' in notifications.text
 
             item = services.notifications().items[0]
             marked_all = await client.post(
                 "/notifications",
-                body=b"intent=mark_all_read",
+                body=b"_action=mark_all_read",
                 headers=_FORM,
             )
             assert marked_all.status == 302
@@ -11019,7 +11021,7 @@ def test_notifications_track_watched_thread_replies_and_open_read_state() -> Non
 
             opened = await client.post(
                 "/notifications",
-                body=f"intent=open&notification_id={item.notification.id}".encode(),
+                body=f"_action=open&notification_id={item.notification.id}".encode(),
                 headers=_FORM,
             )
             assert opened.status == 302


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #303 / #226
- Outcome: `/notifications` mutations dispatch through `pages/notifications/_actions.py` using the `characters/_actions.py` Chirp `@action` / `FormAction` recipe. No new Chirp-UI markup.

## Owned paths

- `src/elbysodic/web/pages/notifications/`
- matching assertions in `tests/test_forum_slice.py` (notifications only)

## Decisions frozen (do not reopen in review)

- Design #299 (pattern gap): one route per leaf; no Lucky Cat UI
- ADR 0002: do not add `chirpui-*` while touching the template
- Copy recipe from `src/elbysodic/web/pages/characters/_actions.py`

## Acceptance run

```bash
test -f src/elbysodic/web/pages/notifications/_actions.py
rg -n '@action\(' src/elbysodic/web/pages/notifications/_actions.py
rg -n 'dispatch_form_action' src/elbysodic/web/pages/notifications/page.py
uv run pytest tests/test_forum_slice.py -q -k notification --tb=short
uv run ruff check .
```

- `_actions.py` exists; `@action("mark_all_read")` and `@action("open")` present
- `dispatch_form_action` absent from `page.py`
- pytest `-k notification`: 11 passed
- ruff: all checks passed

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: web steward via `characters/_actions.py` recipe and ADR 0002; no steward swarm
- Accepted: Chirp `@action` / `FormAction` with `status=302`; `post()` remains a no-`_action` fallback; forms use hidden `_action` instead of `intent`
- Deferred: removing `web/actions.py` until this route no longer needs `dispatch_form_action` (out of scope); Chirp-UI class drain on this template
- Proof: `uv run pytest tests/test_forum_slice.py -q -k notification --tb=short`
- Collateral: `no collateral: internal Chirp action dispatch; same POST behavior and existing markup classes`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge