### PR TITLE
Drain search page off Chirp-UI layout macros (#308)

### DIFF
--- a/changelog.d/+search-chirpui-drain.changed.md
+++ b/changelog.d/+search-chirpui-drain.changed.md
@@ -1,0 +1,1 @@
+Search now lays out with Elbysodic stack and page-local classes instead of Chirp-UI container and stack macros.

--- a/src/elbysodic/web/pages/search/page.html
+++ b/src/elbysodic/web/pages/search/page.html
@@ -1,7 +1,3 @@
-{% imports %}
-  {% from "chirpui/layout.html" import container, stack %}
-{% end %}
-
 {% def scoped_search_form(search) %}
 <form class="elbysodic-scoped-search"
       action="{{ search.action_href }}"
@@ -25,8 +21,7 @@
 <div id="page-root">
 {% block page_root_inner %}
 {% block page_content %}
-{% call container(max_width="72rem") %}
-{% call stack(gap="lg") %}
+<div class="elbysodic-stack elbysodic-stack--lg">
 <section class="elbysodic-search-hero" aria-labelledby="search-heading">
   <div>
     <p class="elbysodic-section-kicker">{{ "All realms" if scoped_search.scope_kind == "global" else "Current realm" }}</p>
@@ -91,8 +86,7 @@
   {% end %}
 </section>
 {% end %}
-{% end %}
-{% end %}
+</div>
 {% endblock %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #308 / #300
- Outcome: `/search` templates no longer import `chirpui/*`. Layout uses existing Elbysodic primitives (`elbysodic-stack` and page-local search classes). No new Chirp-UI classes and no new theme CSS files.

Closes #308

## Owned paths

- `src/elbysodic/web/pages/search/`
- `changelog.d/+search-chirpui-drain.changed.md`
- search-route assertions in `tests/test_forum_slice.py` only if they currently require `chirpui-` class names (they did not; tests unchanged)

## Decisions frozen (do not reopen in review)

- ADR 0002; epic #300
- Use existing `elbysodic-stack` / page classes. Do not add `--chirpui-*` or new primitive CSS in this leaf.
- Replace `{% call container %}` / `{% call stack %}` with ordinary markup.

## Acceptance run

```bash
rg -n 'chirpui/' src/elbysodic/web/pages/search/
rg -n 'chirpui-' src/elbysodic/web/pages/search/
uv run pytest tests/test_forum_slice.py -q -k 'search and not mentionable' --tb=short
uv run ruff check .
```

- `rg chirpui/` empty
- `rg chirpui-` empty
- pytest passed
- ruff clean

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: web rendering steward (`src/elbysodic/web/AGENTS.md`), changelog steward, ADR 0002
- Accepted: replace Chirp-UI `container`/`stack` macros with `elbysodic-stack elbysodic-stack--lg`; leave tests untouched because search assertions already use Elbysodic class names
- Deferred: theme CSS, `_layout.html`, and `app.py` remain out of scope
- Proof: empty `chirpui/` and `chirpui-` scans under `pages/search/`; focused search pytest; ruff
- Collateral: `changelog.d/+search-chirpui-drain.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge