### PR TITLE
Migrate claims POST to Chirp page actions (#309)

### DIFF
--- a/changelog.d/+claims-page-actions.changed.md
+++ b/changelog.d/+claims-page-actions.changed.md
@@ -1,0 +1,1 @@
+The claims directory now dispatches create and update through Chirp page actions instead of intent-form handlers.

--- a/src/elbysodic/web/pages/claims/_actions.py
+++ b/src/elbysodic/web/pages/claims/_actions.py
@@ -1,0 +1,78 @@
+"""Page actions for /claims — Chirp 0.10 ``_actions.py`` (#309).
+
+Follows the recipe in ``pages/characters/_actions.py`` and
+``pages/notifications/_actions.py``. Mutations dispatch on the hidden
+``_action`` form field. ``page.py`` ``post()`` is only the no-``_action``
+fallback.
+"""
+
+from __future__ import annotations
+
+from chirp.errors import HTTPError
+from chirp.http.request import Request
+from chirp.pages.actions import action
+from chirp.templating.returns import FormAction, Page
+
+from elbysodic.db.repositories.base import TenantBoundaryError
+from elbysodic.services import AppServices
+from elbysodic.web.pages.claims.page import render_claims
+
+
+def _optional_int(value: str) -> int | None:
+    return int(value) if value else None
+
+
+def _required_int(value: str, message: str) -> int:
+    if not value:
+        raise ValueError(message)
+    return int(value)
+
+
+@action("create_claim")
+async def create_claim(
+    request: Request,
+    services: AppServices,
+    claim_type_id: str = "",
+    label: str = "",
+    status: str = "",
+    character_id: str = "",
+    notes: str = "",
+) -> FormAction | Page:
+    try:
+        services.create_director_claim(
+            _required_int(claim_type_id, "choose a claim type"),
+            label=label,
+            status=status or "claimed",
+            character_id=_optional_int(character_id),
+            notes=notes,
+        )
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except (LookupError, ValueError, TenantBoundaryError) as exc:
+        return render_claims(request, error=str(exc))
+    return FormAction("/claims", status=302)
+
+
+@action("update_claim")
+async def update_claim(
+    request: Request,
+    services: AppServices,
+    claim_id: str = "",
+    label: str = "",
+    status: str = "",
+    character_id: str = "",
+    notes: str = "",
+) -> FormAction | Page:
+    try:
+        services.update_director_claim(
+            _required_int(claim_id, "choose a claim to update"),
+            label=label,
+            status=status or "claimed",
+            character_id=_optional_int(character_id),
+            notes=notes,
+        )
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except (LookupError, ValueError, TenantBoundaryError) as exc:
+        return render_claims(request, error=str(exc))
+    return FormAction("/claims", status=302)

--- a/src/elbysodic/web/pages/claims/page.html
+++ b/src/elbysodic/web/pages/claims/page.html
@@ -121,7 +121,7 @@
                   data-elbysodic-submit-label="Saving claim..."
                   class="chirpui-stack chirpui-stack--sm">
         {{ csrf_field() }}
-              <input type="hidden" name="intent" value="update_claim">
+              <input type="hidden" name="_action" value="update_claim">
               <input type="hidden" name="claim_id" value="{{ item.claim.id }}">
               <div class="elbysodic-form-grid">
                 <label>
@@ -176,7 +176,7 @@
             data-elbysodic-submit-label="Adding claim..."
             class="elbysodic-claim-create-form">
         {{ csrf_field() }}
-        <input type="hidden" name="intent" value="create_claim">
+        <input type="hidden" name="_action" value="create_claim">
         <input type="hidden" name="claim_type_id" value="{{ group.claim_type.id }}">
         <header>
           <p class="elbysodic-section-kicker">Director entry</p>

--- a/src/elbysodic/web/pages/claims/page.py
+++ b/src/elbysodic/web/pages/claims/page.py
@@ -1,4 +1,9 @@
-"""Realm claims directory."""
+"""Realm claims directory.
+
+Mutations live in ``_actions.py`` (Chirp page actions, dispatched on the
+hidden ``_action`` form field). ``post()`` below is only the no-``_action``
+fallback that keeps the POST method registered on this path.
+"""
 
 from __future__ import annotations
 
@@ -6,18 +11,17 @@ from dataclasses import dataclass
 from urllib.parse import quote_plus
 
 from chirp.contracts import FormContract, contract
-from chirp.errors import HTTPError
 from chirp.http.request import Request
-from chirp.http.response import Redirect
 from chirp.templating.returns import Page
 
-from elbysodic.db.repositories.base import TenantBoundaryError
 from elbysodic.web.state import get_services
+
+CLAIMS_TEMPLATE = "claims/page.html"
 
 
 @dataclass(frozen=True, slots=True)
 class ClaimsActionForm:
-    intent: str = ""
+    _action: str
     claim_id: str = ""
     claim_type_id: str = ""
     label: str = ""
@@ -28,47 +32,20 @@ class ClaimsActionForm:
 
 
 def get(request: Request) -> Page:
-    return _render_claims(
+    return render_claims(
         request,
         status_filter=_status_filter(request),
         search_query=_search_query(request),
     )
 
 
-@contract(form=FormContract(ClaimsActionForm, "claims/page.html"))
-async def post(request: Request) -> Page | Redirect:
-    services = get_services(request)
-    form = await request.form()
-    intent = str(form.get("intent") or "")
-    try:
-        if intent == "create_claim":
-            raw_character_id = str(form.get("character_id") or "")
-            services.create_director_claim(
-                _required_int(form.get("claim_type_id"), "choose a claim type"),
-                label=str(form.get("label") or ""),
-                status=str(form.get("status") or "claimed"),
-                character_id=int(raw_character_id) if raw_character_id else None,
-                notes=str(form.get("notes") or ""),
-            )
-        elif intent == "update_claim":
-            raw_character_id = str(form.get("character_id") or "")
-            services.update_director_claim(
-                _required_int(form.get("claim_id"), "choose a claim to update"),
-                label=str(form.get("label") or ""),
-                status=str(form.get("status") or "claimed"),
-                character_id=int(raw_character_id) if raw_character_id else None,
-                notes=str(form.get("notes") or ""),
-            )
-        else:
-            raise HTTPError(status=400, detail=f"unknown claims action: {intent}")
-    except PermissionError as exc:
-        raise HTTPError(status=403, detail=str(exc)) from exc
-    except (LookupError, ValueError, TenantBoundaryError) as exc:
-        return _render_claims(request, error=str(exc))
-    return Redirect("/claims")
+@contract(form=FormContract(ClaimsActionForm, CLAIMS_TEMPLATE))
+async def post(request: Request) -> Page:
+    """Fallback — mutations dispatch via ``pages/claims/_actions.py``."""
+    return render_claims(request)
 
 
-def _render_claims(
+def render_claims(
     request: Request,
     *,
     error: str | None = None,
@@ -82,7 +59,7 @@ def _render_claims(
         search_query=search_query,
     )
     return Page.mounted(
-        "claims/page.html",
+        CLAIMS_TEMPLATE,
         current_path=request.url,
         viewer=viewer,
         directory=claims_page.directory,
@@ -91,13 +68,6 @@ def _render_claims(
         error=error,
         search_query_encoded=quote_plus(claims_page.directory.search_query),
     )
-
-
-def _required_int(raw: object, message: str) -> int:
-    value = str(raw or "")
-    if not value:
-        raise ValueError(message)
-    return int(value)
 
 
 def _status_filter(request: Request) -> str | None:

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -9247,7 +9247,7 @@ def test_director_can_record_manual_claims_from_claims_directory() -> None:
                 "/claims",
                 body=urlencode(
                     {
-                        "intent": "create_claim",
+                        "_action": "create_claim",
                         "claim_type_id": str(face_claim.id),
                         "label": "Cyclops tactical visor",
                         "status": "claimed",
@@ -9270,7 +9270,7 @@ def test_director_can_record_manual_claims_from_claims_directory() -> None:
                 "/claims",
                 body=urlencode(
                     {
-                        "intent": "update_claim",
+                        "_action": "update_claim",
                         "claim_id": str(created_claim.id),
                         "label": "Cyclops visor reserve",
                         "status": "reserved",
@@ -9299,6 +9299,10 @@ def test_director_can_record_manual_claims_from_claims_directory() -> None:
         assert directory.status == 200
         assert "Record claim" in directory.text
         assert "Cyclops" in directory.text
+        assert 'name="_action" value="create_claim"' in directory.text
+        assert 'name="_action" value="update_claim"' in directory.text
+        assert 'name="intent" value="create_claim"' not in directory.text
+        assert 'name="intent" value="update_claim"' not in directory.text
         assert response.status == 302
         assert update_response.status == 302
         assert manual_claim.label == "Cyclops visor reserve"


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #309 / #226
- Outcome: `/claims` create and update dispatch through `pages/claims/_actions.py` using the `characters/_actions.py` / `notifications/_actions.py` recipe. Hidden `_action` replaces `intent`. `post()` remains as the no-`_action` fallback. No new Chirp-UI markup.

Closes #309

## Owned paths

- `src/elbysodic/web/pages/claims/`
- claims POST assertions in `tests/test_forum_slice.py` (claims directory / director record only)
- `changelog.d/+claims-page-actions.changed.md`

## Decisions frozen (do not reopen in review)

- Design #299: one route per leaf; no Lucky Cat UI
- ADR 0002: do not add `chirpui-*`
- Copy recipe from `src/elbysodic/web/pages/notifications/_actions.py`

## Acceptance run

```bash
test -f src/elbysodic/web/pages/claims/_actions.py
rg -n '@action\(' src/elbysodic/web/pages/claims/_actions.py
rg -n 'form.get\("intent"\)|intent ==' src/elbysodic/web/pages/claims/page.py
uv run pytest tests/test_forum_slice.py -q -k 'claims_directory or record_manual_claims' --tb=short
uv run ruff check .
```

Results:

- `_actions.py` exists
- `@action("create_claim")` and `@action("update_claim")` present
- `intent` scan of `page.py` empty
- pytest: 2 passed (`test_claims_directory_renders_seeded_claims_and_studio_summary`, `test_director_can_record_manual_claims_from_claims_directory`)
- ruff: All checks passed

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: web (page actions recipe), changelog (towncrier fragment), tests (claims POST carve-out in `test_forum_slice.py`)
- Accepted / deferred: follow notifications/characters `_action` + `FormContract` + `post()` fallback; no Chirp-UI markup; no drive-by megafile refactor
- Proof: focused pytest `-k 'claims_directory or record_manual_claims'` and `uv run ruff check .`
- Collateral: `changelog.d/+claims-page-actions.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge