### PR TITLE
Drain Writer Desk off Chirp-UI layout macros (#312)

### DIFF
--- a/changelog.d/+desk-chirpui-drain.changed.md
+++ b/changelog.d/+desk-chirpui-drain.changed.md
@@ -1,0 +1,1 @@
+Writer Desk now lays out with Elbysodic stack and desk page classes instead of Chirp-UI container and stack macros.

--- a/src/elbysodic/web/pages/desk/page.html
+++ b/src/elbysodic/web/pages/desk/page.html
@@ -1,5 +1,4 @@
 {% imports %}
-  {% from "chirpui/layout.html" import container, stack %}
   {% from "_components/ui.html" import empty_policy_block, page_section %}
   {% from "_components/vocabulary.html" import command_action, lane_preview, metric_item, page_pulse %}
 {% end %}
@@ -8,11 +7,10 @@
 <div id="page-root">
 {% block page_root_inner %}
 {% block page_content %}
-{% call container(max_width="72rem") %}
-{% call stack(gap="lg") %}
+<div class="elbysodic-stack elbysodic-stack--lg">
 <div class="elbysodic-editorial-page elbysodic-desk-page">
   <section class="elbysodic-desk-hero elbysodic-desk-hero--v2">
-    <div class="chirpui-stack chirpui-stack--sm">
+    <div class="elbysodic-stack elbysodic-stack--sm">
       <h1>Writer Desk</h1>
       <p class="elbysodic-copy-lead">Return to a scene, catch up on reading, or move a plot forward.</p>
     </div>
@@ -76,9 +74,8 @@
   {% end %}
   {% end %}
 </div>
-{% end %}
-{% end %}
-{% end %}
+</div>
 {% endblock %}
 </div>
+{% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #312 / #300
- Outcome: Writer Desk templates no longer import `chirpui/*` or use `chirpui-*` classes. Layout uses existing `elbysodic-stack` and desk page classes. No new Chirp-UI classes and no new theme CSS files.

Closes #312

## Owned paths

- `src/elbysodic/web/pages/desk/`
- `changelog.d/+desk-chirpui-drain.changed.md`

## Decisions frozen (do not reopen in review)

- ADR 0002; epic #300
- Use existing `elbysodic-stack` and desk page classes. Do not add `--chirpui-*` or new primitive CSS in this leaf.
- Replace `{% call container %}` / `{% call stack %}` and `chirpui-stack` with ordinary markup.

## Acceptance run

```bash
rg -n 'chirpui/' src/elbysodic/web/pages/desk/
rg -n 'chirpui-' src/elbysodic/web/pages/desk/
uv run pytest tests/test_forum_slice.py -q -k writer_desk --tb=short
uv run ruff check .
```

- `rg chirpui/` empty
- `rg chirpui-` empty
- pytest passed (`..` / 2 tests)
- ruff clean

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: web rendering steward (`src/elbysodic/web/AGENTS.md`), changelog steward, ADR 0002
- Accepted: replace Chirp-UI `container`/`stack` macros and `chirpui-stack--sm` with `elbysodic-stack` (`--lg` page, `--sm` hero); leave tests untouched because desk assertions already use product copy and Elbysodic class names
- Deferred: theme CSS, `_layout.html`, and `app.py` remain out of scope
- Proof: empty `chirpui/` and `chirpui-` scans under `pages/desk/`; focused writer_desk pytest; ruff
- Collateral: `changelog.d/+desk-chirpui-drain.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge