### PR TITLE
Migrate wanted-hook POST to Chirp page actions (#314)

### DIFF
--- a/changelog.d/+wanted-page-actions.changed.md
+++ b/changelog.d/+wanted-page-actions.changed.md
@@ -1,0 +1,1 @@
+Wanted-hook detail now dispatches interest, reserve, plotting-room, and lifecycle mutations through Chirp page actions instead of intent-form handlers.

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/_actions.py
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/_actions.py
@@ -1,0 +1,131 @@
+"""Page actions for /wanted/{wanted_slug} — Chirp 0.10 ``_actions.py`` (#314).
+
+Follows the recipe in ``pages/notifications/_actions.py`` and
+``pages/claims/_actions.py``. Mutations dispatch on the hidden
+``_action`` form field. ``page.py`` ``post()`` is only the no-``_action``
+fallback.
+"""
+
+from __future__ import annotations
+
+from chirp.errors import HTTPError
+from chirp.pages.actions import action
+from chirp.templating.returns import FormAction
+
+from elbysodic.services import AppServices
+
+
+def _parse_interest_id(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise HTTPError(status=400, detail="interest_id must be an integer") from exc
+
+
+@action("express_interest")
+async def express_interest(services: AppServices, wanted_slug: str) -> FormAction:
+    try:
+        services.express_wanted_interest(wanted_slug)
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/wanted/{wanted_slug}", status=302)
+
+
+@action("express_prospective_interest")
+async def express_prospective_interest(
+    services: AppServices,
+    wanted_slug: str,
+    prospective_character_name: str = "",
+    note: str = "",
+) -> FormAction:
+    try:
+        services.express_prospective_wanted_interest(
+            wanted_slug,
+            prospective_character_name=prospective_character_name,
+            note=note,
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/wanted/{wanted_slug}", status=302)
+
+
+@action("reserve_interest")
+async def reserve_interest(
+    services: AppServices,
+    wanted_slug: str,
+    interest_id: str = "",
+) -> FormAction:
+    try:
+        services.reserve_wanted_interest(wanted_slug, _parse_interest_id(interest_id))
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/wanted/{wanted_slug}", status=302)
+
+
+@action("start_plotting_room")
+async def start_plotting_room(
+    services: AppServices,
+    wanted_slug: str,
+    interest_id: str = "",
+) -> FormAction:
+    try:
+        room = services.create_plotting_room_from_wanted_interest(
+            wanted_slug,
+            _parse_interest_id(interest_id),
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/plotting/{room.id}", status=302)
+
+
+@action("create_reserve")
+async def create_reserve(
+    services: AppServices,
+    wanted_slug: str,
+    interest_id: str = "",
+) -> FormAction:
+    try:
+        services.create_reserve_for_wanted_interest(
+            wanted_slug,
+            _parse_interest_id(interest_id),
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/wanted/{wanted_slug}", status=302)
+
+
+@action("update_lifecycle_status")
+async def update_lifecycle_status(
+    services: AppServices,
+    wanted_slug: str,
+    status: str = "",
+) -> FormAction:
+    try:
+        services.update_wanted_ad_lifecycle_status(wanted_slug, status=status)
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/wanted/{wanted_slug}", status=302)

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/page.html
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/page.html
@@ -159,7 +159,7 @@
             data-elbysodic-idempotency="service-duplicate-policy"
             class="chirpui-cluster elbysodic-cluster--end">
         {{ csrf_field() }}
-        <input type="hidden" name="intent" value="express_interest">
+        <input type="hidden" name="_action" value="express_interest">
         <button type="submit" class="chirpui-btn chirpui-btn--primary">
           Raise interest as {{ viewer.current_character.name }}
         </button>
@@ -198,7 +198,7 @@
               class="chirpui-stack chirpui-stack--sm"
               aria-labelledby="prospective-interest">
         {{ csrf_field() }}
-          <input type="hidden" name="intent" value="express_prospective_interest">
+          <input type="hidden" name="_action" value="express_prospective_interest">
           <div>
             <label class="chirpui-field__label" for="prospective-character-name">Face concept</label>
             <input id="prospective-character-name"
@@ -241,7 +241,7 @@
             class="chirpui-stack chirpui-stack--sm"
             aria-labelledby="wanted-lifecycle">
         {{ csrf_field() }}
-        <input type="hidden" name="intent" value="update_lifecycle_status">
+        <input type="hidden" name="_action" value="update_lifecycle_status">
         <label class="chirpui-field__label" for="wanted-status">Lifecycle status</label>
         <select id="wanted-status" class="chirpui-field__input" name="status">
           <option value="open" {{ "selected" if wanted.wanted_ad.status == "open" else "" }}>Open</option>
@@ -317,7 +317,7 @@
                   data-elbysodic-stale-behavior="service-validates-interest-state"
                   data-elbysodic-idempotency="service-duplicate-policy">
         {{ csrf_field() }}
-              <input type="hidden" name="intent" value="start_plotting_room">
+              <input type="hidden" name="_action" value="start_plotting_room">
               <input type="hidden" name="interest_id" value="{{ item.interest.id }}">
               <button type="submit" class="chirpui-btn chirpui-btn--primary">
                 Start plotting room
@@ -332,7 +332,7 @@
                   data-elbysodic-stale-behavior="service-validates-interest-state"
                   data-elbysodic-idempotency="service-duplicate-policy">
         {{ csrf_field() }}
-              <input type="hidden" name="intent" value="reserve_interest">
+              <input type="hidden" name="_action" value="reserve_interest">
               <input type="hidden" name="interest_id" value="{{ item.interest.id }}">
               <button type="submit" class="chirpui-btn chirpui-btn--secondary">
                 Reserve for {{ item.display_name }}
@@ -352,7 +352,7 @@
                 data-elbysodic-idempotency="service-duplicate-policy"
                 class="chirpui-cluster elbysodic-cluster--end">
         {{ csrf_field() }}
-            <input type="hidden" name="intent" value="create_reserve">
+            <input type="hidden" name="_action" value="create_reserve">
             <input type="hidden" name="interest_id" value="{{ item.interest.id }}">
             <button type="submit" class="chirpui-btn chirpui-btn--secondary">
               Create reserve

--- a/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
+++ b/src/elbysodic/web/pages/wanted/{wanted_slug}/page.py
@@ -1,4 +1,9 @@
-"""Wanted hook detail page."""
+"""Wanted hook detail page.
+
+Mutations live in ``_actions.py`` (Chirp page actions, dispatched on the
+hidden ``_action`` form field). ``post()`` below is only the no-``_action``
+fallback that keeps the POST method registered on this path.
+"""
 
 from __future__ import annotations
 
@@ -7,17 +12,18 @@ from dataclasses import dataclass
 from chirp.contracts import FormContract, contract
 from chirp.errors import HTTPError
 from chirp.http.request import Request
-from chirp.http.response import Redirect
 from chirp.templating.returns import Page
 
 from elbysodic.web.recovery import recover_missing_route
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_tenant_slug
 
+WANTED_TEMPLATE = "wanted/{wanted_slug}/page.html"
+
 
 @dataclass(frozen=True, slots=True)
 class WantedActionForm:
-    intent: str
+    _action: str
     prospective_character_name: str = ""
     note: str = ""
     status: str = ""
@@ -28,88 +34,10 @@ def get(request: Request, wanted_slug: str) -> Page:
     return _render_wanted(request, wanted_slug)
 
 
-@contract(form=FormContract(WantedActionForm, "wanted/{wanted_slug}/page.html"))
-async def post(request: Request, wanted_slug: str) -> Page | Redirect:
-    services = get_services(request)
-    form = await request.form()
-    intent = str(form.get("intent") or "")
-    if intent == "express_interest":
-        try:
-            services.express_wanted_interest(wanted_slug)
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/wanted/{wanted_slug}")
-    if intent == "express_prospective_interest":
-        try:
-            services.express_prospective_wanted_interest(
-                wanted_slug,
-                prospective_character_name=str(form.get("prospective_character_name") or ""),
-                note=str(form.get("note") or ""),
-            )
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/wanted/{wanted_slug}")
-    if intent == "reserve_interest":
-        try:
-            services.reserve_wanted_interest(
-                wanted_slug,
-                _parse_interest_id(form.get("interest_id")),
-            )
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/wanted/{wanted_slug}")
-    if intent == "start_plotting_room":
-        try:
-            room = services.create_plotting_room_from_wanted_interest(
-                wanted_slug,
-                _parse_interest_id(form.get("interest_id")),
-            )
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/plotting/{room.id}")
-    if intent == "create_reserve":
-        try:
-            services.create_reserve_for_wanted_interest(
-                wanted_slug,
-                _parse_interest_id(form.get("interest_id")),
-            )
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/wanted/{wanted_slug}")
-    if intent == "update_lifecycle_status":
-        try:
-            services.update_wanted_ad_lifecycle_status(
-                wanted_slug,
-                status=str(form.get("status") or ""),
-            )
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/wanted/{wanted_slug}")
-    raise HTTPError(status=400, detail=f"unknown wanted intent: {intent}")
+@contract(form=FormContract(WantedActionForm, WANTED_TEMPLATE))
+async def post(request: Request, wanted_slug: str) -> Page:
+    """Fallback — mutations dispatch via ``pages/wanted/{wanted_slug}/_actions.py``."""
+    return _render_wanted(request, wanted_slug)
 
 
 def _render_wanted(request: Request, wanted_slug: str) -> Page:
@@ -134,7 +62,7 @@ def _render_wanted(request: Request, wanted_slug: str) -> Page:
             return recover_missing_route(request, kind="wanted", slug=wanted_slug)
         community = viewer.community
     return Page.mounted(
-        "wanted/{wanted_slug}/page.html",
+        WANTED_TEMPLATE,
         current_path=request.url,
         viewer=viewer,
         account_visitor=(
@@ -149,10 +77,3 @@ def _render_wanted(request: Request, wanted_slug: str) -> Page:
         wanted=wanted,
         show_community_shell=viewer is not None,
     )
-
-
-def _parse_interest_id(value: object) -> int:
-    try:
-        return int(str(value or ""))
-    except ValueError as exc:
-        raise HTTPError(status=400, detail="interest_id must be an integer") from exc

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -8255,7 +8255,7 @@ def test_wanted_ads_render_board_detail_and_character_hub() -> None:
 
             interest_response = await client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=b"intent=express_interest",
+                body=b"_action=express_interest",
                 headers=_FORM,
             )
             assert interest_response.status == 302
@@ -8300,7 +8300,7 @@ def test_wanted_ads_render_board_detail_and_character_hub() -> None:
 
                 reserve_response = await charlie_client.post(
                     "/wanted/human-un-liaison-for-b24",
-                    body=f"intent=reserve_interest&interest_id={interest.id}".encode(),
+                    body=f"_action=reserve_interest&interest_id={interest.id}".encode(),
                     headers=_FORM,
                 )
                 assert reserve_response.status == 302
@@ -8313,7 +8313,7 @@ def test_wanted_ads_render_board_detail_and_character_hub() -> None:
 
                 reserve_create = await charlie_client.post(
                     "/wanted/human-un-liaison-for-b24",
-                    body=f"intent=create_reserve&interest_id={interest.id}".encode(),
+                    body=f"_action=create_reserve&interest_id={interest.id}".encode(),
                     headers=_FORM,
                 )
                 assert reserve_create.status == 302
@@ -8368,7 +8368,7 @@ def test_wanted_ads_render_board_detail_and_character_hub() -> None:
                     "/wanted/human-un-liaison-for-b24",
                     body=urlencode(
                         {
-                            "intent": "update_lifecycle_status",
+                            "_action": "update_lifecycle_status",
                             "status": "filled",
                         }
                     ).encode(),
@@ -8380,7 +8380,7 @@ def test_wanted_ads_render_board_detail_and_character_hub() -> None:
                     "/wanted/human-un-liaison-for-b24",
                     body=urlencode(
                         {
-                            "intent": "update_lifecycle_status",
+                            "_action": "update_lifecycle_status",
                             "status": "archived",
                         }
                     ).encode(),
@@ -8392,7 +8392,7 @@ def test_wanted_ads_render_board_detail_and_character_hub() -> None:
                     "/wanted/human-un-liaison-for-b24",
                     body=urlencode(
                         {
-                            "intent": "update_lifecycle_status",
+                            "_action": "update_lifecycle_status",
                             "status": "open",
                         }
                     ).encode(),
@@ -10008,7 +10008,7 @@ def test_tenant_prefixed_plotting_room_scopes_live_and_plan_routes() -> None:
         async with TestClient(app) as client:
             response = await client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=b"intent=express_interest",
+                body=b"_action=express_interest",
                 headers=_FORM,
             )
             assert response.status == 302
@@ -10030,7 +10030,7 @@ def test_tenant_prefixed_plotting_room_scopes_live_and_plan_routes() -> None:
         async with TestClient(charlie_app) as charlie_client:
             room_response = await charlie_client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                body=f"_action=start_plotting_room&interest_id={interest.id}".encode(),
                 headers=_FORM,
             )
             assert room_response.status == 302
@@ -10092,7 +10092,7 @@ def test_plotting_room_sse_ready_event_uses_safe_channel() -> None:
         async with TestClient(app) as client:
             response = await client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=b"intent=express_interest",
+                body=b"_action=express_interest",
                 headers=_FORM,
             )
             assert response.status == 302
@@ -10116,7 +10116,7 @@ def test_plotting_room_sse_ready_event_uses_safe_channel() -> None:
         async with TestClient(charlie_app) as charlie_client:
             room_response = await charlie_client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                body=f"_action=start_plotting_room&interest_id={interest.id}".encode(),
                 headers=_FORM,
             )
             assert room_response.status == 302
@@ -10149,7 +10149,7 @@ def test_plotting_room_sse_closes_cleanly_on_worker_draining(caplog) -> None:
         async with TestClient(app) as client:
             response = await client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=b"intent=express_interest",
+                body=b"_action=express_interest",
                 headers=_FORM,
             )
             assert response.status == 302
@@ -10173,7 +10173,7 @@ def test_plotting_room_sse_closes_cleanly_on_worker_draining(caplog) -> None:
         async with TestClient(charlie_app) as charlie_client:
             room_response = await charlie_client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                body=f"_action=start_plotting_room&interest_id={interest.id}".encode(),
                 headers=_FORM,
             )
             assert room_response.status == 302
@@ -10230,7 +10230,7 @@ def test_tenant_prefixed_plotting_room_id_does_not_leak_cross_realm_room() -> No
         async with TestClient(app) as client:
             response = await client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=b"intent=express_interest",
+                body=b"_action=express_interest",
                 headers=_FORM,
             )
             assert response.status == 302
@@ -10252,7 +10252,7 @@ def test_tenant_prefixed_plotting_room_id_does_not_leak_cross_realm_room() -> No
         async with TestClient(charlie_app) as charlie_client:
             room_response = await charlie_client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                body=f"_action=start_plotting_room&interest_id={interest.id}".encode(),
                 headers=_FORM,
             )
             assert room_response.status == 302
@@ -10283,7 +10283,7 @@ def test_plotting_room_plan_can_turn_into_scene() -> None:
         async with TestClient(app) as client:
             response = await client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=b"intent=express_interest",
+                body=b"_action=express_interest",
                 headers=_FORM,
             )
             assert response.status == 302
@@ -10305,7 +10305,7 @@ def test_plotting_room_plan_can_turn_into_scene() -> None:
         async with TestClient(charlie_app) as charlie_client:
             room_response = await charlie_client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                body=f"_action=start_plotting_room&interest_id={interest.id}".encode(),
                 headers=_FORM,
             )
             assert room_response.status == 302
@@ -10442,7 +10442,7 @@ def test_plotting_room_scene_handoff_rolls_back_on_attach_failure(
         async with TestClient(app) as client:
             response = await client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=b"intent=express_interest",
+                body=b"_action=express_interest",
                 headers=_FORM,
             )
             assert response.status == 302
@@ -10464,7 +10464,7 @@ def test_plotting_room_scene_handoff_rolls_back_on_attach_failure(
         async with TestClient(charlie_app) as charlie_client:
             room_response = await charlie_client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                body=f"_action=start_plotting_room&interest_id={interest.id}".encode(),
                 headers=_FORM,
             )
             assert room_response.status == 302
@@ -10505,7 +10505,7 @@ def test_plotting_room_notifications_do_not_leak_to_non_participants() -> None:
         async with TestClient(app) as client:
             response = await client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=b"intent=express_interest",
+                body=b"_action=express_interest",
                 headers=_FORM,
             )
             assert response.status == 302
@@ -10527,7 +10527,7 @@ def test_plotting_room_notifications_do_not_leak_to_non_participants() -> None:
         async with TestClient(charlie_app) as charlie_client:
             room_response = await charlie_client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                body=f"_action=start_plotting_room&interest_id={interest.id}".encode(),
                 headers=_FORM,
             )
             assert room_response.status == 302

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -9758,7 +9758,7 @@ def test_wanted_hooks_accept_prospective_character_interest() -> None:
                 "/wanted/human-un-liaison-for-b24",
                 body=urlencode(
                     {
-                        "intent": "express_prospective_interest",
+                        "_action": "express_prospective_interest",
                         "prospective_character_name": "Val Cooper",
                         "note": "I would app her as a UN pressure point.",
                     }
@@ -9830,7 +9830,7 @@ def test_wanted_hooks_accept_prospective_character_interest() -> None:
 
             reserve = await creator_client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=f"intent=reserve_interest&interest_id={prospective.id}".encode(),
+                body=f"_action=reserve_interest&interest_id={prospective.id}".encode(),
                 headers=_FORM,
             )
             assert reserve.status == 302
@@ -9946,7 +9946,7 @@ def test_plotting_rooms_start_from_wanted_interest() -> None:
         async with TestClient(app) as client:
             response = await client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=b"intent=express_interest",
+                body=b"_action=express_interest",
                 headers=_FORM,
             )
             assert response.status == 302
@@ -9972,7 +9972,7 @@ def test_plotting_rooms_start_from_wanted_interest() -> None:
 
             room_response = await charlie_client.post(
                 "/wanted/human-un-liaison-for-b24",
-                body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                body=f"_action=start_plotting_room&interest_id={interest.id}".encode(),
                 headers=_FORM,
             )
             assert room_response.status == 302


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #314 / #226
- Outcome: `/wanted/{wanted_slug}` mutations dispatch through `pages/wanted/{wanted_slug}/_actions.py` using the notifications/claims recipe. Hidden `_action` replaces `intent`. `post()` remains as the no-`_action` fallback. No new Chirp-UI markup. Wanted list `page.html` is untouched.

Closes #314

## Owned paths

- `src/elbysodic/web/pages/wanted/{wanted_slug}/`
- wanted POST assertions in `tests/test_forum_slice.py` only (`wanted_hooks_accept_prospective`, `wanted_interest_rolls_back`, `plotting_rooms_start_from_wanted`)
- `changelog.d/+wanted-page-actions.changed.md`

## Decisions frozen (do not reopen in review)

- Design #299: one route per leaf; no Lucky Cat UI
- ADR 0002: do not add `chirpui-*`
- Copy recipe from `src/elbysodic/web/pages/notifications/_actions.py` and `src/elbysodic/web/pages/claims/_actions.py`
- Hidden `_action` replaces `intent`; keep `post()` fallback; add `_action` to `WantedActionForm`

## Acceptance run

```bash
test -f 'src/elbysodic/web/pages/wanted/{wanted_slug}/_actions.py'
rg -n '@action\(' 'src/elbysodic/web/pages/wanted/{wanted_slug}/_actions.py'
rg -n 'form.get\("intent"\)|intent ==' 'src/elbysodic/web/pages/wanted/{wanted_slug}/page.py'
uv run pytest tests/test_forum_slice.py -q -k 'wanted_hooks_accept_prospective or wanted_interest_rolls_back or plotting_rooms_start_from_wanted' --tb=short
uv run ruff check .
```

Results:

- `_actions.py` exists
- `@action` present for `express_interest`, `express_prospective_interest`, `reserve_interest`, `start_plotting_room`, `create_reserve`, `update_lifecycle_status`
- `intent` scan of `page.py` empty
- pytest: 3 passed (`test_wanted_hooks_accept_prospective_character_interest`, `test_wanted_interest_rolls_back_when_notification_fanout_fails`, `test_plotting_rooms_start_from_wanted_interest`)
- ruff: All checks passed

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: web (page actions recipe, ADR 0002), changelog (towncrier fragment), tests (wanted POST carve-out in `test_forum_slice.py`)
- Accepted / deferred: follow notifications/claims `_action` + `FormContract` + `post()` fallback; no Chirp-UI markup; no wanted list template edits; no drive-by megafile refactor
- Proof: focused pytest `-k` slice and `uv run ruff check .`
- Collateral: `changelog.d/+wanted-page-actions.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge
- Other `test_forum_slice.py` POSTs to `/wanted/{slug}` still send `intent` and were left unchanged per owned-path carve-out