### PR TITLE
Drain locations page off Chirp-UI layout macros

### DIFF
--- a/changelog.d/+locations-chirpui-drain.changed.md
+++ b/changelog.d/+locations-chirpui-drain.changed.md
@@ -1,0 +1,1 @@
+The locations page now lays out with Elbysodic stack and hero markup instead of Chirp-UI container, stack, and section_header macros.

--- a/src/elbysodic/web/pages/locations/page.html
+++ b/src/elbysodic/web/pages/locations/page.html
@@ -1,5 +1,4 @@
 {% imports %}
-  {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "_components/boards.html" import board_signal %}
   {% from "_components/thread_summary.html" import activity_item %}
   {% from "_components/ui.html" import empty_policy_block %}
@@ -9,8 +8,7 @@
 <div id="page-root">
 {% block page_root_inner %}
 {% block page_content %}
-{% call container(max_width="76rem") %}
-{% call stack(gap="xl") %}
+<div class="elbysodic-stack elbysodic-stack--xl">
   <section class="elbysodic-world-hero">
     <div class="elbysodic-world-hero__copy">
       <p class="elbysodic-kicker">Locations</p>
@@ -26,9 +24,10 @@
     </div>
   </section>
 
-  {% call section_header("Major locations") %}
-  Parent locations stay cinematic; sublocations open inside each place.
-  {% end %}
+  <header class="elbysodic-page-section__header">
+    <h2>Major locations</h2>
+    <p>Parent locations stay cinematic; sublocations open inside each place.</p>
+  </header>
 
   {% if location_boards %}
   <div class="elbysodic-location-grid">
@@ -42,19 +41,19 @@
 
   {% if attention %}
   <section class="elbysodic-location-attention-pulse" aria-label="Location scenes needing reply">
-    {% call section_header("Scene turns here") %}
-    Location scenes where another writer has the last beat.
-    {% end %}
-  <div class="chirpui-stack chirpui-stack--sm elbysodic-activity-list">
+    <header class="elbysodic-page-section__header">
+      <h2>Scene turns here</h2>
+      <p>Location scenes where another writer has the last beat.</p>
+    </header>
+  <div class="elbysodic-stack elbysodic-stack--sm elbysodic-activity-list">
     {% for item in attention %}
     {{ activity_item(item.board, item.thread, item.latest_post, item.snippet, "needs reply", "warning") }}
     {% end %}
   </div>
   </section>
   {% end %}
-{% end %}
-{% end %}
-{% end %}
+</div>
 {% endblock %}
 </div>
+{% endblock %}
 {% endblock %}

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -3404,7 +3404,7 @@ def test_new_realm_locations_use_actionable_empty_states() -> None:
 
         assert response.status == 200
         content = _page_content(response.text)
-        assert "chirpui-section-header" in content
+        assert "elbysodic-page-section__header" in content
         assert "No scenes have opened here yet." in content
         assert 'href="/c/rl-nyc/boards/brooklyn/threads/new"' in content
         assert 'href="/c/rl-nyc/boards/queens-night-market/threads/new"' in content


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #313 / #300
- Outcome: `/locations` templates no longer import `chirpui/*` or use `chirpui-*` classes; layout uses existing Elbysodic stack, hero, and section header markup.

## Owned paths

- `src/elbysodic/web/pages/locations/`
- `changelog.d/+locations-chirpui-drain.changed.md`

Proof alignment outside the owned-path allowlist: one assertion in `tests/test_forum_slice.py` now looks for `elbysodic-page-section__header` instead of `chirpui-section-header`, so the named acceptance test can pass after the drain.

## Decisions frozen (do not reopen in review)

- ADR 0002; epic #300. No new primitive CSS. Replace container/stack/section_header macros with ordinary markup.

## Acceptance run

```bash
rg -n 'chirpui/' src/elbysodic/web/pages/locations/
rg -n 'chirpui-' src/elbysodic/web/pages/locations/
uv run pytest tests/test_forum_slice.py -q -k new_realm_locations --tb=short
uv run ruff check .
```

- `rg chirpui/` empty
- `rg chirpui-` empty
- pytest `test_new_realm_locations_use_actionable_empty_states` passed
- ruff clean

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: Rendering And UI steward (`src/elbysodic/web/AGENTS.md`); Changelog steward (`changelog.d/AGENTS.md`)
- Accepted: replace Chirp-UI container/stack/section_header with existing Elbysodic stack/hero/section header markup; no theme CSS and no `_components/` edits
- Deferred: included `board_signal` / `activity_item` still emit chirpui classes from `_components/` (out of scope)
- Proof: named rg, pytest, and ruff commands above
- Collateral: `changelog.d/+locations-chirpui-drain.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge

Closes #313