### PR TITLE
Bind tenant-prefixed access-request POST to the URL realm

### DIFF
--- a/changelog.d/+access-request-prefix.changed.md
+++ b/changelog.d/+access-request-prefix.changed.md
@@ -1,0 +1,2 @@
+A request-access form posted under a realm URL now creates or withdraws the
+access request for that realm only, even if the form names a different realm.

--- a/src/elbysodic/web/pages/request-access/page.py
+++ b/src/elbysodic/web/pages/request-access/page.py
@@ -29,11 +29,18 @@ def get(request: Request) -> Page:
     return _render_request_access(request)
 
 
+def _access_request_community_slug(request: Request, form: RequestAccessForm) -> str:
+    tenant_slug = request_tenant_slug(request)
+    if tenant_slug is not None:
+        return tenant_slug
+    return form.community_slug.strip()
+
+
 @contract(form=FormContract(RequestAccessForm, "request-access/page.html"))
 async def post(request: Request, form: RequestAccessForm) -> Page:
     services = get_services()
     account_visitor = services.account_visitor(request)
-    community_slug = form.community_slug.strip()
+    community_slug = _access_request_community_slug(request, form)
     if not community_slug:
         return _render_request_access(request, error="Choose a realm before requesting access.")
     if form.intent == "withdraw_access_request":

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -1146,6 +1146,159 @@ def test_tenant_prefix_does_not_wrap_app_global_routes() -> None:
     asyncio.run(run())
 
 
+def test_tenant_prefixed_access_request_post_ignores_foreign_community_slug() -> None:
+    async def run() -> None:
+        app = _app()
+        services = get_services()
+        url_community = services.seed.community
+        foreign_community = services.repo.get_community_by_slug("afterlight-accord")
+        email = "prefix-bound-prospect@example.com"
+
+        async with TestClient(app) as client:
+            page = await client.get(f"/c/{url_community.slug}/request-access")
+            submitted = await client.post(
+                f"/c/{url_community.slug}/request-access",
+                body=urlencode(
+                    {
+                        "_csrf_token": _csrf_token(page.text),
+                        "community_slug": foreign_community.slug,
+                        "email": email,
+                        "display_name": "Prefix Bound Prospect",
+                        "face_concept": "Archive thief",
+                        "wanted_hook": "Sealed branch",
+                        "notes": "Posted under a foreign form slug.",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+
+        assert page.status == 200
+        assert submitted.status == 200
+        assert "Access request received" in submitted.text
+        url_requests = [
+            item
+            for item in services.repo.list_community_access_requests(url_community.id)
+            if item.email == email
+        ]
+        foreign_requests = [
+            item
+            for item in services.repo.list_community_access_requests(foreign_community.id)
+            if item.email == email
+        ]
+        assert len(url_requests) == 1
+        assert url_requests[0].status == "pending"
+        assert foreign_requests == []
+
+    asyncio.run(run())
+
+
+def test_tenant_prefixed_access_request_withdraw_ignores_foreign_community_slug() -> None:
+    async def run() -> None:
+        app = _app()
+        services = get_services()
+        url_community = services.seed.community
+        foreign_community = services.repo.get_community_by_slug("afterlight-accord")
+        account = services.repo.create_user(
+            "prefix-withdraw@example.com",
+            hash_password("password"),
+        )
+        role = services.repo.get_role_by_slug(url_community.id, "member")
+        services.repo.create_membership(
+            url_community.id,
+            account.id,
+            role.id,
+            "prefix-withdraw",
+            "Prefix Withdraw",
+        )
+        foreign_request = services.create_access_request(
+            foreign_community.slug,
+            email=account.email,
+            display_name="Prefix Withdraw",
+            face_concept="Rebel heir",
+            wanted_hook="Town politics",
+            notes="Should stay in the foreign realm.",
+            account_user_id=account.id,
+        )
+
+        async with TestClient(app) as client:
+            login_page = await client.get("/login")
+            login = await client.post(
+                "/login",
+                body=urlencode(
+                    {
+                        "_csrf_token": _csrf_token(login_page.text),
+                        "email": account.email,
+                        "password": "password",
+                        "next": f"/c/{url_community.slug}/request-access",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            page = await client.get(f"/c/{url_community.slug}/request-access")
+            withdrawn = await client.post(
+                f"/c/{url_community.slug}/request-access",
+                body=urlencode(
+                    {
+                        "_csrf_token": _csrf_token(page.text),
+                        "intent": "withdraw_access_request",
+                        "access_request_id": str(foreign_request.id),
+                        "community_slug": foreign_community.slug,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+
+        assert login.status == 302
+        assert withdrawn.status == 200
+        assert "Your access request was withdrawn" not in withdrawn.text
+        remaining = services.repo.get_community_access_request(
+            foreign_community.id,
+            foreign_request.id,
+        )
+        assert remaining.status == "pending"
+
+    asyncio.run(run())
+
+
+def test_unscoped_request_access_post_accepts_chosen_realm_slug() -> None:
+    async def run() -> None:
+        app = _app()
+        services = get_services()
+        chosen = services.repo.get_community_by_slug("afterlight-accord")
+        email = "unscoped-chosen-realm@example.com"
+
+        async with TestClient(app) as client:
+            page = await client.get(f"/c/{chosen.slug}/request-access")
+            submitted = await client.post(
+                "/request-access",
+                body=urlencode(
+                    {
+                        "_csrf_token": _csrf_token(page.text),
+                        "community_slug": chosen.slug,
+                        "email": email,
+                        "display_name": "Unscoped Prospect",
+                        "face_concept": "Forbidden envoy",
+                        "wanted_hook": "Transit gate",
+                        "notes": "Chose a realm without a tenant prefix.",
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+
+        assert page.status == 200
+        assert submitted.status == 200
+        assert "Access request received" in submitted.text
+        chosen_requests = [
+            item
+            for item in services.repo.list_community_access_requests(chosen.id)
+            if item.email == email
+        ]
+        assert len(chosen_requests) == 1
+        assert chosen_requests[0].status == "pending"
+
+    asyncio.run(run())
+
+
 def test_boosted_main_navigation_uses_chirp_shell_outlet() -> None:
     async def run() -> None:
         app = _app()


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #321 / #318
- Outcome: A POST to `/c/{community_slug}/request-access` creates or withdraws an access request only for that URL realm, even if the form sends a different `community_slug`. Unscoped `/request-access` can still choose a realm.

Closes #321

## Owned paths

- `src/elbysodic/web/pages/request-access/`
- matching assertions in `tests/test_forum_slice.py` (request-access / tenant prefix only)
- `changelog.d/+access-request-prefix.changed.md`

## Decisions frozen (do not reopen in review)

- Design #319 (closed): prefix is authoritative; ignore conflicting form slug; unscoped `/request-access` may still choose a realm.
- `docs/architecture/multi-tenancy.md` Route And Link Contract.
- Do not invent a new access-request schema or email flow.

## Acceptance run

```bash
uv run pytest tests/test_forum_slice.py -q -k 'access_request or request_access or tenant_prefix' --tb=short
uv run ruff check .
```

29 passed. Ruff clean.

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: Rendering And UI Steward (`src/elbysodic/web/AGENTS.md`), Test Steward (`tests/AGENTS.md`), Changelog Steward (`changelog.d/AGENTS.md`)
- Accepted: bind POST `community_slug` to `request_tenant_slug` when a prefix is present; prove create and withdraw ignore a foreign form slug; keep unscoped realm choice.
- Proof: `tests/test_forum_slice.py` prefixed create/withdraw and unscoped POST cases
- Collateral: `changelog.d/+access-request-prefix.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge