### PR TITLE
Drain login page off Chirp-UI layout macros

### DIFF
--- a/changelog.d/+login-chirpui-drain.changed.md
+++ b/changelog.d/+login-chirpui-drain.changed.md
@@ -1,0 +1,1 @@
+The login page now lays out with Elbysodic stack, cluster, and button primitives instead of Chirp-UI container, stack, surface, and section_header macros.

--- a/src/elbysodic/web/pages/login/page.html
+++ b/src/elbysodic/web/pages/login/page.html
@@ -1,6 +1,4 @@
 {% imports %}
-  {% from "chirpui/layout.html" import container, stack, section_header %}
-  {% from "chirpui/surface.html" import surface %}
   {% from "_components/access.html" import product_identity %}
 {% end %}
 
@@ -8,16 +6,17 @@
 <div id="page-root">
 {% block page_root_inner %}
 {% block page_content %}
-{% call container(max_width="42rem") %}
-{% call stack(gap="lg") %}
+<div class="elbysodic-stack elbysodic-stack--lg">
   {{ product_identity() }}
-  {% call section_header("Log In") %}
-  Choose the account first; Elbysodic will resolve the current community membership and active face after that.
-  {% end %}
+  <div class="elbysodic-stack elbysodic-stack--sm">
+    <h1>Log In</h1>
+    <p class="elbysodic-copy-lead">
+      Choose the account first; Elbysodic will resolve the current community membership and active face after that.
+    </p>
+  </div>
 
-  {% call surface(variant="elevated") %}
-  <form method="post" class="chirpui-stack chirpui-stack--md" hx-boost="false">
-        {{ csrf_field() }}
+  <form method="post" class="elbysodic-stack elbysodic-stack--md" hx-boost="false">
+    {{ csrf_field() }}
     <input type="hidden" name="next" value="{{ next_url }}">
     {% if error %}
     <p class="elbysodic-form-error">{{ error }}</p>
@@ -30,26 +29,24 @@
       <span>Password</span>
       <input name="password" type="password" autocomplete="current-password" required>
     </label>
-    <div class="chirpui-cluster elbysodic-cluster--between">
+    <div class="elbysodic-cluster elbysodic-cluster--between">
       <p class="elbysodic-copy-helper">
         {% if show_demo_login_hint %}
         Invite/demo accounts use password: <code>password</code>.
         {% else %}
         Already have an account? Use it before requesting realm access so directors can review the linked account request.
         {% end %}
-        <a class="chirpui-link" href="/request-access">Request access</a>.
+        <a href="/request-access">Request access</a>.
       </p>
-      <button class="chirpui-btn chirpui-btn--primary" type="submit">Log in</button>
+      <button class="elbysodic-btn elbysodic-btn--primary" type="submit">Log in</button>
     </div>
     <p id="passkey-login-error" class="elbysodic-form-error" hidden></p>
-    <button class="chirpui-btn" type="button" id="passkey-login" hidden>
+    <button class="elbysodic-btn" type="button" id="passkey-login" hidden>
       Sign in with a passkey
     </button>
   </form>
-  {% end %}
-{% end %}
-{% end %}
-{% end %}
+</div>
+{% endblock %}
 </div>
 {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #325 / epic #300 / design #293
- Outcome: `/login` templates no longer import `chirpui/*` or use `chirpui-*` classes. Layout uses existing Elbysodic stack, cluster, and button primitives. Passkey and session behavior stay unchanged.

Closes #325

## Owned paths

- `src/elbysodic/web/pages/login/`
- `changelog.d/+login-chirpui-drain.changed.md`

## Decisions frozen (do not reopen in review)

- ADR 0002; epic #300; design #293
- No new primitive CSS
- Replace `{% call container %}` / `{% call stack %}` / `{% call surface %}` / `{% call section_header %}` and `chirpui-btn|cluster|stack|link` with ordinary Elbysodic markup (`elbysodic-stack`, `elbysodic-btn`, `elbysodic-cluster`)
- Copy desk/locations drain shape

## Acceptance run

```bash
rg -n 'chirpui/' src/elbysodic/web/pages/login/
# empty
rg -n 'chirpui-' src/elbysodic/web/pages/login/
# empty
uv run pytest tests/test_forum_slice.py tests/test_auth_entry_surface_contracts.py tests/test_web_security.py -q -k 'login_route or login' --tb=short
uv run ruff check .
```

- `rg chirpui/` empty
- `rg chirpui-` empty
- pytest: 7 passed
- ruff: All checks passed

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: web rendering steward (local AGENTS.md); changelog steward for the towncrier fragment. No steward swarm.
- Accepted: drain Chirp-UI macros/classes on login only; keep passkey ids, CSRF, copy, and form fields.
- Proof: focused login pytest slice + `rg` emptiness on owned templates.
- Collateral: `changelog.d/+login-chirpui-drain.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge
- Stop And Ask: none. No schema, auth, passkey, layout, or theme-file changes.
