### PR TITLE
Migrate character plot-hook POST to Chirp page actions

### DIFF
--- a/changelog.d/+plot-hook-page-actions.changed.md
+++ b/changelog.d/+plot-hook-page-actions.changed.md
@@ -1,0 +1,1 @@
+Character plot-hook detail now dispatches interest, plotting-room, save, and archive mutations through Chirp page actions instead of intent-form handlers.

--- a/src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/_actions.py
+++ b/src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/_actions.py
@@ -1,0 +1,145 @@
+"""Page actions for /characters/{character_slug}/hooks/{hook_slug} (#327).
+
+Follows the recipe in ``pages/wanted/{wanted_slug}/_actions.py``. Mutations
+dispatch on the hidden ``_action`` form field. ``page.py`` ``post()`` is only
+the no-``_action`` fallback.
+"""
+
+from __future__ import annotations
+
+from chirp.errors import HTTPError
+from chirp.http.request import Request
+from chirp.pages.actions import action
+from chirp.templating.returns import FormAction
+
+from elbysodic.services import AppServices
+
+
+def _parse_interest_id(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise HTTPError(status=400, detail="interest_id must be an integer") from exc
+
+
+def _facet_slugs(form: object) -> list[str]:
+    values: list[object]
+    get_list = getattr(form, "get_list", None)
+    getlist = getattr(form, "getlist", None)
+    if callable(get_list):
+        values = list(get_list("facets"))
+    elif callable(getlist):
+        values = list(getlist("facets"))
+    else:
+        raw = getattr(form, "get", lambda _name: None)("facets")
+        values = [] if raw is None else [raw]
+    slugs: list[str] = []
+    for value in values:
+        slug = str(value or "").strip()
+        if slug and slug not in slugs:
+            slugs.append(slug)
+    return slugs
+
+
+@action("express_interest")
+async def express_interest(
+    services: AppServices,
+    character_slug: str,
+    hook_slug: str,
+) -> FormAction:
+    try:
+        services.express_plot_hook_interest(character_slug, hook_slug)
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/characters/{character_slug}/hooks/{hook_slug}", status=302)
+
+
+@action("start_plotting_room")
+async def start_plotting_room(
+    services: AppServices,
+    character_slug: str,
+    hook_slug: str,
+    interest_id: str = "",
+) -> FormAction:
+    try:
+        room = services.create_plotting_room_from_plot_hook_interest(
+            character_slug,
+            hook_slug,
+            _parse_interest_id(interest_id),
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/plotting/{room.id}", status=302)
+
+
+@action("save")
+async def save(
+    request: Request,
+    services: AppServices,
+    character_slug: str,
+    hook_slug: str,
+    title: str = "",
+    hook_type: str = "",
+    summary: str = "",
+    body: str = "",
+    status: str = "",
+) -> FormAction:
+    form = await request.form()
+    try:
+        hook = services.update_plot_hook(
+            character_slug,
+            hook_slug,
+            title=title,
+            hook_type=hook_type or "scene",
+            summary=summary,
+            body=body,
+            status=status or "open",
+            facet_slugs=_facet_slugs(form),
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/characters/{character_slug}/hooks/{hook.slug}", status=302)
+
+
+@action("archive")
+async def archive(
+    request: Request,
+    services: AppServices,
+    character_slug: str,
+    hook_slug: str,
+    title: str = "",
+    hook_type: str = "",
+    summary: str = "",
+    body: str = "",
+) -> FormAction:
+    form = await request.form()
+    try:
+        hook = services.update_plot_hook(
+            character_slug,
+            hook_slug,
+            title=title,
+            hook_type=hook_type or "scene",
+            summary=summary,
+            body=body,
+            status="archived",
+            facet_slugs=_facet_slugs(form),
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/characters/{character_slug}/hooks/{hook.slug}", status=302)

--- a/src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/page.html
+++ b/src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/page.html
@@ -59,7 +59,7 @@
       {% elif hook.can_express_interest and viewer.current_character %}
       <form method="post" hx-boost="false" class="chirpui-cluster elbysodic-cluster--end">
         {{ csrf_field() }}
-        <input type="hidden" name="intent" value="express_interest">
+        <input type="hidden" name="_action" value="express_interest">
         <button type="submit" class="chirpui-btn chirpui-btn--primary">
           I'm interested as {{ viewer.current_character.name }}
         </button>
@@ -100,7 +100,7 @@
           {% if hook.can_manage and item.interest.status == "interested" %}
           <form method="post" hx-boost="false" class="chirpui-cluster elbysodic-cluster--end">
         {{ csrf_field() }}
-            <input type="hidden" name="intent" value="start_plotting_room">
+            <input type="hidden" name="_action" value="start_plotting_room">
             <input type="hidden" name="interest_id" value="{{ item.interest.id }}">
             <button type="submit" class="chirpui-btn chirpui-btn--primary">
               Start plotting room
@@ -193,8 +193,8 @@
         {% end %}
       </div>
       <div class="chirpui-cluster elbysodic-cluster--between">
-        <button type="submit" name="intent" value="save" class="chirpui-btn chirpui-btn--primary">Save plot hook</button>
-        <button type="submit" name="intent" value="archive" class="chirpui-btn chirpui-btn--danger chirpui-btn--outlined">Archive</button>
+        <button type="submit" name="_action" value="save" class="chirpui-btn chirpui-btn--primary">Save plot hook</button>
+        <button type="submit" name="_action" value="archive" class="chirpui-btn chirpui-btn--danger chirpui-btn--outlined">Archive</button>
       </div>
     </form>
   </details>

--- a/src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/page.py
+++ b/src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/page.py
@@ -1,4 +1,9 @@
-"""Character plot-hook detail page."""
+"""Character plot-hook detail page.
+
+Mutations live in ``_actions.py`` (Chirp page actions, dispatched on the
+hidden ``_action`` form field). ``post()`` below is only the no-``_action``
+fallback that keeps the POST method registered on this path.
+"""
 
 from __future__ import annotations
 
@@ -7,16 +12,17 @@ from dataclasses import dataclass
 from chirp.contracts import FormContract, contract
 from chirp.errors import HTTPError
 from chirp.http.request import Request
-from chirp.http.response import Redirect
 from chirp.templating.returns import Page
 
 from elbysodic.services.plot_hooks import PLOT_HOOK_STATUSES, PLOT_HOOK_TYPES
 from elbysodic.web.state import get_services
 
+HOOK_TEMPLATE = "characters/{character_slug}/hooks/{hook_slug}/page.html"
+
 
 @dataclass(frozen=True, slots=True)
 class PlotHookActionForm:
-    intent: str
+    _action: str
     interest_id: str = ""
     title: str = ""
     hook_type: str = ""
@@ -30,79 +36,10 @@ def get(request: Request, character_slug: str, hook_slug: str) -> Page:
     return _render_hook(request, character_slug, hook_slug)
 
 
-@contract(
-    form=FormContract(
-        PlotHookActionForm,
-        "characters/{character_slug}/hooks/{hook_slug}/page.html",
-    )
-)
-async def post(request: Request, character_slug: str, hook_slug: str) -> Page | Redirect:
-    services = get_services(request)
-    form = await request.form()
-    intent = str(form.get("intent") or "")
-    if intent == "express_interest":
-        try:
-            services.express_plot_hook_interest(character_slug, hook_slug)
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/characters/{character_slug}/hooks/{hook_slug}")
-    if intent == "start_plotting_room":
-        try:
-            room = services.create_plotting_room_from_plot_hook_interest(
-                character_slug,
-                hook_slug,
-                _parse_interest_id(form.get("interest_id")),
-            )
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/plotting/{room.id}")
-    if intent == "save":
-        try:
-            hook = services.update_plot_hook(
-                character_slug,
-                hook_slug,
-                title=str(form.get("title") or ""),
-                hook_type=str(form.get("hook_type") or "scene"),
-                summary=str(form.get("summary") or ""),
-                body=str(form.get("body") or ""),
-                status=str(form.get("status") or "open"),
-                facet_slugs=_facet_slugs(form),
-            )
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/characters/{character_slug}/hooks/{hook.slug}")
-    if intent == "archive":
-        try:
-            hook = services.update_plot_hook(
-                character_slug,
-                hook_slug,
-                title=str(form.get("title") or ""),
-                hook_type=str(form.get("hook_type") or "scene"),
-                summary=str(form.get("summary") or ""),
-                body=str(form.get("body") or ""),
-                status="archived",
-                facet_slugs=_facet_slugs(form),
-            )
-        except LookupError as exc:
-            raise HTTPError(status=404, detail=str(exc)) from exc
-        except PermissionError as exc:
-            raise HTTPError(status=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPError(status=400, detail=str(exc)) from exc
-        return Redirect(f"/characters/{character_slug}/hooks/{hook.slug}")
-    raise HTTPError(status=400, detail=f"unknown plot hook intent: {intent}")
+@contract(form=FormContract(PlotHookActionForm, HOOK_TEMPLATE))
+async def post(request: Request, character_slug: str, hook_slug: str) -> Page:
+    """Fallback — mutations dispatch via this directory's ``_actions.py``."""
+    return _render_hook(request, character_slug, hook_slug)
 
 
 def _render_hook(request: Request, character_slug: str, hook_slug: str) -> Page:
@@ -112,36 +49,10 @@ def _render_hook(request: Request, character_slug: str, hook_slug: str) -> Page:
     except LookupError as exc:
         raise HTTPError(status=404, detail=str(exc)) from exc
     return Page.mounted(
-        "characters/{character_slug}/hooks/{hook_slug}/page.html",
+        HOOK_TEMPLATE,
         current_path=request.url,
         viewer=services.viewer(),
         hook=hook,
         plot_hook_types=PLOT_HOOK_TYPES,
         plot_hook_statuses=PLOT_HOOK_STATUSES,
     )
-
-
-def _facet_slugs(form: object) -> list[str]:
-    values: list[object]
-    get_list = getattr(form, "get_list", None)
-    getlist = getattr(form, "getlist", None)
-    if callable(get_list):
-        values = list(get_list("facets"))
-    elif callable(getlist):
-        values = list(getlist("facets"))
-    else:
-        raw = getattr(form, "get", lambda _name: None)("facets")
-        values = [] if raw is None else [raw]
-    slugs: list[str] = []
-    for value in values:
-        slug = str(value or "").strip()
-        if slug and slug not in slugs:
-            slugs.append(slug)
-    return slugs
-
-
-def _parse_interest_id(value: object) -> int:
-    try:
-        return int(str(value or ""))
-    except ValueError as exc:
-        raise HTTPError(status=400, detail="interest_id must be an integer") from exc

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -9722,7 +9722,7 @@ def test_character_plot_hooks_render_create_and_notify_interest() -> None:
 
                 interest = await outsider_client.post(
                     "/characters/rogue/hooks/coffee-before-the-crisis",
-                    body=b"intent=express_interest",
+                    body=b"_action=express_interest",
                     headers=_FORM,
                 )
                 assert interest.status == 302
@@ -9791,7 +9791,7 @@ def test_character_plot_hooks_render_create_and_notify_interest() -> None:
 
                 room_response = await owner_client.post(
                     "/characters/rogue/hooks/coffee-before-the-crisis",
-                    body=f"intent=start_plotting_room&interest_id={interest.id}".encode(),
+                    body=f"_action=start_plotting_room&interest_id={interest.id}".encode(),
                     headers=_FORM,
                 )
                 assert room_response.status == 302


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #327 / #226 (design #299)
- Outcome: `/characters/{character_slug}/hooks/{hook_slug}` mutations dispatch through `_actions.py` using the notifications/claims/wanted-hook recipe. No new Chirp-UI markup.

Closes #327

## Owned paths

- `src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/`
- plot-hook POST assertions in `tests/test_forum_slice.py` only
- `changelog.d/+plot-hook-page-actions.changed.md`

## Decisions frozen (do not reopen in review)

- Design #299; ADR 0002
- Copy `src/elbysodic/web/pages/wanted/{wanted_slug}/_actions.py`
- One route; hidden `_action` replaces `intent`
- Keep `post()` fallback that re-renders
- Add `_action` to FormContract
- Every test POST to this path uses `_action=` (character-hub and `/wanted/` POSTs unchanged)

## Acceptance run

```bash
test -f 'src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/_actions.py'
rg -n '@action\(' 'src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/_actions.py'
rg -n 'form.get\("intent"\)|intent ==' 'src/elbysodic/web/pages/characters/{character_slug}/hooks/{hook_slug}/page.py'
# must be empty
uv run pytest tests/test_forum_slice.py -q -k 'character_plot_hooks_render_create_and_notify_interest or plot_hook_room_start_rolls_back' --tb=short
uv run ruff check .
```

- `_actions.py` present with `@action` for `express_interest`, `start_plotting_room`, `save`, `archive`
- `page.py` intent dispatch empty
- pytest: 2 passed
- no leftover `intent=` bodies on `/characters/.../hooks/` POSTs

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: web, tests, changelog (no steward swarm; copy of closed design #299 recipe)
- Accepted / deferred: page-action dispatch + FormContract `_action`; character-hub `create_plot_hook` stays intent dispatch (out of scope)
- Proof: focused forum-slice tests + ruff + Chirp `app.check(warnings_as_errors=True)` all clear
- Collateral: towncrier fragment `changelog.d/+plot-hook-page-actions.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge
- Stop And Ask / triage: none