### PR TITLE
Drain notifications page off Chirp-UI layout macros

### DIFF
--- a/changelog.d/+notifications-chirpui-drain.changed.md
+++ b/changelog.d/+notifications-chirpui-drain.changed.md
@@ -1,0 +1,1 @@
+The notifications inbox now lays out with Elbysodic stack, cluster, chip, and button markup instead of Chirp-UI macros.

--- a/src/elbysodic/web/pages/notifications/page.html
+++ b/src/elbysodic/web/pages/notifications/page.html
@@ -1,7 +1,4 @@
 {% imports %}
-  {% from "chirpui/badge.html" import badge %}
-  {% from "chirpui/layout.html" import container, stack, section_header %}
-  {% from "chirpui/surface.html" import surface %}
   {% from "_components/ui.html" import empty_policy_block %}
   {% from "_components/vocabulary.html" import metric_item, page_pulse %}
 {% end %}
@@ -10,11 +7,13 @@
 <div id="page-root">
 {% block page_root_inner %}
 {% block page_content %}
-{% call container(max_width="72rem") %}
-{% call stack(gap="lg") %}
-  {% call section_header("Notifications") %}
-  Watched threads and direct mentions for {{ viewer.community.name }}.
-  {% end %}
+<div class="elbysodic-stack elbysodic-stack--lg">
+  <section class="elbysodic-stack elbysodic-stack--sm">
+    <h1>Notifications</h1>
+    <p class="elbysodic-copy-lead">
+      Watched threads and direct mentions for {{ viewer.community.name }}.
+    </p>
+  </section>
 
   {% call page_pulse("Signals", "What changed while you were writing", "Mentions, watched thread replies, applications, and plotting movement land here.", "notification-signals-heading", "elbysodic-notification-command") %}
     <div class="elbysodic-command-panel__metrics" aria-label="Notification totals">
@@ -25,24 +24,25 @@
     <form method="post" hx-boost="false">
       {{ csrf_field() }}
       <input type="hidden" name="_action" value="mark_all_read">
-      <button type="submit" class="chirpui-btn chirpui-btn--secondary">Mark all read</button>
+      <button type="submit" class="elbysodic-btn">Mark all read</button>
     </form>
     {% end %}
   {% end %}
 
-  <div class="chirpui-stack chirpui-stack--sm">
+  <div class="elbysodic-stack elbysodic-stack--sm">
     {% if inbox.items %}
     {% for item in inbox.items %}
-    {% call surface(variant="elevated") %}
     <article class="elbysodic-notification-card {{ "elbysodic-notification-card--unread" if item.is_unread else "" }}">
       <div class="elbysodic-notification-card__body">
-        <div class="chirpui-cluster chirpui-cluster--sm">
-          {{ badge(item.label, variant="info" if item.is_unread else "muted") }}
-          {{ badge("new", variant="warning") if item.is_unread else "" }}
+        <div class="elbysodic-cluster">
+          <span class="elbysodic-reader-chip{{ " elbysodic-reader-chip--strong" if item.is_unread else "" }}">{{ item.label }}</span>
+          {% if item.is_unread %}
+          <span class="elbysodic-reader-chip elbysodic-reader-chip--strong">new</span>
+          {% end %}
         </div>
         <h2>{{ item.title }}</h2>
         <p class="elbysodic-copy-meta">
-          {{ item.actor.name if item.actor else item.actor_membership.display_name }} · writer <a class="chirpui-link" href="/members/{{ item.actor_membership.username }}">{{ item.actor_membership.username }}</a>
+          {{ item.actor.name if item.actor else item.actor_membership.display_name }} · writer <a href="/members/{{ item.actor_membership.username }}">{{ item.actor_membership.username }}</a>
           · {{ item.created_at_label }}
         </p>
         <p class="elbysodic-copy-summary">{{ item.snippet }}</p>
@@ -51,18 +51,16 @@
         {{ csrf_field() }}
         <input type="hidden" name="_action" value="open">
         <input type="hidden" name="notification_id" value="{{ item.notification.id }}">
-        <button type="submit" class="chirpui-btn chirpui-btn--primary">Open</button>
+        <button type="submit" class="elbysodic-btn elbysodic-btn--primary">Open</button>
       </form>
     </article>
-    {% end %}
     {% end %}
     {% else %}
     {{ empty_policy_block("No notifications are waiting on you.", "Watched scenes, mentions, review movement, and plotting room updates will appear here.", "Caught up") }}
     {% end %}
   </div>
-{% end %}
-{% end %}
-{% end %}
+</div>
 {% endblock %}
 </div>
+{% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #341 / #300
- Outcome: The `/notifications` template no longer imports `chirpui/*` or uses `chirpui-*` classes. Layout uses Elbysodic stack, cluster, reader chips, and buttons. Page-action dispatch in `_actions.py` is unchanged.

Closes #341

## Owned paths

- `src/elbysodic/web/pages/notifications/page.html`
- `changelog.d/+notifications-chirpui-drain.changed.md`

## Decisions frozen (do not reopen in review)

- ADR 0002; epic #300; design #293
- No new primitive CSS
- Replace Chirp-UI container/stack/section_header/surface/badge and `chirpui-btn|cluster|stack|link` with existing Elbysodic markup
- Do not use `elbysodic-cluster--sm|xs|md|lg` (theme tests only allow `--between` and `--end`)
- Keep `page_pulse`, `empty_policy_block`, `_action=mark_all_read`, and `_action=open`

## Acceptance run

```bash
rg -n 'chirpui/' src/elbysodic/web/pages/notifications/page.html
rg -n 'chirpui-' src/elbysodic/web/pages/notifications/page.html
uv run pytest tests/test_forum_slice.py -q -k 'notification' --tb=short
uv run pytest tests/test_theme_css.py::test_cluster_alignment_modifiers_have_owned_layout_rules tests/test_frontend_surface_contracts.py -q --tb=short
uv run ruff check .
```

- `rg chirpui/` empty
- `rg chirpui-` empty
- forum-slice `-k notification`: 11 passed
- theme cluster + frontend surface contracts: 19 passed
- ruff: All checks passed

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: Rendering And UI Steward (`src/elbysodic/web/AGENTS.md`); Changelog Steward (`changelog.d/AGENTS.md`)
- Accepted: drain Chirp-UI macros from the notifications inbox onto existing Elbysodic primitives; keep surface-contract imports and mark-all-read copy
- Proof: `rg` drain checks, notification forum-slice tests, theme cluster modifier test, frontend surface contracts, ruff
- Collateral: `changelog.d/+notifications-chirpui-drain.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge