### PR TITLE
Migrate application-review POST to Chirp page actions

### DIFF
--- a/changelog.d/+application-room-page-actions.changed.md
+++ b/changelog.d/+application-room-page-actions.changed.md
@@ -1,0 +1,1 @@
+Application review rooms now dispatch save, review, accept, and revision mutations through Chirp page actions instead of intent-form handlers.

--- a/src/elbysodic/web/pages/applications/{character_slug}/_actions.py
+++ b/src/elbysodic/web/pages/applications/{character_slug}/_actions.py
@@ -1,0 +1,140 @@
+"""Page actions for /applications/{character_slug} — Chirp 0.10 ``_actions.py`` (#343).
+
+Follows the recipe in ``pages/wanted/{wanted_slug}/_actions.py`` and
+``pages/characters/{character_slug}/hooks/{hook_slug}/_actions.py``. Mutations
+dispatch on the hidden ``_action`` form field. ``page.py`` ``post()`` is only
+the no-``_action`` fallback.
+"""
+
+from __future__ import annotations
+
+from chirp.errors import HTTPError
+from chirp.http.request import Request
+from chirp.pages.actions import action
+from chirp.templating.returns import FormAction
+
+from elbysodic.services import AppServices
+from elbysodic.services.read_models import ApplicationReviewRoom
+
+
+def _application_field_values(
+    form: object,
+    room: ApplicationReviewRoom,
+) -> dict[int, str]:
+    values: dict[int, str] = {}
+    form_get = getattr(form, "get", lambda _name: None)
+    if not any(
+        form_get(f"application_field_{item.field.field.id}") is not None
+        for item in room.intake_fields
+    ):
+        return values
+    for item in room.intake_fields:
+        field = item.field.field
+        value = str(form_get(f"application_field_{field.id}") or "")
+        value = value.strip()
+        if field.is_required and not value:
+            raise ValueError(f"{field.label} is required")
+        values[field.id] = value[:5000]
+    return values
+
+
+@action("save_application")
+async def save_application(
+    request: Request,
+    services: AppServices,
+    character_slug: str,
+    summary: str = "",
+    body: str = "",
+) -> FormAction:
+    form = await request.form()
+    try:
+        room = services.read_application_review_room(character_slug)
+        services.update_application_draft(
+            character_slug,
+            summary=summary,
+            body=body,
+            application_field_values=_application_field_values(form, room),
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/applications/{character_slug}", status=302)
+
+
+@action("submit_application")
+async def submit_application(
+    services: AppServices,
+    character_slug: str,
+) -> FormAction:
+    try:
+        services.submit_character_application(character_slug)
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/applications/{character_slug}", status=302)
+
+
+@action("save_review")
+async def save_review(
+    services: AppServices,
+    character_slug: str,
+    revision_notes: str = "",
+    staff_notes: str = "",
+    checklist: str = "",
+) -> FormAction:
+    try:
+        services.update_application_review(
+            character_slug,
+            revision_notes=revision_notes,
+            staff_notes=staff_notes,
+            checklist=checklist,
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/applications/{character_slug}", status=302)
+
+
+@action("accept_application")
+async def accept_application(
+    services: AppServices,
+    character_slug: str,
+) -> FormAction:
+    try:
+        services.accept_character_application(character_slug)
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/applications/{character_slug}", status=302)
+
+
+@action("request_revision")
+async def request_revision(
+    services: AppServices,
+    character_slug: str,
+    revision_notes: str = "",
+) -> FormAction:
+    try:
+        services.request_character_application_revision(
+            character_slug,
+            note=revision_notes,
+        )
+    except LookupError as exc:
+        raise HTTPError(status=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPError(status=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPError(status=400, detail=str(exc)) from exc
+    return FormAction(f"/applications/{character_slug}", status=302)

--- a/src/elbysodic/web/pages/applications/{character_slug}/page.html
+++ b/src/elbysodic/web/pages/applications/{character_slug}/page.html
@@ -97,7 +97,7 @@
           hx-boost="false"
           data-elbysodic-submit-label="Saving application...">
         {{ csrf_field() }}
-      <input type="hidden" name="intent" value="save_application">
+      <input type="hidden" name="_action" value="save_application">
       <label>
         <span class="chirpui-field__label">Application summary</span>
         <textarea class="chirpui-field__input"
@@ -264,7 +264,7 @@
           hx-boost="false"
           data-elbysodic-submit-label="Saving review...">
         {{ csrf_field() }}
-      <input type="hidden" name="intent" value="save_review">
+      <input type="hidden" name="_action" value="save_review">
       <label>
         <span class="chirpui-field__label">Revision note for applicant</span>
         <textarea class="chirpui-field__input"
@@ -291,7 +291,7 @@
     <div class="chirpui-cluster elbysodic-cluster--end">
       <form method="post" hx-boost="false" data-elbysodic-submit-label="Accepting face...">
         {{ csrf_field() }}
-        <input type="hidden" name="intent" value="accept_application">
+        <input type="hidden" name="_action" value="accept_application">
         <button type="submit"
                 class="chirpui-btn chirpui-btn--primary"
                 {{ "disabled" if room.has_blocking_claim_conflicts else "" }}>
@@ -300,7 +300,7 @@
       </form>
       <form method="post" hx-boost="false" data-elbysodic-submit-label="Requesting revisions...">
         {{ csrf_field() }}
-        <input type="hidden" name="intent" value="request_revision">
+        <input type="hidden" name="_action" value="request_revision">
         <input type="hidden" name="revision_notes" value="{{ revision_note_value }}">
         <button type="submit" class="chirpui-btn chirpui-btn--secondary">Request revisions</button>
       </form>

--- a/src/elbysodic/web/pages/applications/{character_slug}/page.py
+++ b/src/elbysodic/web/pages/applications/{character_slug}/page.py
@@ -1,4 +1,9 @@
-"""Character application review room."""
+"""Character application review room.
+
+Mutations live in ``_actions.py`` (Chirp page actions, dispatched on the
+hidden ``_action`` form field). ``post()`` below is only the no-``_action``
+fallback that keeps the POST method registered on this path.
+"""
 
 from __future__ import annotations
 
@@ -7,17 +12,17 @@ from dataclasses import dataclass
 from chirp.contracts import FormContract, contract
 from chirp.errors import HTTPError
 from chirp.http.request import Request
-from chirp.http.response import Redirect
 from chirp.templating.returns import Page
 
-from elbysodic.services.read_models import ApplicationReviewRoom
 from elbysodic.web.recovery import recover_missing_route
 from elbysodic.web.state import get_services
+
+APPLICATION_ROOM_TEMPLATE = "applications/{character_slug}/page.html"
 
 
 @dataclass(frozen=True, slots=True)
 class ApplicationRoomForm:
-    intent: str
+    _action: str
     summary: str = ""
     body: str = ""
     revision_notes: str = ""
@@ -29,45 +34,10 @@ def get(request: Request, character_slug: str) -> Page:
     return _render_application_room(request, character_slug)
 
 
-@contract(form=FormContract(ApplicationRoomForm, "applications/{character_slug}/page.html"))
-async def post(request: Request, character_slug: str) -> Page | Redirect:
-    form = await request.form()
-    services = get_services(request)
-    intent = str(form.get("intent") or "")
-    try:
-        if intent == "save_application":
-            room = services.read_application_review_room(character_slug)
-            services.update_application_draft(
-                character_slug,
-                summary=str(form.get("summary") or ""),
-                body=str(form.get("body") or ""),
-                application_field_values=_application_field_values(form, room),
-            )
-        elif intent == "submit_application":
-            services.submit_character_application(character_slug)
-        elif intent == "save_review":
-            services.update_application_review(
-                character_slug,
-                revision_notes=str(form.get("revision_notes") or ""),
-                staff_notes=str(form.get("staff_notes") or ""),
-                checklist=str(form.get("checklist") or ""),
-            )
-        elif intent == "accept_application":
-            services.accept_character_application(character_slug)
-        elif intent == "request_revision":
-            services.request_character_application_revision(
-                character_slug,
-                note=str(form.get("revision_notes") or ""),
-            )
-        else:
-            raise HTTPError(status=400, detail=f"unknown application room action: {intent}")
-    except PermissionError as exc:
-        raise HTTPError(status=403, detail=str(exc)) from exc
-    except LookupError as exc:
-        raise HTTPError(status=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPError(status=400, detail=str(exc)) from exc
-    return Redirect(f"/applications/{character_slug}")
+@contract(form=FormContract(ApplicationRoomForm, APPLICATION_ROOM_TEMPLATE))
+async def post(request: Request, character_slug: str) -> Page:
+    """Fallback — mutations dispatch via ``pages/applications/{character_slug}/_actions.py``."""
+    return _render_application_room(request, character_slug)
 
 
 def _render_application_room(request: Request, character_slug: str) -> Page:
@@ -79,7 +49,7 @@ def _render_application_room(request: Request, character_slug: str) -> Page:
     except LookupError:
         return recover_missing_route(request, kind="application", slug=character_slug)
     return Page.mounted(
-        "applications/{character_slug}/page.html",
+        APPLICATION_ROOM_TEMPLATE,
         current_path=request.url,
         viewer=services.viewer(),
         room=room,
@@ -90,24 +60,3 @@ def _render_application_room(request: Request, character_slug: str) -> Page:
             else None
         ),
     )
-
-
-def _application_field_values(
-    form: object,
-    room: ApplicationReviewRoom,
-) -> dict[int, str]:
-    values: dict[int, str] = {}
-    form_get = getattr(form, "get", lambda _name: None)
-    if not any(
-        form_get(f"application_field_{item.field.field.id}") is not None
-        for item in room.intake_fields
-    ):
-        return values
-    for item in room.intake_fields:
-        field = item.field.field
-        value = str(form_get(f"application_field_{field.id}") or "")
-        value = value.strip()
-        if field.is_required and not value:
-            raise ValueError(f"{field.label} is required")
-        values[field.id] = value[:5000]
-    return values

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -8188,7 +8188,7 @@ def test_applications_desk_tracks_character_statuses() -> None:
                 "/applications/jubilee",
                 body=urlencode(
                     {
-                        "intent": "save_application",
+                        "_action": "save_application",
                         "summary": "Fireworks, mall instincts, and a very loud jacket.",
                         "body": "Jubilee is looking for a found-family first scene.",
                     }
@@ -8269,7 +8269,7 @@ def test_applications_desk_tracks_character_statuses() -> None:
                     "/applications/jubilee",
                     body=urlencode(
                         {
-                            "intent": "save_review",
+                            "_action": "save_review",
                             "revision_notes": "",
                             "staff_notes": "Voice is clear.",
                             "checklist": "Starter hook\nCast tie",
@@ -8283,7 +8283,7 @@ def test_applications_desk_tracks_character_statuses() -> None:
                     "/applications/jubilee",
                     body=urlencode(
                         {
-                            "intent": "accept_application",
+                            "_action": "accept_application",
                         }
                     ).encode(),
                     headers=_FORM,
@@ -8294,7 +8294,7 @@ def test_applications_desk_tracks_character_statuses() -> None:
                     "/applications/kitty-pryde",
                     body=urlencode(
                         {
-                            "intent": "request_revision",
+                            "_action": "request_revision",
                             "revision_notes": "Add one concrete school-life pressure point.",
                         }
                     ).encode(),
@@ -8769,7 +8769,7 @@ def test_application_start_form_creates_draft_face_and_review_room() -> None:
                 "/applications/jean-grey",
                 body=urlencode(
                     {
-                        "intent": "save_application",
+                        "_action": "save_application",
                         "summary": "A powerful telepath trying to stay gentle.",
                         "body": "Trying a visual that directors should catch.",
                         f"application_field_{fields['face_claim'].id}": "Magneto Visual",
@@ -8795,7 +8795,7 @@ def test_application_start_form_creates_draft_face_and_review_room() -> None:
                 "/applications/jean-grey",
                 body=urlencode(
                     {
-                        "intent": "save_application",
+                        "_action": "save_application",
                         "summary": "A powerful telepath trying to stay gentle.",
                         "body": "Updated notes for school pressure and rescue work.",
                         f"application_field_{fields['face_claim'].id}": "Sophie Turner",
@@ -8850,7 +8850,7 @@ def test_application_start_form_creates_draft_face_and_review_room() -> None:
             review_room = await alex_client.get("/applications/jean-grey")
             accept_response = await alex_client.post(
                 "/applications/jean-grey",
-                body=urlencode({"intent": "accept_application"}).encode(),
+                body=urlencode({"_action": "accept_application"}).encode(),
                 headers=_FORM,
             )
             claims = await alex_client.get("/claims")
@@ -8999,14 +8999,14 @@ def test_application_review_flags_mapped_claim_conflicts_before_accept() -> None
             review_room = await alex_client.get("/applications/duplicate-face")
             accept_response = await alex_client.post(
                 "/applications/duplicate-face",
-                body=urlencode({"intent": "accept_application"}).encode(),
+                body=urlencode({"_action": "accept_application"}).encode(),
                 headers=_FORM,
             )
             revision_response = await alex_client.post(
                 "/applications/duplicate-face",
                 body=urlencode(
                     {
-                        "intent": "request_revision",
+                        "_action": "request_revision",
                         "revision_notes": expected_revision_note,
                     }
                 ).encode(),

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -1982,7 +1982,7 @@ def test_production_application_room_requires_csrf_and_accepts_rendered_token(
                 "/applications/kitty-pryde",
                 body=urlencode(
                     {
-                        "intent": "save_review",
+                        "_action": "save_review",
                         "staff_notes": "Private staff note.",
                         "checklist": "Voice\nHooks",
                     }
@@ -1993,7 +1993,7 @@ def test_production_application_room_requires_csrf_and_accepts_rendered_token(
                 "/applications/kitty-pryde",
                 body=urlencode(
                     {
-                        "intent": "save_review",
+                        "_action": "save_review",
                         "staff_notes": "Private staff note.",
                         "checklist": "Voice\nHooks",
                         "_csrf_token": _csrf_token(room.text),


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #343 / #226 (design #299)
- Outcome: `/applications/{character_slug}` mutations dispatch through `_actions.py` using the wanted-hook / plot-hook recipe. Applications list `/applications` POST stays intent dispatch.

Closes #343

## Owned paths

- `src/elbysodic/web/pages/applications/{character_slug}/`
- application-review-room POST assertions in `tests/test_forum_slice.py` whose URL is `/applications/{slug}`
- POST bodies to `/applications/{slug}` in `tests/test_web_security.py` (CSRF save_review)
- `changelog.d/+application-room-page-actions.changed.md`

## Decisions frozen (do not reopen in review)

- Design #299; ADR 0002
- Copy `wanted/{wanted_slug}/_actions.py` and plot-hook `_actions.py` (`request.form()` for dynamic `application_field_*`)
- One route; hidden `_action` replaces `intent`; keep `post()` fallback
- Leave list POSTs to `/applications` on `intent=`

## Acceptance run

```bash
test -f 'src/elbysodic/web/pages/applications/{character_slug}/_actions.py'
rg -n '@action\(' 'src/elbysodic/web/pages/applications/{character_slug}/_actions.py'
rg -n 'form.get\("intent"\)|intent ==' 'src/elbysodic/web/pages/applications/{character_slug}/page.py'
uv run pytest tests/test_forum_slice.py tests/test_web_security.py -q -k 'application' --tb=short
uv run ruff check .
```

- `_actions.py` present with `@action` handlers: save_application, submit_application, save_review, accept_application, request_revision
- `page.py` has no `form.get("intent")` / `intent ==`
- pytest `-k application`: 15 passed
- ruff: All checks passed

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: Rendering And UI steward (`src/elbysodic/web/AGENTS.md`); tests steward for room POST / CSRF assertions. No steward swarm: recipe copy of wanted/plot-hook page actions.
- Accepted / deferred: accepted Chirp `_action` dispatch + FormContract `_action`; deferred Chirp-UI drain on this room (out of scope).
- Proof: application-filtered pytest on `tests/test_forum_slice.py` and `tests/test_web_security.py`; ruff check.
- Collateral: `changelog.d/+application-room-page-actions.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge