### PR TITLE
Drain wanted catalog off Chirp-UI layout macros

### DIFF
--- a/changelog.d/+wanted-catalog-chirpui-drain.changed.md
+++ b/changelog.d/+wanted-catalog-chirpui-drain.changed.md
@@ -1,0 +1,1 @@
+The wanted catalog now lays out with Elbysodic stack markup instead of Chirp-UI container, stack, and section header macros.

--- a/src/elbysodic/web/pages/wanted/page.html
+++ b/src/elbysodic/web/pages/wanted/page.html
@@ -1,5 +1,4 @@
 {% imports %}
-  {% from "chirpui/layout.html" import container, stack, section_header %}
   {% from "_components/ui.html" import empty_policy_block %}
   {% from "_components/wanted.html" import wanted_card %}
 {% end %}
@@ -8,11 +7,13 @@
 <div id="page-root">
 {% block page_root_inner %}
 {% block page_content %}
-{% call container(max_width="72rem") %}
-{% call stack(gap="lg") %}
-  {% call section_header("Wanted") %}
-  Character connections, event roles, faction needs, and plot hooks.
-  {% end %}
+<div class="elbysodic-stack elbysodic-stack--lg">
+  <section class="elbysodic-stack elbysodic-stack--sm">
+    <h1>Wanted</h1>
+    <p class="elbysodic-copy-lead">
+      Character connections, event roles, faction needs, and plot hooks.
+    </p>
+  </section>
 
   {% if board.open_ads %}
   <div class="elbysodic-wanted-grid">
@@ -23,9 +24,8 @@
   {% else %}
   {{ empty_policy_block("No open wanted hooks yet.", "When directors or writers publish wanted hooks, they will appear here for browsing.", "Quiet board") }}
   {% end %}
-{% end %}
-{% end %}
-{% end %}
+</div>
 {% endblock %}
 </div>
+{% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #348 / #300
- Outcome: The `/wanted` catalog template no longer imports `chirpui/*` or uses `chirpui-*` classes. Layout uses Elbysodic stack markup, matching the members/desk drain. Wanted detail stays out of scope.

Closes #348

## Owned paths

- `src/elbysodic/web/pages/wanted/page.html`
- `changelog.d/+wanted-catalog-chirpui-drain.changed.md`

## Decisions frozen (do not reopen in review)

- ADR 0002; epic #300. No new primitive CSS. Keep `empty_policy_block` and `wanted_card`. Do not drain `_components/wanted.html`. Do not use `elbysodic-cluster--sm|xs|md|lg`. Detail `/wanted/{wanted_slug}` remains Chirp-UI (`chirpui-detail-header` proof).

## Acceptance run

```bash
rg -n 'chirpui/' src/elbysodic/web/pages/wanted/page.html
rg -n 'chirpui-' src/elbysodic/web/pages/wanted/page.html
uv run pytest tests/test_forum_slice.py -q -k wanted_ads_render --tb=short
uv run pytest tests/test_theme_css.py::test_cluster_alignment_modifiers_have_owned_layout_rules tests/test_frontend_surface_contracts.py -q --tb=short
uv run ruff check .
```

- `rg chirpui/` empty
- `rg chirpui-` empty
- `wanted_ads_render`: passed
- theme CSS + frontend surface contracts: passed
- ruff: All checks passed

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: Rendering And UI Steward (`src/elbysodic/web/AGENTS.md`); Changelog Steward (`changelog.d/AGENTS.md`)
- Accepted / deferred: catalog-only Chirp-UI layout drain; shared `wanted_card` still may emit chirpui classes (deferred to a later leaf)
- Proof: machine acceptance above
- Collateral: changelog fragment in this PR

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge