### PR TITLE
Drain applications desk off Chirp-UI layout macros

### DIFF
--- a/changelog.d/+applications-desk-chirpui-drain.changed.md
+++ b/changelog.d/+applications-desk-chirpui-drain.changed.md
@@ -1,0 +1,1 @@
+The applications desk now lays out with Elbysodic stack, chip, and button markup instead of Chirp-UI container, stack, surface, and badge macros.

--- a/src/elbysodic/web/pages/applications/page.html
+++ b/src/elbysodic/web/pages/applications/page.html
@@ -15,7 +15,7 @@
       {% end %}
     </a>
     <div class="elbysodic-application-card__identity">
-      <h3><a href="/characters/{{ item.character.slug }}">{{ item.character.name }}</a></h3>
+      <h2><a href="/characters/{{ item.character.slug }}">{{ item.character.name }}</a></h2>
       <p class="elbysodic-copy-meta">
         writer
         <a href="/members/{{ item.membership.username }}">{{ item.membership.display_name }}</a>
@@ -151,7 +151,7 @@
       {% for item in desk.application_materials %}
       <article class="elbysodic-stack elbysodic-stack--sm">
         <div class="elbysodic-cluster elbysodic-cluster--between">
-          <h3><a href="/world/{{ item.material.slug }}">{{ item.material.title }}</a></h3>
+          <h2><a href="/world/{{ item.material.slug }}">{{ item.material.title }}</a></h2>
           <span class="elbysodic-reader-chip">{{ item.type_label }}</span>
         </div>
         <p class="elbysodic-copy-summary">{{ item.rendered_summary }}</p>

--- a/src/elbysodic/web/pages/applications/page.html
+++ b/src/elbysodic/web/pages/applications/page.html
@@ -1,14 +1,10 @@
 {% imports %}
-  {% from "chirpui/badge.html" import badge %}
-  {% from "chirpui/layout.html" import container, stack, section_header %}
-  {% from "chirpui/surface.html" import surface %}
   {% from "_components/facets.html" import facet_pills %}
   {% from "_components/ui.html" import empty_policy_block, page_section %}
   {% from "_components/vocabulary.html" import command_panel, metric_item %}
 {% end %}
 
 {% def application_card(item) %}
-{% call surface(variant="elevated") %}
 <article class="elbysodic-application-card">
   <div class="elbysodic-application-card__face">
     <a class="elbysodic-application-card__avatar" href="/characters/{{ item.character.slug }}" aria-label="{{ item.character.name }}">
@@ -19,10 +15,10 @@
       {% end %}
     </a>
     <div class="elbysodic-application-card__identity">
-      <h3><a class="chirpui-link" href="/characters/{{ item.character.slug }}">{{ item.character.name }}</a></h3>
+      <h3><a href="/characters/{{ item.character.slug }}">{{ item.character.name }}</a></h3>
       <p class="elbysodic-copy-meta">
         writer
-        <a class="chirpui-link" href="/members/{{ item.membership.username }}">{{ item.membership.display_name }}</a>
+        <a href="/members/{{ item.membership.username }}">{{ item.membership.display_name }}</a>
       </p>
     </div>
   </div>
@@ -34,17 +30,24 @@
   </div>
   <div class="elbysodic-application-card__review">
     <div class="elbysodic-application-card__badges">
-      {{ badge(item.status_label, variant=item.status_variant) }}
-      {{ badge("yours", variant="success") if item.is_owned_by_viewer else "" }}
-      {{ badge(item.reserves | length ~ " reserves", variant="info") if item.reserves else "" }}
-      {{ badge(item.claim_conflict_count ~ " claim conflict", variant="warning") if item.claim_conflict_count == 1 else "" }}
-      {{ badge(item.claim_conflict_count ~ " claim conflicts", variant="warning") if item.claim_conflict_count > 1 else "" }}
+      <span class="elbysodic-reader-chip{{ " elbysodic-reader-chip--strong" if item.status_variant in ("warning", "success") else "" }}">{{ item.status_label }}</span>
+      {% if item.is_owned_by_viewer %}
+      <span class="elbysodic-reader-chip elbysodic-reader-chip--strong">yours</span>
+      {% end %}
+      {% if item.reserves %}
+      <span class="elbysodic-reader-chip">{{ item.reserves | length }} reserves</span>
+      {% end %}
+      {% if item.claim_conflict_count == 1 %}
+      <span class="elbysodic-reader-chip elbysodic-reader-chip--strong">1 claim conflict</span>
+      {% elif item.claim_conflict_count > 1 %}
+      <span class="elbysodic-reader-chip elbysodic-reader-chip--strong">{{ item.claim_conflict_count }} claim conflicts</span>
+      {% end %}
     </div>
     {% if item.has_claim_conflicts %}
     <p class="elbysodic-copy-meta">{{ item.claim_conflict_summary }} Open the review room to resolve it.</p>
     {% end %}
     <div class="elbysodic-application-card__actions">
-      <a class="chirpui-btn chirpui-btn--secondary" href="/applications/{{ item.character.slug }}">
+      <a class="elbysodic-btn" href="/applications/{{ item.character.slug }}">
         {{ "Open review room" if desk.can_review else "Open application room" }}
       </a>
       {% if item.is_owned_by_viewer and item.character.application_status == "draft" %}
@@ -53,7 +56,7 @@
         <input type="hidden" name="intent" value="submit_application">
         <input type="hidden" name="character_slug" value="{{ item.character.slug }}">
         <button type="submit"
-                class="chirpui-btn chirpui-btn--primary"
+                class="elbysodic-btn elbysodic-btn--primary"
                 {{ "disabled" if item.has_claim_conflicts else "" }}>
           Submit application
         </button>
@@ -64,7 +67,7 @@
         <input type="hidden" name="intent" value="submit_application">
         <input type="hidden" name="character_slug" value="{{ item.character.slug }}">
         <button type="submit"
-                class="chirpui-btn chirpui-btn--primary"
+                class="elbysodic-btn elbysodic-btn--primary"
                 {{ "disabled" if item.has_claim_conflicts else "" }}>
           Resubmit application
         </button>
@@ -76,12 +79,12 @@
         <input type="hidden" name="intent" value="accept_application">
         <input type="hidden" name="character_slug" value="{{ item.character.slug }}">
         <button type="submit"
-                class="chirpui-btn chirpui-btn--primary"
+                class="elbysodic-btn elbysodic-btn--primary"
                 {{ "disabled" if item.has_claim_conflicts else "" }}>
           Accept
         </button>
       </form>
-      <a class="chirpui-btn chirpui-btn--secondary" href="/applications/{{ item.character.slug }}">
+      <a class="elbysodic-btn" href="/applications/{{ item.character.slug }}">
         Request revisions
       </a>
       {% end %}
@@ -89,32 +92,31 @@
   </div>
 </article>
 {% end %}
-{% end %}
 
 {% block page_root %}
 <div id="page-root">
 {% block page_root_inner %}
 {% block page_content %}
-{% call container(max_width="72rem") %}
-{% call stack(gap="lg") %}
-  {% call section_header("Applications") %}
-  Character drafts, submissions, and review queues for {{ viewer.community.name }}.
-  {% end %}
+<div class="elbysodic-stack elbysodic-stack--lg">
+  <section class="elbysodic-stack elbysodic-stack--sm">
+    <h1>Applications</h1>
+    <p class="elbysodic-copy-lead">
+      Character drafts, submissions, and review queues for {{ viewer.community.name }}.
+    </p>
+  </section>
 
-  {% call surface(variant="elevated") %}
   {% call command_panel("Applications", "Active application work", "Drafts, submissions, and requested revisions stay here. Accepted faces move to the roster and profile pages.", "application-pipeline-heading") %}
     <div class="elbysodic-command-panel__actions">
       {% if desk.application_materials %}
-      <a class="chirpui-btn chirpui-btn--secondary" href="/world/{{ desk.application_materials[0].material.slug }}">Open guide</a>
+      <a class="elbysodic-btn" href="/world/{{ desk.application_materials[0].material.slug }}">Open guide</a>
       {% end %}
-      <a class="chirpui-btn chirpui-btn--primary" href="/applications/new">Start application</a>
+      <a class="elbysodic-btn elbysodic-btn--primary" href="/applications/new">Start application</a>
     </div>
     <div class="elbysodic-command-panel__metrics" aria-label="Application pipeline totals">
       {{ metric_item(active_my_applications | length, "Active drafts") }}
       {{ metric_item(desk.review_queue | length, "Review queue") }}
       {{ metric_item(desk.application_materials | length, "Guide materials") }}
     </div>
-  {% end %}
   {% end %}
 
   {% call page_section("My Applications", "Drafts, submitted faces, and revision requests that still need movement.") %}
@@ -147,24 +149,21 @@
     {% if desk.application_materials %}
     <div class="elbysodic-wanted-grid">
       {% for item in desk.application_materials %}
-      {% call surface(variant="elevated") %}
-      <article class="chirpui-stack chirpui-stack--sm">
-        <div class="chirpui-cluster elbysodic-cluster--between">
-          <h3><a class="chirpui-link" href="/world/{{ item.material.slug }}">{{ item.material.title }}</a></h3>
-          {{ badge(item.type_label, variant="info") }}
+      <article class="elbysodic-stack elbysodic-stack--sm">
+        <div class="elbysodic-cluster elbysodic-cluster--between">
+          <h3><a href="/world/{{ item.material.slug }}">{{ item.material.title }}</a></h3>
+          <span class="elbysodic-reader-chip">{{ item.type_label }}</span>
         </div>
         <p class="elbysodic-copy-summary">{{ item.rendered_summary }}</p>
       </article>
-      {% end %}
       {% end %}
     </div>
     {% else %}
     {{ empty_policy_block("No application guidance has been published yet.", "Directors can publish application materials from Studio when the realm is ready for structured intake.", "Guide missing") }}
     {% end %}
   {% end %}
-{% end %}
-{% end %}
-{% end %}
+</div>
 {% endblock %}
 </div>
+{% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Parent leaf/epic: #349 / #300
- Outcome: The `/applications` desk template no longer imports `chirpui/*` or uses `chirpui-*` classes. List POST still uses hidden `intent` fields. Review room `/applications/{character_slug}` is unchanged.

Closes #349

## Owned paths

- `src/elbysodic/web/pages/applications/page.html`
- `changelog.d/+applications-desk-chirpui-drain.changed.md`

## Decisions frozen (do not reopen in review)

- ADR 0002; epic #300. No new primitive CSS.
- Keep `facet_pills`, `empty_policy_block`, `page_section`, `command_panel`, `metric_item`.
- Keep hidden `intent` fields (`submit_application`, `accept_application`). Do not migrate list POST to `_action` in this leaf.
- Replace container/stack/section_header/surface/badge and `chirpui-btn`/`chirpui-link` with Elbysodic stack, reader chips, and `elbysodic-btn` markup copied from members directory + login.
- Clusters use `elbysodic-cluster` plus `--end`/`--between` only; no `--sm|xs|md|lg`.

## Acceptance run

```bash
rg -n 'chirpui/' src/elbysodic/web/pages/applications/page.html
rg -n 'chirpui-' src/elbysodic/web/pages/applications/page.html
uv run pytest tests/test_forum_slice.py -q -k 'applications_desk or application_review_flags' --tb=short
uv run pytest tests/test_theme_css.py::test_cluster_alignment_modifiers_have_owned_layout_rules tests/test_frontend_surface_contracts.py -q --tb=short
uv run ruff check .
```

- `rg` both empty
- pytest desk/review flags: 2 passed
- pytest theme CSS + surface contracts: 19 passed
- ruff: All checks passed

## Pre-push lint

```bash
uv run ruff check .
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: Rendering And UI Steward (`src/elbysodic/web/AGENTS.md`); Changelog Steward (`changelog.d/AGENTS.md`); Surface Contract Steward (kept required `_components/` imports)
- Accepted / deferred: Accepted Chirp-UI layout drain on the desk template only. Deferred list POST `_action` migration and review-room drain.
- Proof: rg emptiness, forum-slice desk/review-flag tests, `test_frontend_surface_contracts.py`, cluster-alignment CSS test, ruff
- Collateral: `changelog.d/+applications-desk-chirpui-drain.changed.md`

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no
- Orchestrator merges; worker leaves PR open unless `ship` said merge