### PR TITLE
Make writing commands atomic and replay-safe

### DIFF
--- a/changelog.d/+atomic-writing.fixed.md
+++ b/changelog.d/+atomic-writing.fixed.md
@@ -1,0 +1,2 @@
+Posting, post edits, and scene edits now commit their complete workflow
+atomically, including duplicate-submit results and collision-safe scene slugs.

--- a/docs/adr/0004-engineering-audit-corrections.md
+++ b/docs/adr/0004-engineering-audit-corrections.md
@@ -1,0 +1,26 @@
+# ADR 0004: Engineering audit correction contracts
+
+- Status: Accepted
+- Date: 2026-09-05
+- Authorization: User requested correction of all findings in the September 5 engineering audit.
+- Scope: A01–A11 correctness, error handling, composition, query costs, and verification parity.
+
+## Decisions
+
+1. Keep tenant, membership, face, visibility and capability boundaries. Use the existing SQLite transaction mechanism; no schema migration or new runtime dependency is needed.
+2. Application services own atomic post/scene changes and command execution. The authoritative reads, mutation, and command result are committed together. Failed commands roll back; repeated successful tokens return the persisted result. Allocate thread slugs inside the write transaction. Preserve existing public facade methods while extracting a small command helper if useful.
+3. Blueprint apply fingerprints include the live state of all existing objects affected by the packet. Revalidate under the write transaction before writes. Skip-existing never assigns a foreign-owned face as the importing membership's default or wanted author. Correct and execute the canonical example.
+4. Drafts are independent by realm/composer/face, including empty values. Save outgoing state and initialize the incoming face. Associate a submission token with the exact submitted draft snapshot. Successful server redirects carry a `draft_ack` query parameter equal to the existing random idempotency token (edit forms may supply a separate random draft token). Browser acknowledgement removes only that submitted version, retaining newer edits and drafts on failed/network-invalid submissions. Consume the receipt before restore and remove it from the visible URL. This receipt controls local draft cleanup only; it never grants permission or suppresses server validation.
+5. Guard browser storage effects; failures leave composition usable with truthful autosave status. Mention lookup applies only the latest query/cursor generation. Add executable JavaScript regressions; Node is a development/test prerequisite, not a runtime application dependency.
+6. SSE generators own and await all child tasks on normal completion, exception, cancellation and disconnect. Poll authorized incremental message rows, not full room histories; recheck current access and preserve cross-worker delivery. Batch notification/author lookups and retain privacy/read-state behavior under query budgets.
+7. Standard Python 3.14.2 remains supported locally and in production; free-threaded Python is additionally tested in CI. General health smoke validates the expected running interpreter's GIL posture rather than unconditionally requiring free-threading. Explicit free-threaded checks remain available and strict. No production deployment/config change is part of this correction.
+8. One canonical developer check definition supplies CLI/task-runner/Make parity for lint, formatting, types, strict application checks, Kida, hypermedia baseline and client behavior tests; the full gate additionally runs tests and contract diff. Required-stage tests are independent of the producer. Changelog selection excludes configured guidance files while malformed real fragments fail.
+9. Keep framework lifecycle integration behind an adapter, adopt available supported public seams, and test the adapter with a lifecycle canary. Do not guess an unsupported upstream method or silently upgrade dependencies. If the frozen framework lacks a public seam, eliminate avoidable private references, isolate any essential compatibility bridge, document and test it explicitly.
+10. Use focused workflow/read-model extractions while correcting these bugs. No wholesale facade rewrite, new cache infrastructure, feature expansion, or product redesign.
+
+## Proof and collateral
+
+Every leaf includes the relevant fault-injection, concurrency, JavaScript, lifecycle or query-budget regression, plus its affected docs and changelog. Existing route/identity/privacy proofs remain mandatory. Integrated validation runs lint/format/type/template/hypermedia gates, the split coverage suite, process tests on supported runtimes, and focused browser checks for draft submission flows.
+
+Source and tests shared by posting, composer acknowledgement and stream work require explicit carve-outs or integration ordering. Separate leaf branches may be integrated locally for combined validation without authorizing merge or deployment.
+

--- a/docs/architecture/transactional-writing.md
+++ b/docs/architecture/transactional-writing.md
@@ -1,0 +1,42 @@
+# Transactional writing
+
+Writing workflows use the repository's SQLite transaction boundary to keep a
+writer's visible action and its supporting records together.
+
+## Post and scene edits
+
+A post edit reads the authoritative post, checks edit permission, records the
+revision, and changes the body in one transaction. If either write fails, the
+old body remains current and no revision is retained.
+
+A scene edit reads the authoritative thread, checks management permission,
+updates scene metadata, derives required cast members from existing posts, and
+replaces the participant set in one transaction. A failure leaves both the
+metadata and participant set unchanged.
+
+## Posting commands
+
+Start-thread and reply submissions execute through the service command helper.
+The helper begins an immediate transaction, checks for a completed submission,
+reserves a new token, performs the posting workflow, and persists its result
+path before commit. A failure rolls back both the story writes and reservation.
+A repeated completed token returns its persisted result without running the
+posting workflow again. A pending reservation from an older release is
+ambiguous because its story writes may have committed before result
+persistence failed, so it fails closed and asks the writer to reload instead
+of risking a duplicate post. The older `AppServices` command lookup,
+reservation, completion, and discard methods remain available for
+compatibility.
+
+Thread slug selection happens after the write transaction begins. Concurrent
+same-title requests therefore observe earlier committed threads and choose the
+next available suffix under the database write lock.
+
+Successful start and reply result paths include `draft_ack` with the submitted
+idempotency token. Post edits use their separate random `draft_token`. These
+receipts only identify the submitted browser draft for cleanup; authorization
+and validation still run on the server.
+
+Regression proof lives in `tests/test_posting_atomicity.py`. It injects late
+edit and command-result failures, exercises command replay, and starts
+same-title scenes through separate database connections.

--- a/src/elbysodic/services/commands.py
+++ b/src/elbysodic/services/commands.py
@@ -1,0 +1,100 @@
+"""Atomic application-command execution."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class CommandSubmission(Protocol):
+    @property
+    def result_path(self) -> str | None: ...
+
+
+class CommandRepository(Protocol):
+    def transaction(self) -> AbstractContextManager[None]: ...
+
+    def get_command_submission(
+        self,
+        community_id: int,
+        membership_id: int,
+        *,
+        command_key: str,
+        token: str,
+    ) -> CommandSubmission | None: ...
+
+    def reserve_command_submission(
+        self,
+        community_id: int,
+        membership_id: int,
+        *,
+        command_key: str,
+        token: str,
+    ) -> bool: ...
+
+    def complete_command_submission(
+        self,
+        community_id: int,
+        membership_id: int,
+        *,
+        command_key: str,
+        token: str,
+        result_path: str,
+    ) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExecution:
+    result_path: str
+    replayed: bool
+
+
+class PendingCommandError(ValueError):
+    """Raised when an older command reservation has no trustworthy result."""
+
+
+def execute_command(
+    repo: CommandRepository,
+    *,
+    command_key: str,
+    token: str,
+    resolve_scope: Callable[[], tuple[int, int]],
+    operation: Callable[[], str],
+) -> CommandExecution:
+    """Commit one command's mutation and replay result as a single unit."""
+    with repo.transaction():
+        community_id, membership_id = resolve_scope()
+        if token:
+            submission = repo.get_command_submission(
+                community_id,
+                membership_id,
+                command_key=command_key,
+                token=token,
+            )
+            if submission is not None and submission.result_path is not None:
+                return CommandExecution(submission.result_path, replayed=True)
+            if submission is not None:
+                raise PendingCommandError(
+                    "This submission may already have completed, but its result was not "
+                    "recorded. Reload the scene before posting again."
+                )
+            if not repo.reserve_command_submission(
+                community_id,
+                membership_id,
+                command_key=command_key,
+                token=token,
+            ):
+                raise RuntimeError("command token could not be reserved")
+
+        result_path = operation()
+        if token:
+            repo.complete_command_submission(
+                community_id,
+                membership_id,
+                command_key=command_key,
+                token=token,
+                result_path=result_path,
+            )
+    return CommandExecution(result_path, replayed=False)

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -7,6 +7,7 @@ import re
 import secrets
 import sqlite3
 import sys
+from collections.abc import Callable
 from contextlib import AbstractContextManager, suppress
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
@@ -147,6 +148,8 @@ from elbysodic.services.claims import (
     application_template_field_view as _application_template_field_view,
 )
 from elbysodic.services.claims import claims_directory as _claims_directory
+from elbysodic.services.commands import CommandExecution
+from elbysodic.services.commands import execute_command as _execute_command
 from elbysodic.services.discovery import discover_plots as _discover_plots
 from elbysodic.services.exports import CommunityExportManifest
 from elbysodic.services.exports import community_export_manifest as _community_export_manifest
@@ -856,6 +859,25 @@ class AppServices:
             viewer.membership.id,
             command_key=command_key,
             token=token,
+        )
+
+    def execute_command(
+        self,
+        command_key: str,
+        token: str,
+        operation: Callable[[], str],
+    ) -> CommandExecution:
+        def resolve_scope() -> tuple[int, int]:
+            self._invalidate_viewer()
+            current_viewer = self.viewer()
+            return current_viewer.community.id, current_viewer.membership.id
+
+        return _execute_command(
+            self.repo,
+            command_key=command_key,
+            token=token,
+            resolve_scope=resolve_scope,
+            operation=operation,
         )
 
     def recovery_view(self, *, kind: RecoveryKind, slug: str) -> RecoveryView:

--- a/src/elbysodic/services/posting.py
+++ b/src/elbysodic/services/posting.py
@@ -236,20 +236,21 @@ def update_post(
     post_number: int,
     body: str,
 ) -> Post:
-    _board, _thread, post = editable_post(repo, viewer, board_slug, thread_slug, post_number)
-    cleaned = body.strip()
-    if not cleaned:
-        raise ValueError("post body is required")
-    if cleaned == post.body:
-        return post
-    repo.create_post_revision(
-        viewer.community.id,
-        post.id,
-        viewer.membership.id,
-        post.body,
-        cleaned,
-    )
-    return repo.update_post_body(viewer.community.id, post.id, cleaned)
+    with repo.transaction():
+        _board, _thread, post = editable_post(repo, viewer, board_slug, thread_slug, post_number)
+        cleaned = body.strip()
+        if not cleaned:
+            raise ValueError("post body is required")
+        if cleaned == post.body:
+            return post
+        repo.create_post_revision(
+            viewer.community.id,
+            post.id,
+            viewer.membership.id,
+            post.body,
+            cleaned,
+        )
+        return repo.update_post_body(viewer.community.id, post.id, cleaned)
 
 
 def update_thread_scene(
@@ -266,44 +267,47 @@ def update_thread_scene(
     posting_mode: str = "freeform",
     participant_ids: list[int] | None = None,
 ) -> Thread:
-    _board, thread = visible_thread(repo, viewer, board_slug, thread_slug)
-    if not can_manage_scene(viewer, thread):
-        raise PermissionError(f"membership {viewer.membership.id} cannot manage scene {thread.id}")
-    cleaned_status = clean_thread_status(status)
-    cleaned_visibility = None if visibility is None else clean_thread_visibility(visibility)
-    cleaned_posting_mode = clean_posting_mode(posting_mode)
-    repo.update_thread_scene(
-        viewer.community.id,
-        thread.id,
-        status=cleaned_status,
-        visibility=cleaned_visibility,
-        location=location.strip(),
-        timeline=timeline.strip(),
-        summary=summary.strip(),
-        posting_mode=cleaned_posting_mode,
-    )
-    posted_character_ids = {
-        post.author_character_id for post in repo.list_posts(viewer.community.id, thread.id)
-    }
-    required_ids = [thread.author_character_id, *posted_character_ids]
-    taggable_ids = {
-        character.id
-        for character in taggable_characters(
-            repo.list_community_characters(viewer.community.id),
-            viewer.roster,
+    with repo.transaction():
+        _board, thread = visible_thread(repo, viewer, board_slug, thread_slug)
+        if not can_manage_scene(viewer, thread):
+            raise PermissionError(
+                f"membership {viewer.membership.id} cannot manage scene {thread.id}"
+            )
+        cleaned_status = clean_thread_status(status)
+        cleaned_visibility = None if visibility is None else clean_thread_visibility(visibility)
+        cleaned_posting_mode = clean_posting_mode(posting_mode)
+        repo.update_thread_scene(
+            viewer.community.id,
+            thread.id,
+            status=cleaned_status,
+            visibility=cleaned_visibility,
+            location=location.strip(),
+            timeline=timeline.strip(),
+            summary=summary.strip(),
+            posting_mode=cleaned_posting_mode,
         )
-    }
-    tag_ids = [
-        character_id
-        for character_id in clean_participant_ids(participant_ids or [])
-        if character_id in taggable_ids
-    ]
-    repo.set_thread_participants(
-        viewer.community.id,
-        thread.id,
-        clean_participant_ids([*required_ids, *tag_ids]),
-    )
-    return repo.get_thread(viewer.community.id, thread.id)
+        posted_character_ids = {
+            post.author_character_id for post in repo.list_posts(viewer.community.id, thread.id)
+        }
+        required_ids = [thread.author_character_id, *posted_character_ids]
+        taggable_ids = {
+            character.id
+            for character in taggable_characters(
+                repo.list_community_characters(viewer.community.id),
+                viewer.roster,
+            )
+        }
+        tag_ids = [
+            character_id
+            for character_id in clean_participant_ids(participant_ids or [])
+            if character_id in taggable_ids
+        ]
+        repo.set_thread_participants(
+            viewer.community.id,
+            thread.id,
+            clean_participant_ids([*required_ids, *tag_ids]),
+        )
+        return repo.get_thread(viewer.community.id, thread.id)
 
 
 def join_thread_as_current_character(
@@ -408,8 +412,8 @@ def start_thread(
         if participant_id in taggable_ids
     ]
     cleaned_participant_ids = clean_participant_ids([character.id, *tag_ids])
-    slug = unique_thread_slug(repo, viewer.community.id, board.id, cleaned_title)
     with repo.transaction():
+        slug = unique_thread_slug(repo, viewer.community.id, board.id, cleaned_title)
         thread = repo.create_thread(
             viewer.community.id,
             board.id,

--- a/src/elbysodic/web/commands.py
+++ b/src/elbysodic/web/commands.py
@@ -3,7 +3,17 @@
 from __future__ import annotations
 
 import secrets
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 
 def idempotency_key() -> str:
     return secrets.token_urlsafe(24)
+
+
+def draft_ack_path(path: str, token: str) -> str:
+    if not token:
+        return path
+    parts = urlsplit(path)
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    query.append(("draft_ack", token))
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py
@@ -10,7 +10,7 @@ from elbysodic.domain import Character
 from elbysodic.services import Mentionable
 from elbysodic.services.forum import POSTING_MODES, THREAD_STATUSES, THREAD_VISIBILITIES
 from elbysodic.services.threads import taggable_characters
-from elbysodic.web.commands import idempotency_key
+from elbysodic.web.commands import draft_ack_path, idempotency_key
 from elbysodic.web.composer import composer_config, mention_picker_config
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_scoped_path
@@ -22,7 +22,8 @@ def get(request: Request, board_slug: str) -> Page:
 
 async def post(request: Request, board_slug: str) -> Page | Redirect:
     form = await request.form()
-    character_id = _parse_character_id(form.get("character_id"))
+    character_id: int | None = None
+    raw_character_id = form.get("character_id")
     participant_ids = _parse_participant_ids(form)
     title = str(form.get("title") or "")
     status = str(form.get("status") or "active")
@@ -35,28 +36,32 @@ async def post(request: Request, board_slug: str) -> Page | Redirect:
     key = str(form.get("idempotency_key") or "")
     services = get_services(request)
     command_key = f"start-thread:{board_slug}"
-    existing_result = services.command_result(command_key, key)
-    if existing_result is not None:
-        return Redirect(existing_result)
-    if not services.reserve_command(command_key, key):
-        return Redirect(f"/boards/{board_slug}/threads/new")
-
     try:
-        created = services.start_thread_with_post(
-            board_slug=board_slug,
-            character_id=character_id,
-            title=title,
-            body=body,
-            status=status,
-            visibility=visibility,
-            location=location,
-            timeline=timeline,
-            summary=summary,
-            posting_mode=posting_mode,
-            participant_ids=participant_ids,
-        )
+
+        def start() -> str:
+            nonlocal character_id
+            character_id = _parse_character_id(raw_character_id)
+            created = services.start_thread_with_post(
+                board_slug=board_slug,
+                character_id=character_id,
+                title=title,
+                body=body,
+                status=status,
+                visibility=visibility,
+                location=location,
+                timeline=timeline,
+                summary=summary,
+                posting_mode=posting_mode,
+                participant_ids=participant_ids,
+            )
+            result_path = (
+                f"/boards/{board_slug}/threads/{created.thread.slug}"
+                f"#post-{created.post.post_number}"
+            )
+            return draft_ack_path(result_path, key)
+
+        execution = services.execute_command(command_key, key, start)
     except (LookupError, PermissionError, ValueError) as exc:
-        services.discard_command(command_key, key)
         return _render_form(
             request,
             board_slug,
@@ -71,16 +76,9 @@ async def post(request: Request, board_slug: str) -> Page | Redirect:
             summary=summary,
             posting_mode=posting_mode,
             body=body,
+            command_token=key,
         )
-    except Exception:
-        services.discard_command(command_key, key)
-        raise
-
-    result_path = (
-        f"/boards/{board_slug}/threads/{created.thread.slug}#post-{created.post.post_number}"
-    )
-    services.complete_command(command_key, key, result_path)
-    return Redirect(result_path)
+    return Redirect(execution.result_path)
 
 
 def _render_form(
@@ -98,6 +96,7 @@ def _render_form(
     summary: str = "",
     posting_mode: str = "freeform",
     body: str = "",
+    command_token: str | None = None,
 ) -> Page:
     services = get_services(request)
     viewer = services.viewer()
@@ -135,7 +134,7 @@ def _render_form(
             body=body,
             composer_config={},
             composer_config_id="thread-composer-config",
-            idempotency_key=idempotency_key(),
+            idempotency_key=command_token or idempotency_key(),
         )
     selected_character = _select_character(
         viewer.roster,
@@ -191,7 +190,7 @@ def _render_form(
             mention_endpoint=mention_endpoint,
         ),
         composer_config_id=config_id,
-        idempotency_key=idempotency_key(),
+        idempotency_key=command_token or idempotency_key(),
     )
 
 

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py
@@ -10,7 +10,7 @@ from chirp.templating.returns import Page
 from elbysodic.domain import Character
 from elbysodic.services import Mentionable
 from elbysodic.services.forum import POSTING_MODES, THREAD_STATUSES, THREAD_VISIBILITIES
-from elbysodic.web.commands import idempotency_key
+from elbysodic.web.commands import draft_ack_path, idempotency_key
 from elbysodic.web.composer import composer_config, mention_picker_config
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_scoped_path, request_tenant_slug
@@ -107,20 +107,24 @@ async def post(request: Request, board_slug: str, thread_slug: str) -> Page | Re
             return _render_thread(request, board_slug, thread_slug, error=str(exc))
         return Redirect(request.path)
 
-    character_id = _parse_character_id(form.get("character_id"))
+    character_id: int | None = None
+    raw_character_id = form.get("character_id")
     body = str(form.get("body") or "")
     key = str(form.get("idempotency_key") or "")
     command_key = f"reply:{board_slug}:{thread_slug}"
-    existing_result = services.command_result(command_key, key)
-    if existing_result is not None:
-        return Redirect(existing_result)
-    if not services.reserve_command(command_key, key):
-        return Redirect(request.path)
-
     try:
-        post = services.reply_to_thread(board_slug, thread_slug, character_id, body)
+
+        def reply() -> str:
+            nonlocal character_id
+            character_id = _parse_character_id(raw_character_id)
+            created_post = services.reply_to_thread(board_slug, thread_slug, character_id, body)
+            return draft_ack_path(
+                f"{request.path}#post-{created_post.post_number}",
+                key,
+            )
+
+        execution = services.execute_command(command_key, key, reply)
     except (LookupError, PermissionError, ValueError) as exc:
-        services.discard_command(command_key, key)
         return _render_thread(
             request,
             board_slug,
@@ -128,14 +132,9 @@ async def post(request: Request, board_slug: str, thread_slug: str) -> Page | Re
             error=str(exc),
             body=body,
             selected_character_id=character_id,
+            command_token=key,
         )
-    except Exception:
-        services.discard_command(command_key, key)
-        raise
-
-    result_path = f"{request.path}#post-{post.post_number}"
-    services.complete_command(command_key, key, result_path)
-    return Redirect(result_path)
+    return Redirect(execution.result_path)
 
 
 def _render_thread(
@@ -146,6 +145,7 @@ def _render_thread(
     error: str | None = None,
     body: str = "",
     selected_character_id: int | None = None,
+    command_token: str | None = None,
 ) -> Page:
     tenant_slug = request_tenant_slug(request)
     try:
@@ -188,7 +188,7 @@ def _render_thread(
             body=body,
             composer_config={},
             composer_config_id="reply-composer-config",
-            idempotency_key=idempotency_key(),
+            idempotency_key=command_token or idempotency_key(),
             thread_statuses=THREAD_STATUSES,
             thread_visibilities=THREAD_VISIBILITIES,
             posting_modes=POSTING_MODES,
@@ -222,7 +222,7 @@ def _render_thread(
             mention_endpoint=mention_endpoint,
         ),
         composer_config_id=config_id,
-        idempotency_key=idempotency_key(),
+        idempotency_key=command_token or idempotency_key(),
         thread_statuses=THREAD_STATUSES,
         thread_visibilities=THREAD_VISIBILITIES,
         posting_modes=POSTING_MODES,

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.html
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.html
@@ -29,6 +29,7 @@
         x-data="elbysodicComposer('{{ composer_config_id }}')"
         @submit="submitDraft()">
         {{ csrf_field() }}
+    <input type="hidden" name="draft_token" value="{{ draft_receipt }}">
     <div class="elbysodic-composer-heading">
       <div>
         <h2>{{ edit_view.thread.title }}</h2>

--- a/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.py
+++ b/src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.py
@@ -10,6 +10,7 @@ from chirp.http.request import Request
 from chirp.http.response import Redirect
 from chirp.templating.returns import Page
 
+from elbysodic.web.commands import draft_ack_path, idempotency_key
 from elbysodic.web.composer import composer_config
 from elbysodic.web.state import get_services
 from elbysodic.web.tenant import request_scoped_path
@@ -18,6 +19,7 @@ from elbysodic.web.tenant import request_scoped_path
 @dataclass(frozen=True, slots=True)
 class PostEditForm:
     body: str
+    draft_token: str
 
 
 def get(request: Request, board_slug: str, thread_slug: str, post_id: str) -> Page:
@@ -39,6 +41,7 @@ async def post(
     parsed_post_number = _parse_post_number(post_id)
     form = await request.form()
     body = str(form.get("body") or "")
+    draft_token = str(form.get("draft_token") or "")
 
     try:
         post_view = get_services(request).update_post(
@@ -55,13 +58,19 @@ async def post(
             post_id,
             error=str(exc),
             body=body,
+            draft_token=draft_token,
         )
     except LookupError as exc:
         raise HTTPError(status=404, detail=str(exc)) from exc
     except PermissionError as exc:
         raise HTTPError(status=403, detail=str(exc)) from exc
 
-    return Redirect(f"/boards/{board_slug}/threads/{thread_slug}#post-{post_view.post_number}")
+    return Redirect(
+        draft_ack_path(
+            f"/boards/{board_slug}/threads/{thread_slug}#post-{post_view.post_number}",
+            draft_token,
+        )
+    )
 
 
 def _render_form(
@@ -72,6 +81,7 @@ def _render_form(
     *,
     error: str | None = None,
     body: str | None = None,
+    draft_token: str | None = None,
 ) -> Page:
     parsed_post_number = _parse_post_number(post_id)
     services = get_services(request)
@@ -101,6 +111,7 @@ def _render_form(
             mention_endpoint=request_scoped_path(request, "/mentionables/search"),
         ),
         composer_config_id=config_id,
+        draft_receipt=draft_token or idempotency_key(),
     )
 
 

--- a/tests/test_forum_slice.py
+++ b/tests/test_forum_slice.py
@@ -8,7 +8,7 @@ import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
-from urllib.parse import urlencode, urljoin
+from urllib.parse import parse_qs, urlencode, urljoin, urlsplit
 
 import pytest
 from chirp.app import App
@@ -12978,9 +12978,10 @@ def test_start_thread_creates_opening_post_as_selected_character() -> None:
                 headers=_FORM,
             )
             assert response.status == 302
-            assert dict(response.headers)["location"].startswith(
-                "/boards/danger-room/threads/metal-and-memory#post-"
-            )
+            response_location = urlsplit(dict(response.headers)["location"])
+            assert response_location.path == ("/boards/danger-room/threads/metal-and-memory")
+            assert response_location.fragment.startswith("post-")
+            assert parse_qs(response_location.query) == {"draft_ack": [key]}
             assert duplicate.status == 302
             assert dict(duplicate.headers)["location"] == dict(response.headers)["location"]
 
@@ -13060,9 +13061,10 @@ def test_start_thread_validation_error_discards_idempotency_reservation() -> Non
         assert invalid.status == 200
         assert "thread title is required" in invalid.text
         assert corrected.status == 302
-        assert dict(corrected.headers)["location"].startswith(
-            "/boards/danger-room/threads/retryable-scene-command#post-"
-        )
+        corrected_location = urlsplit(dict(corrected.headers)["location"])
+        assert corrected_location.path == ("/boards/danger-room/threads/retryable-scene-command")
+        assert corrected_location.fragment.startswith("post-")
+        assert parse_qs(corrected_location.query) == {"draft_ack": [key]}
         board = services.repo.get_board_by_slug(services.seed.community.id, "danger-room")
         thread = services.repo.get_thread_by_slug(
             services.seed.community.id,

--- a/tests/test_posting_atomicity.py
+++ b/tests/test_posting_atomicity.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import asyncio
+import re
+import sqlite3
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from threading import Barrier
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+import pytest
+from chirp.testing import TestClient
+
+from elbysodic.db import ForumRepository, connect
+from elbysodic.services import AppServices, create_services
+from elbysodic.services.commands import PendingCommandError
+from elbysodic.web import create_app
+from elbysodic.web.commands import draft_ack_path
+
+_FORM = {"Content-Type": "application/x-www-form-urlencoded"}
+
+
+def test_post_edit_rolls_back_revision_when_body_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    services = create_services(path=":memory:")
+    viewer = services.viewer()
+    assert viewer.current_character is not None
+    created = services.start_thread_with_post(
+        board_slug="danger-room",
+        character_id=viewer.current_character.id,
+        title="Revision rollback proof",
+        body="The original post survives.",
+    )
+    before_revisions = services.repo.list_post_revisions(viewer.community.id, created.post.id)
+
+    def fail_body_write(*_args: object, **_kwargs: object) -> object:
+        raise sqlite3.OperationalError("injected body write failure")
+
+    monkeypatch.setattr(services.repo, "update_post_body", fail_body_write)
+    with pytest.raises(sqlite3.OperationalError, match="injected body write failure"):
+        services.update_post(
+            "danger-room",
+            created.thread.slug,
+            created.post.post_number,
+            "A changed post that must roll back.",
+        )
+
+    persisted = services.repo.get_post(viewer.community.id, created.post.id)
+    after_revisions = services.repo.list_post_revisions(viewer.community.id, created.post.id)
+    assert persisted.body == "The original post survives."
+    assert after_revisions == before_revisions
+
+
+def test_scene_edit_rolls_back_metadata_when_participant_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    services = create_services(path=":memory:")
+    viewer = services.viewer()
+    assert viewer.current_character is not None
+    created = services.start_thread_with_post(
+        board_slug="danger-room",
+        character_id=viewer.current_character.id,
+        title="Scene rollback proof",
+        body="The scene begins unchanged.",
+    )
+    before = services.repo.get_thread(viewer.community.id, created.thread.id)
+
+    def fail_participants(*_args: object, **_kwargs: object) -> object:
+        raise sqlite3.OperationalError("injected participant write failure")
+
+    monkeypatch.setattr(services.repo, "set_thread_participants", fail_participants)
+    with pytest.raises(sqlite3.OperationalError, match="injected participant write failure"):
+        services.update_thread_scene(
+            "danger-room",
+            created.thread.slug,
+            status="archived",
+            location="Changed location",
+            timeline="Changed timeline",
+            summary="Changed summary",
+        )
+
+    after = services.repo.get_thread(viewer.community.id, created.thread.id)
+    assert (
+        after.status,
+        after.location,
+        after.timeline,
+        after.summary,
+    ) == (
+        before.status,
+        before.location,
+        before.timeline,
+        before.summary,
+    )
+
+
+def test_command_completion_failure_rolls_back_post_and_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    services = create_services(path=":memory:")
+    viewer = services.viewer()
+    assert viewer.current_character is not None
+    character_id = viewer.current_character.id
+    board = services.repo.get_board_by_slug(viewer.community.id, "danger-room")
+    thread = services.repo.get_thread_by_slug(viewer.community.id, board.id, "sentinel-drill")
+    before_posts = services.repo.list_posts(viewer.community.id, thread.id)
+    command_key = "reply:danger-room:sentinel-drill"
+    submission_id = "atomic-command-token"
+    result_path = draft_ack_path(
+        f"/boards/danger-room/threads/sentinel-drill#post-{len(before_posts) + 1}",
+        submission_id,
+    )
+
+    def operation() -> str:
+        services.reply_to_thread(
+            "danger-room",
+            "sentinel-drill",
+            character_id,
+            "The command result commits with this reply.",
+        )
+        return result_path
+
+    original_complete = services.repo.complete_command_submission
+
+    def fail_completion(*_args: object, **_kwargs: object) -> None:
+        raise sqlite3.OperationalError("injected command completion failure")
+
+    monkeypatch.setattr(services.repo, "complete_command_submission", fail_completion)
+    with pytest.raises(sqlite3.OperationalError, match="injected command completion failure"):
+        services.execute_command(command_key, submission_id, operation)
+
+    assert services.repo.list_posts(viewer.community.id, thread.id) == before_posts
+    assert services.command_result(command_key, submission_id) is None
+
+    monkeypatch.setattr(
+        services.repo,
+        "complete_command_submission",
+        original_complete,
+    )
+    first = services.execute_command(command_key, submission_id, operation)
+    replay = services.execute_command(
+        command_key,
+        submission_id,
+        lambda: pytest.fail("a completed command must not execute again"),
+    )
+
+    assert first.replayed is False
+    assert replay.replayed is True
+    assert replay.result_path == first.result_path == result_path
+    assert len(services.repo.list_posts(viewer.community.id, thread.id)) == len(before_posts) + 1
+
+
+def test_legacy_pending_command_fails_closed_without_reposting() -> None:
+    services = create_services(path=":memory:")
+    viewer = services.viewer()
+    assert viewer.current_character is not None
+    board = services.repo.get_board_by_slug(viewer.community.id, "danger-room")
+    thread = services.repo.get_thread_by_slug(viewer.community.id, board.id, "sentinel-drill")
+    command_key = "reply:danger-room:sentinel-drill"
+    submission_id = "legacy-ambiguous-command"
+
+    assert services.reserve_command(command_key, submission_id)
+    committed_post = services.reply_to_thread(
+        "danger-room",
+        "sentinel-drill",
+        viewer.current_character.id,
+        "This post committed before the old command result write failed.",
+    )
+
+    invoked = False
+
+    def duplicate_operation() -> str:
+        nonlocal invoked
+        invoked = True
+        return "/must-not-run"
+
+    with pytest.raises(PendingCommandError, match="may already have completed"):
+        services.execute_command(command_key, submission_id, duplicate_operation)
+
+    assert invoked is False
+    assert services.command_result(command_key, submission_id) is None
+    posts = services.repo.list_posts(viewer.community.id, thread.id)
+    assert [post.id for post in posts].count(committed_post.id) == 1
+    assert posts[-1].body == ("This post committed before the old command result write failed.")
+
+
+def test_reply_command_revalidates_membership_inside_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_services = create_services(path=":memory:")
+    services = root_services.for_request(object())
+    viewer = services.viewer()
+    assert viewer.current_character is not None
+    character_id = viewer.current_character.id
+    repo = services.repo
+    board = repo.get_board_by_slug(viewer.community.id, "danger-room")
+    thread = repo.get_thread_by_slug(viewer.community.id, board.id, "sentinel-drill")
+    before_posts = repo.list_posts(viewer.community.id, thread.id)
+    submission_id = "revoked-reply"
+    original_transaction = repo.transaction
+    revoked = False
+
+    @contextmanager
+    def transaction_after_revocation() -> Iterator[None]:
+        nonlocal revoked
+        if not revoked:
+            repo.connection.execute(
+                "UPDATE community_memberships SET is_active = 0 WHERE id = ?",
+                (viewer.membership.id,),
+            )
+            repo.connection.commit()
+            revoked = True
+        with original_transaction():
+            yield
+
+    monkeypatch.setattr(repo, "transaction", transaction_after_revocation)
+
+    def reply() -> str:
+        post = services.reply_to_thread(
+            "danger-room",
+            "sentinel-drill",
+            character_id,
+            "A revoked writer must not add this reply.",
+        )
+        return f"/boards/danger-room/threads/sentinel-drill#post-{post.post_number}"
+
+    with pytest.raises(PermissionError, match=r"membership .* is not active"):
+        services.execute_command("reply:danger-room:sentinel-drill", submission_id, reply)
+
+    assert repo.list_posts(viewer.community.id, thread.id) == before_posts
+    assert (
+        repo.get_command_submission(
+            viewer.community.id,
+            viewer.membership.id,
+            command_key="reply:danger-room:sentinel-drill",
+            token=submission_id,
+        )
+        is None
+    )
+
+
+def test_start_command_revalidates_membership_inside_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_services = create_services(path=":memory:")
+    services = root_services.for_request(object())
+    viewer = services.viewer()
+    assert viewer.current_character is not None
+    character_id = viewer.current_character.id
+    repo = services.repo
+    board = repo.get_board_by_slug(viewer.community.id, "danger-room")
+    before_thread_ids = {thread.id for thread in repo.list_threads(viewer.community.id, board.id)}
+    submission_id = "revoked-start"
+    original_transaction = repo.transaction
+    revoked = False
+
+    @contextmanager
+    def transaction_after_revocation() -> Iterator[None]:
+        nonlocal revoked
+        if not revoked:
+            repo.connection.execute(
+                "UPDATE community_memberships SET is_active = 0 WHERE id = ?",
+                (viewer.membership.id,),
+            )
+            repo.connection.commit()
+            revoked = True
+        with original_transaction():
+            yield
+
+    monkeypatch.setattr(repo, "transaction", transaction_after_revocation)
+
+    def start() -> str:
+        thread = services.start_thread(
+            board_slug="danger-room",
+            character_id=character_id,
+            title="Revoked transaction scene",
+            body="A revoked writer must not open this scene.",
+        )
+        return f"/boards/danger-room/threads/{thread.slug}"
+
+    with pytest.raises(PermissionError, match=r"membership .* is not active"):
+        services.execute_command("start-thread:danger-room", submission_id, start)
+
+    assert {
+        thread.id for thread in repo.list_threads(viewer.community.id, board.id)
+    } == before_thread_ids
+    assert (
+        repo.get_command_submission(
+            viewer.community.id,
+            viewer.membership.id,
+            command_key="start-thread:danger-room",
+            token=submission_id,
+        )
+        is None
+    )
+
+
+def test_concurrent_same_title_threads_receive_distinct_slugs(tmp_path) -> None:
+    database_path = tmp_path / "atomic-slugs.sqlite3"
+    seeded = create_services(path=database_path)
+    viewer = seeded.viewer()
+    assert viewer.current_character is not None
+    seed = seeded.seed
+    character_id = viewer.current_character.id
+    seeded.close()
+
+    services = [
+        AppServices(
+            ForumRepository(connect(database_path, check_same_thread=False)),
+            seed,
+        )
+        for _ in range(2)
+    ]
+    barrier = Barrier(2)
+
+    def create_scene(service: AppServices, body: str) -> str:
+        barrier.wait()
+        return service.start_thread(
+            board_slug="danger-room",
+            character_id=character_id,
+            title="Simultaneous Arrival",
+            body=body,
+        ).slug
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(create_scene, service, f"Opening from writer {index}.")
+                for index, service in enumerate(services, start=1)
+            ]
+            slugs = {future.result(timeout=10) for future in futures}
+    finally:
+        for service in services:
+            service.close()
+
+    assert slugs == {"simultaneous-arrival", "simultaneous-arrival-2"}
+
+
+def test_success_redirects_carry_the_submitted_draft_receipt() -> None:
+    async def run() -> None:
+        services = create_services(path=":memory:")
+        viewer = services.viewer()
+        assert viewer.current_character is not None
+        character_id = viewer.current_character.id
+        app = create_app(debug=False, services=services)
+
+        async with TestClient(app) as client:
+            new_form = await client.get("/boards/danger-room/threads/new")
+            command_token = _input_value(new_form.text, "idempotency_key")
+            created = await client.post(
+                "/boards/danger-room/threads/new",
+                body=urlencode(
+                    {
+                        "character_id": character_id,
+                        "title": "Draft receipt proof",
+                        "body": "An opening tied to its submitted draft.",
+                        "idempotency_key": command_token,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            created_location = _header(created, "location")
+            created_parts = urlsplit(created_location)
+            assert created_parts.path.endswith("/threads/draft-receipt-proof")
+            assert created_parts.fragment == "post-1"
+            assert parse_qs(created_parts.query) == {"draft_ack": [command_token]}
+
+            duplicate = await client.post(
+                "/boards/danger-room/threads/new",
+                body=urlencode(
+                    {
+                        "character_id": "not-an-integer",
+                        "idempotency_key": command_token,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            assert _header(duplicate, "location") == created_location
+
+            reply_form = await client.get(created_parts.path)
+            reply_token = _input_value(reply_form.text, "idempotency_key")
+            replied = await client.post(
+                created_parts.path,
+                body=urlencode(
+                    {
+                        "character_id": character_id,
+                        "body": "A reply with a replayable result.",
+                        "idempotency_key": reply_token,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            malformed_reply = await client.post(
+                created_parts.path,
+                body=urlencode(
+                    {
+                        "character_id": "not-an-integer",
+                        "idempotency_key": reply_token,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            assert _header(malformed_reply, "location") == _header(replied, "location")
+            created_thread = services.repo.get_thread_by_slug(
+                viewer.community.id,
+                services.repo.get_board_by_slug(viewer.community.id, "danger-room").id,
+                "draft-receipt-proof",
+            )
+            assert len(services.repo.list_posts(viewer.community.id, created_thread.id)) == 2
+
+            edit_path = "/boards/danger-room/threads/draft-receipt-proof/posts/1/edit"
+            first_edit_form = await client.get(edit_path)
+            second_edit_form = await client.get(edit_path)
+            draft_receipt = _input_value(first_edit_form.text, "draft_token")
+            assert draft_receipt
+            assert _input_value(second_edit_form.text, "draft_token") != draft_receipt
+
+            invalid_edit = await client.post(
+                edit_path,
+                body=urlencode({"body": "", "draft_token": draft_receipt}).encode(),
+                headers=_FORM,
+            )
+            assert invalid_edit.status == 200
+            assert _input_value(invalid_edit.text, "draft_token") == draft_receipt
+
+            edited = await client.post(
+                edit_path,
+                body=urlencode(
+                    {
+                        "body": "The opening is edited atomically.",
+                        "draft_token": draft_receipt,
+                    }
+                ).encode(),
+                headers=_FORM,
+            )
+            edited_parts = urlsplit(_header(edited, "location"))
+            assert edited_parts.path.endswith("/threads/draft-receipt-proof")
+            assert edited_parts.fragment == "post-1"
+            assert parse_qs(edited_parts.query) == {"draft_ack": [draft_receipt]}
+
+    asyncio.run(run())
+
+
+def _input_value(html: str, name: str) -> str:
+    match = re.search(
+        rf'<input[^>]+name="{re.escape(name)}"[^>]+value="(?P<value>[^"]*)"',
+        html,
+    )
+    assert match is not None
+    return match.group("value")
+
+
+def _header(response: Any, name: str) -> str:
+    headers = response.headers
+    if isinstance(headers, dict):
+        return str(headers[name])
+    for key, value in headers:
+        if str(key).lower() == name.lower():
+            return str(value)
+    raise AssertionError(f"response header not found: {name}")


### PR DESCRIPTION
Draft for immediate review. Focused checks pass; final integrated validation is still being completed. The original local commit history is preserved; this review branch uses an identical code tree with GitHub noreply authorship.

## Summary

- Parent leaf/epic: #354 / #353
- Outcome: Posting commands, post edits, and scene edits now commit their mutations and supporting records atomically. Completed command tokens replay their persisted redirect, ambiguous legacy reservations fail closed, same-title scenes allocate distinct slugs inside the write transaction, and successful composer submissions carry the exact submitted draft receipt for version-safe browser cleanup.

## Owned paths

- `src/elbysodic/services/posting.py`
- `src/elbysodic/services/commands.py`
- `src/elbysodic/services/forum.py` (posting and command methods/imports)
- `src/elbysodic/web/commands.py`
- `src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py`
- `src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py`
- `src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.py`
- `src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.html` (draft receipt context alias)
- `tests/test_posting_atomicity.py`
- `tests/test_forum_slice.py` (successful redirect assertions only)
- `docs/architecture/transactional-writing.md`
- `changelog.d/+atomic-writing.fixed.md`

## Decisions frozen (do not reopen in review)

- ADR 0004 keeps the existing tenant, membership, face, visibility, capability, schema, dependency, and SQLite transaction contracts.
- The command reservation, story mutation, and persisted result share one transaction. Failed new commands roll back so a retry is safe; an older pending reservation without a result is ambiguous and must fail closed rather than repeat a possibly committed post.
- Command scope and posting authorization are reloaded after the transaction begins. Completed-token replay is checked before validating mutable composer payload fields.
- `draft_ack` is a browser-cleanup receipt only. Start/reply reuse the submitted idempotency key; edit uses a separate random `draft_token`. The rendered edit context is named `draft_receipt` to satisfy strict privacy analysis while the submitted field remains `draft_token`.

## Acceptance run

```bash
PYTHONPATH=src /tmp/elbysodic-audit-stable/bin/python -m pytest tests/test_posting_atomicity.py tests/test_backend_contracts.py -q --tb=short
# 28 passed

PYTHONPATH=src /tmp/elbysodic-audit-stable/bin/python -c "from elbysodic.web import create_app; create_app(debug=False, db_path=':memory:').check(warnings_as_errors=True)"
# All clear: 56 routes, 315 templates

/tmp/elbysodic-audit-stable/bin/ty check --python /tmp/elbysodic-audit-stable/bin/python src/elbysodic/services/commands.py src/elbysodic/services/forum.py 'src/elbysodic/web/pages/boards/{board_slug}/threads/new/page.py' 'src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/page.py' 'src/elbysodic/web/pages/boards/{board_slug}/threads/{thread_slug}/posts/{post_id}/edit/page.py' tests/test_posting_atomicity.py
# All checks passed
```

Regression coverage includes late revision/body failures, late scene participant failures, command result persistence failure, completed replay, legacy ambiguous reservation recovery, transaction-entry membership revocation for start and reply, malformed replay payloads, concurrent slug allocation through separate database connections, redirect/anchor equality, and edit receipt generation, validation retention, and acknowledgement.

## Pre-push lint

```bash
/tmp/elbysodic-audit-stable/bin/ruff check .
# All checks passed
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: service, web, test, docs, and composer contracts; coordinated the shared edit template/JavaScript field contract with the composer leaf.
- Accepted / deferred: accepted fresh in-transaction authorization, fail-closed legacy reservations, validation-after-replay, and a privacy-safe edit receipt context alias. No audit findings in this leaf were deferred.
- Proof: `tests/test_posting_atomicity.py`, preserved scoped route/post-anchor/replay assertions in `tests/test_forum_slice.py`, and strict Chirp application validation with warnings as errors.
- Collateral: `docs/architecture/transactional-writing.md` and `changelog.d/+atomic-writing.fixed.md` describe the committed behavior and recovery posture.

## Notes

- Field-guide update? — no; no new reusable surprise beyond the regression and architecture contract.
- New ADR needed? — no; `docs/adr/0004-engineering-audit-corrections.md` freezes the decision.
- Commits: `bf0aa34`, `9f25636`, `9a6e5af`, `a0b1599`.
- Orchestrator merges; worker leaves the PR open.
