### PR TITLE
Bound stream and inbox reads and close lifecycle leaks

### DIFF
--- a/changelog.d/+bounded-stream-reads.fixed.md
+++ b/changelog.d/+bounded-stream-reads.fixed.md
@@ -1,0 +1,1 @@
+Plotting-room streams now close cleanly, find messages written by every worker without rereading full histories, and render notification inboxes with bounded author lookups.

--- a/docs/adr/0004-engineering-audit-corrections.md
+++ b/docs/adr/0004-engineering-audit-corrections.md
@@ -1,0 +1,26 @@
+# ADR 0004: Engineering audit correction contracts
+
+- Status: Accepted
+- Date: 2026-09-05
+- Authorization: User requested correction of all findings in the September 5 engineering audit.
+- Scope: A01–A11 correctness, error handling, composition, query costs, and verification parity.
+
+## Decisions
+
+1. Keep tenant, membership, face, visibility and capability boundaries. Use the existing SQLite transaction mechanism; no schema migration or new runtime dependency is needed.
+2. Application services own atomic post/scene changes and command execution. The authoritative reads, mutation, and command result are committed together. Failed commands roll back; repeated successful tokens return the persisted result. Allocate thread slugs inside the write transaction. Preserve existing public facade methods while extracting a small command helper if useful.
+3. Blueprint apply fingerprints include the live state of all existing objects affected by the packet. Revalidate under the write transaction before writes. Skip-existing never assigns a foreign-owned face as the importing membership's default or wanted author. Correct and execute the canonical example.
+4. Drafts are independent by realm/composer/face, including empty values. Save outgoing state and initialize the incoming face. Associate a submission token with the exact submitted draft snapshot. Successful server redirects carry a `draft_ack` query parameter equal to the existing random idempotency token (edit forms may supply a separate random draft token). Browser acknowledgement removes only that submitted version, retaining newer edits and drafts on failed/network-invalid submissions. Consume the receipt before restore and remove it from the visible URL. This receipt controls local draft cleanup only; it never grants permission or suppresses server validation.
+5. Guard browser storage effects; failures leave composition usable with truthful autosave status. Mention lookup applies only the latest query/cursor generation. Add executable JavaScript regressions; Node is a development/test prerequisite, not a runtime application dependency.
+6. SSE generators own and await all child tasks on normal completion, exception, cancellation and disconnect. Poll authorized incremental message rows, not full room histories; recheck current access and preserve cross-worker delivery. Batch notification/author lookups and retain privacy/read-state behavior under query budgets.
+7. Standard Python 3.14.2 remains supported locally and in production; free-threaded Python is additionally tested in CI. General health smoke validates the expected running interpreter's GIL posture rather than unconditionally requiring free-threading. Explicit free-threaded checks remain available and strict. No production deployment/config change is part of this correction.
+8. One canonical developer check definition supplies CLI/task-runner/Make parity for lint, formatting, types, strict application checks, Kida, hypermedia baseline and client behavior tests; the full gate additionally runs tests and contract diff. Required-stage tests are independent of the producer. Changelog selection excludes configured guidance files while malformed real fragments fail.
+9. Keep framework lifecycle integration behind an adapter, adopt available supported public seams, and test the adapter with a lifecycle canary. Do not guess an unsupported upstream method or silently upgrade dependencies. If the frozen framework lacks a public seam, eliminate avoidable private references, isolate any essential compatibility bridge, document and test it explicitly.
+10. Use focused workflow/read-model extractions while correcting these bugs. No wholesale facade rewrite, new cache infrastructure, feature expansion, or product redesign.
+
+## Proof and collateral
+
+Every leaf includes the relevant fault-injection, concurrency, JavaScript, lifecycle or query-budget regression, plus its affected docs and changelog. Existing route/identity/privacy proofs remain mandatory. Integrated validation runs lint/format/type/template/hypermedia gates, the split coverage suite, process tests on supported runtimes, and focused browser checks for draft submission flows.
+
+Source and tests shared by posting, composer acknowledgement and stream work require explicit carve-outs or integration ordering. Separate leaf branches may be integrated locally for combined validation without authorizing merge or deployment.
+

--- a/docs/architecture/stream-read-contracts.md
+++ b/docs/architecture/stream-read-contracts.md
@@ -1,0 +1,39 @@
+# Stream read contracts
+
+Plotting-room streams combine a process-local queue with an authorized database
+poll. The queue gives same-worker writes low latency. The database cursor is the
+cross-worker source of truth: each poll selects messages after the last database
+message id, then batches the author and membership context for only those rows.
+A local queue event does not advance that cursor, so an earlier row written by
+another worker cannot be skipped.
+
+Every poll reloads the membership, role, room, and participant list. An inactive
+membership or a writer who is no longer a participant loses access before new
+messages are returned. The initial room render remains capped at 100 messages;
+later polls have a fixed query cost independent of that history.
+
+The stream generator owns its queue, drain, and timer tasks. Each loop cancels
+and awaits all three tasks in a `finally` block, including when the client
+disconnects or cancels the generator. During worker drain, queued local events
+are flushed, the database is checked once more, and the stream closes.
+
+Notification inbox rendering builds one context for the visible batch. Posts
+are selected by notification target id, authors and memberships are selected by
+id, and the realm mention roster is loaded once. Unrelated history in a notified
+scene is not loaded. Each item keeps the existing target visibility checks and
+unread behavior while reusing that context for snippets.
+
+## Chirp and Pounce lifecycle compatibility
+
+Chirp 0.10 exposes public `freeze` and ASGI application seams. Its public `run`
+method always serves the Chirp application itself, so it cannot launch the
+draining-aware ASGI wrapper required by Pounce 0.9. The compatibility bridge is
+isolated in `pounce_railway.run_chirp_asgi_adapter`: it freezes through the public
+method, then uses Chirp's private `_server` launcher to serve the wrapper. A
+pre-0.10 `_ensure_frozen` fallback remains solely for the existing lifecycle
+canary.
+
+The adapter test verifies that public freeze happens first and that the wrapper,
+host, port, and lifecycle collector reach the launcher. Re-evaluate and remove
+the private launcher bridge whenever Chirp changes version or adds a supported
+wrapped-application startup API.

--- a/src/elbysodic/db/repositories/posts.py
+++ b/src/elbysodic/db/repositories/posts.py
@@ -222,6 +222,35 @@ class PostRepositoryMixin(ClaimRepositoryMixin):
             )
         return _post_from_row(row)
 
+    def list_posts_by_ids(
+        self,
+        community_id: int,
+        post_ids: list[int],
+    ) -> dict[int, Post]:
+        if not post_ids:
+            return {}
+        rows = self.connection.execute(
+            """
+            SELECT
+                id,
+                community_id,
+                thread_id,
+                post_number,
+                author_membership_id,
+                author_character_id,
+                body,
+                created_at,
+                updated_at
+            FROM posts
+            WHERE community_id = ?
+              AND id IN (SELECT value FROM json_each(?))
+            ORDER BY id
+            """,
+            (community_id, json.dumps(post_ids)),
+        ).fetchall()
+        posts = [_post_from_row(row) for row in rows]
+        return {post.id: post for post in posts}
+
     def list_posts(self, community_id: int, thread_id: int) -> list[Post]:
         rows = self.connection.execute(
             """

--- a/src/elbysodic/services/forum.py
+++ b/src/elbysodic/services/forum.py
@@ -230,6 +230,9 @@ from elbysodic.services.plotting import (
 )
 from elbysodic.services.plotting import plotting_desk as _plotting_desk
 from elbysodic.services.plotting import read_plotting_room as _read_plotting_room
+from elbysodic.services.plotting import (
+    read_plotting_room_messages as _read_plotting_room_messages,
+)
 from elbysodic.services.plotting import subscribe_plotting_room_live, unsubscribe_plotting_room_live
 from elbysodic.services.plotting import update_plotting_room_plan as _update_plotting_room_plan
 from elbysodic.services.posting import join_thread_as_current_character as _join_thread
@@ -297,6 +300,7 @@ from elbysodic.services.read_models import (
     PlotDiscovery,
     PlottingDesk,
     PlottingRoomDetail,
+    PlottingRoomMessageBatch,
     PostRevisionHistory,
     PostStylePolicy,
     PublicCatalogCard,
@@ -3524,6 +3528,21 @@ class AppServices:
 
     def read_plotting_room(self, room_id: int) -> PlottingRoomDetail:
         return _read_plotting_room(self.repo, self.viewer(), room_id)
+
+    def read_plotting_room_messages(
+        self,
+        room_id: int,
+        *,
+        after_id: int | None,
+        limit: int = 100,
+    ) -> PlottingRoomMessageBatch:
+        return _read_plotting_room_messages(
+            self.repo,
+            self.viewer(),
+            room_id,
+            after_id=after_id,
+            limit=limit,
+        )
 
     def update_plotting_room_plan(
         self,

--- a/src/elbysodic/services/notifications.py
+++ b/src/elbysodic/services/notifications.py
@@ -21,7 +21,12 @@ from elbysodic.domain.models import (
     WantedAdInterest,
 )
 from elbysodic.services import policies
-from elbysodic.services.posts import PostViewRepository, post_view
+from elbysodic.services.posts import (
+    PostViewContext,
+    PostViewRepository,
+    build_post_view_context,
+    post_view,
+)
 from elbysodic.services.read_models import ForumView, NotificationInbox, NotificationItem
 from elbysodic.services.timestamps import timestamp_label
 
@@ -35,6 +40,14 @@ class NotificationTargetContract:
     visibility_rule: str
     redirect_behavior: str
     fallback_behavior: str
+
+
+@dataclass(frozen=True, slots=True)
+class NotificationReadContext:
+    actor_memberships: dict[int, CommunityMembership]
+    actors: dict[int, Character]
+    posts: dict[int, Post]
+    post_view_context: PostViewContext | None
 
 
 NOTIFICATION_TARGET_CONTRACTS: tuple[NotificationTargetContract, ...] = (
@@ -167,6 +180,12 @@ class NotificationRepository(PostViewRepository, Protocol):
 
     def get_post(self, community_id: int, post_id: int) -> Post: ...
 
+    def list_posts_by_ids(
+        self,
+        community_id: int,
+        post_ids: list[int],
+    ) -> dict[int, Post]: ...
+
     def get_wanted_ad(self, community_id: int, wanted_ad_id: int) -> WantedAd: ...
 
     def get_wanted_ad_interest(
@@ -257,9 +276,10 @@ def notification_inbox(
         viewer.role,
         limit=limit,
     )
+    context = _notification_read_context(repo, viewer, visible_notifications)
     items: list[NotificationItem] = []
     for notification in visible_notifications:
-        item = notification_item(repo, viewer, notification)
+        item = notification_item(repo, viewer, notification, context=context)
         if item is not None:
             items.append(item)
     return NotificationInbox(
@@ -478,17 +498,17 @@ def notification_item(
     repo: NotificationRepository,
     viewer: ForumView,
     notification: Notification,
+    *,
+    context: NotificationReadContext | None = None,
 ) -> NotificationItem | None:
     if notification_target_contract(
         notification.kind
     ) is None or not notification_has_required_target(notification):
         return None
-    actor_membership = repo.get_membership(
-        viewer.community.id,
-        notification.actor_membership_id,
-    )
+    context = context or _notification_read_context(repo, viewer, [notification])
+    actor_membership = context.actor_memberships[notification.actor_membership_id]
     actor = (
-        repo.get_character(viewer.community.id, notification.actor_character_id)
+        context.actors[notification.actor_character_id]
         if notification.actor_character_id is not None
         else None
     )
@@ -630,8 +650,13 @@ def notification_item(
     board = repo.get_board(viewer.community.id, thread.board_id)
     if not policies.can_view_board(viewer.membership, board, viewer.role):
         return None
-    post = repo.get_post(viewer.community.id, notification.post_id)
-    rendered_post = post_view(repo, viewer.community.id, post)
+    post = context.posts[notification.post_id]
+    rendered_post = post_view(
+        repo,
+        viewer.community.id,
+        post,
+        context=context.post_view_context,
+    )
     return NotificationItem(
         notification=notification,
         board=board,
@@ -647,6 +672,46 @@ def notification_item(
         created_at_label=rendered_post.created_at_label,
         snippet=rendered_post.snippet,
         href=f"/boards/{board.slug}/threads/{thread.slug}#{rendered_post.anchor}",
+    )
+
+
+def _notification_read_context(
+    repo: NotificationRepository,
+    viewer: ForumView,
+    notifications: list[Notification],
+) -> NotificationReadContext:
+    community_id = viewer.community.id
+    actor_membership_ids = {item.actor_membership_id for item in notifications}
+    actor_character_ids = {
+        item.actor_character_id for item in notifications if item.actor_character_id is not None
+    }
+    post_ids = {item.post_id for item in notifications if item.post_id is not None}
+    posts = repo.list_posts_by_ids(community_id, sorted(post_ids))
+    if posts:
+        post_view_context = build_post_view_context(
+            repo,
+            community_id,
+            list(posts.values()),
+            extra_character_ids=actor_character_ids,
+            extra_membership_ids=actor_membership_ids,
+        )
+        actor_memberships = post_view_context.memberships
+        actors = post_view_context.authors
+    else:
+        post_view_context = None
+        actor_memberships = repo.list_memberships_by_ids(
+            community_id,
+            sorted(actor_membership_ids),
+        )
+        actors = repo.list_characters_by_ids(
+            community_id,
+            sorted(actor_character_ids),
+        )
+    return NotificationReadContext(
+        actor_memberships=actor_memberships,
+        actors=actors,
+        posts=posts,
+        post_view_context=post_view_context,
     )
 
 

--- a/src/elbysodic/services/plotting.py
+++ b/src/elbysodic/services/plotting.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Protocol
 
 from elbysodic.domain.models import (
@@ -17,6 +17,7 @@ from elbysodic.domain.models import (
     PlottingRoom,
     PlottingRoomMessage,
     PlottingRoomParticipant,
+    Role,
     Thread,
     WantedAd,
     WantedAdInterest,
@@ -42,6 +43,7 @@ from elbysodic.services.read_models import (
     PlotHookInterestInboxItem,
     PlottingDesk,
     PlottingRoomDetail,
+    PlottingRoomMessageBatch,
     PlottingRoomMessageView,
     PlottingRoomParticipantView,
     PlottingRoomSummary,
@@ -82,6 +84,8 @@ class PlottingRepository(
         community_id: int,
         membership_id: int,
     ) -> CommunityMembership: ...
+
+    def get_role(self, community_id: int, role_id: int) -> Role: ...
 
     def get_material(self, community_id: int, material_id: int) -> Material: ...
 
@@ -430,18 +434,60 @@ def read_plotting_room(
             if policies.can_start_thread(viewer.membership, board, viewer.role)
         ],
         scene_character_options=_scene_character_options(viewer, participants),
-        messages=[
-            plotting_room_message_view(repo, viewer.community.id, message)
-            for message in repo.list_plotting_room_messages(
+        messages=plotting_room_message_views(
+            repo,
+            viewer.community.id,
+            repo.list_plotting_room_messages(
                 viewer.community.id,
                 room.id,
                 limit=100,
-            )
-        ],
+            ),
+        ),
         created_at_label=timestamp_label(room.created_at),
         can_manage=can_create_scene,
         can_edit_plan=can_edit_plan,
         can_create_scene=can_create_scene and room.target_thread_id is None,
+    )
+
+
+def read_plotting_room_messages(
+    repo: PlottingRepository,
+    viewer: ForumView,
+    room_id: int,
+    *,
+    after_id: int | None,
+    limit: int = 100,
+) -> PlottingRoomMessageBatch:
+    membership = repo.get_membership(viewer.community.id, viewer.membership.id)
+    role = repo.get_role(viewer.community.id, membership.role_id)
+    if not membership.is_active:
+        raise PermissionError(f"membership {membership.id} cannot view room {room_id}")
+    current_viewer = replace(viewer, membership=membership, role=role)
+    room = repo.get_plotting_room(current_viewer.community.id, room_id)
+    participants = repo.list_plotting_room_participants(
+        current_viewer.community.id,
+        room.id,
+    )
+    participant_membership_ids = {item.membership_id for item in participants}
+    if not _can_edit_plotting_room_plan(
+        current_viewer,
+        room,
+        participant_membership_ids,
+    ):
+        raise PermissionError(f"membership {membership.id} cannot view room {room.id}")
+    messages = repo.list_plotting_room_messages(
+        current_viewer.community.id,
+        room.id,
+        after_id=after_id,
+        limit=limit,
+    )
+    return PlottingRoomMessageBatch(
+        messages=plotting_room_message_views(
+            repo,
+            current_viewer.community.id,
+            messages,
+        ),
+        last_message_id=messages[-1].id if messages else after_id,
     )
 
 
@@ -580,6 +626,40 @@ def plotting_room_message_view(
         ),
         created_at_label=timestamp_label(message.created_at),
     )
+
+
+def plotting_room_message_views(
+    repo: PlottingRepository,
+    community_id: int,
+    messages: list[PlottingRoomMessage],
+) -> list[PlottingRoomMessageView]:
+    memberships = repo.list_memberships_by_ids(
+        community_id,
+        sorted({message.author_membership_id for message in messages}),
+    )
+    characters = repo.list_characters_by_ids(
+        community_id,
+        sorted(
+            {
+                message.author_character_id
+                for message in messages
+                if message.author_character_id is not None
+            }
+        ),
+    )
+    return [
+        PlottingRoomMessageView(
+            message=message,
+            author_membership=memberships[message.author_membership_id],
+            author_character=(
+                characters[message.author_character_id]
+                if message.author_character_id is not None
+                else None
+            ),
+            created_at_label=timestamp_label(message.created_at),
+        )
+        for message in messages
+    ]
 
 
 async def subscribe_plotting_room_live(room_id: int) -> asyncio.Queue[PlottingRoomLiveEvent]:

--- a/src/elbysodic/services/posts.py
+++ b/src/elbysodic/services/posts.py
@@ -79,10 +79,18 @@ class PostViewContextBuilder:
     _community: Community | None = None
     _mention_links: list[MentionLink] | None = None
 
-    def context(self, posts: list[Post]) -> PostViewContext:
+    def context(
+        self,
+        posts: list[Post],
+        *,
+        extra_character_ids: set[int] | None = None,
+        extra_membership_ids: set[int] | None = None,
+    ) -> PostViewContext:
         community = self.community()
         author_ids = {post.author_character_id for post in posts}
         membership_ids = {post.author_membership_id for post in posts}
+        author_ids.update(extra_character_ids or ())
+        membership_ids.update(extra_membership_ids or ())
         authors = self.repo.list_characters_by_ids(self.community_id, sorted(author_ids))
         memberships = self.repo.list_memberships_by_ids(self.community_id, sorted(membership_ids))
         inherited_accent_character_ids = [
@@ -126,8 +134,15 @@ def build_post_view_context(
     repo: PostViewRepository,
     community_id: int,
     posts: list[Post],
+    *,
+    extra_character_ids: set[int] | None = None,
+    extra_membership_ids: set[int] | None = None,
 ) -> PostViewContext:
-    return PostViewContextBuilder(repo, community_id).context(posts)
+    return PostViewContextBuilder(repo, community_id).context(
+        posts,
+        extra_character_ids=extra_character_ids,
+        extra_membership_ids=extra_membership_ids,
+    )
 
 
 def post_view(

--- a/src/elbysodic/services/read_models.py
+++ b/src/elbysodic/services/read_models.py
@@ -1575,6 +1575,12 @@ class PlottingRoomMessageView:
 
 
 @dataclass(frozen=True, slots=True)
+class PlottingRoomMessageBatch:
+    messages: list[PlottingRoomMessageView]
+    last_message_id: int | None
+
+
+@dataclass(frozen=True, slots=True)
 class PlottingRoomSummary:
     room: PlottingRoom
     participants: list[PlottingRoomParticipantView]

--- a/src/elbysodic/web/pages/plotting/{room_id}/stream/page.py
+++ b/src/elbysodic/web/pages/plotting/{room_id}/stream/page.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -45,6 +44,7 @@ def get(request: Request, room_id: str) -> EventStream:
         try:
             room = stream_services.read_plotting_room(parsed_room_id)
             seen_message_ids = {item.message.id for item in room.messages}
+            poll_after_id = max(seen_message_ids) if seen_message_ids else None
             queue = await stream_services.subscribe_plotting_room_live(parsed_room_id)
             plotting_stream_opened()
             stream_opened = True
@@ -52,28 +52,33 @@ def get(request: Request, room_id: str) -> EventStream:
                 get_task = asyncio.create_task(queue.get())
                 drain_task = asyncio.create_task(wait_for_worker_draining())
                 poll_task = asyncio.create_task(asyncio.sleep(_PLOTTING_POLL_INTERVAL))
-                done, pending = await asyncio.wait(
-                    {get_task, drain_task, poll_task},
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                for task in pending:
-                    task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await task
+                tasks = {get_task, drain_task, poll_task}
+                try:
+                    done, _pending = await asyncio.wait(
+                        tasks,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                finally:
+                    for task in tasks:
+                        task.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
                 if get_task in done:
                     event = get_task.result()
                     if event.kind == "ready":
                         yield SSEEvent(event="plotting-room-ready", data="connected")
-                    elif (
-                        event.kind == "message"
-                        and event.message is not None
-                        and event.message.message.id not in seen_message_ids
-                    ):
-                        seen_message_ids.add(event.message.message.id)
-                        yield _message_fragment(request, event.message)
-                if poll_task in done:
+                    elif event.kind != "message":
+                        continue
+                if poll_task in done or (get_task in done and event.kind == "message"):
+                    try:
+                        batch = stream_services.read_plotting_room_messages(
+                            parsed_room_id,
+                            after_id=poll_after_id,
+                        )
+                    except LookupError, PermissionError:
+                        break
+                    poll_after_id = batch.last_message_id
                     for message in _unseen_messages(
-                        stream_services.read_plotting_room(parsed_room_id).messages,
+                        batch.messages,
                         seen_message_ids,
                     ):
                         yield _message_fragment(request, message)
@@ -82,17 +87,14 @@ def get(request: Request, room_id: str) -> EventStream:
                         queued = queue.get_nowait()
                         if queued.kind == "ready":
                             yield SSEEvent(event="plotting-room-ready", data="connected")
-                        elif (
-                            queued.kind == "message"
-                            and queued.message is not None
-                            and queued.message.message.id not in seen_message_ids
-                        ):
-                            seen_message_ids.add(queued.message.message.id)
-                            yield _message_fragment(request, queued.message)
-                    for message in _unseen_messages(
-                        stream_services.read_plotting_room(parsed_room_id).messages,
-                        seen_message_ids,
-                    ):
+                    try:
+                        batch = stream_services.read_plotting_room_messages(
+                            parsed_room_id,
+                            after_id=poll_after_id,
+                        )
+                    except LookupError, PermissionError:
+                        break
+                    for message in _unseen_messages(batch.messages, seen_message_ids):
                         yield _message_fragment(request, message)
                     break
         finally:

--- a/src/elbysodic/web/pounce_railway.py
+++ b/src/elbysodic/web/pounce_railway.py
@@ -12,11 +12,61 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Protocol, cast
+
+from chirp.app import App
 
 POUNCE_HEALTH_CHECK_PATH = "/readyz"
 POUNCE_SHUTDOWN_TIMEOUT = 10.0
 POUNCE_INTROSPECTION_PATH = "/_pounce/info"
+
+
+class _ChirpServerLauncher(Protocol):
+    def run(
+        self,
+        app: App,
+        *,
+        host: str | None,
+        port: int | None,
+        lifecycle_collector: Any | None,
+    ) -> None: ...
+
+
+def run_chirp_asgi_adapter(
+    chirp_app: App,
+    runtime_app: object,
+    *,
+    host: str | None,
+    port: int | None,
+    lifecycle_collector: Any | None,
+) -> None:
+    """Launch a wrapped ASGI app through Chirp's frozen server configuration.
+
+    Chirp 0.10 exposes public ``freeze`` and ASGI call seams, but its public
+    ``run`` method always serves the Chirp object itself. The one private
+    launcher lookup below is the compatibility bridge that lets Pounce send
+    ``pounce.worker.draining`` to Elbysodic's wrapper without duplicating
+    Chirp's development and production configuration mapping.
+    """
+
+    freeze = getattr(chirp_app, "freeze", None)
+    if callable(freeze):
+        freeze()
+    else:
+        # Compatibility for the pre-0.10 shape retained by existing canaries.
+        ensure_frozen = getattr(chirp_app, "_ensure_frozen", None)
+        if not callable(ensure_frozen):
+            raise TypeError("Chirp launch adapter requires a supported freeze seam")
+        ensure_frozen()
+    launcher = cast(_ChirpServerLauncher | None, getattr(chirp_app, "_server", None))
+    if launcher is None or not callable(getattr(launcher, "run", None)):
+        raise RuntimeError("Chirp 0.10 server launcher compatibility seam changed")
+    launcher.run(
+        cast(App, runtime_app),
+        host=host,
+        port=port,
+        lifecycle_collector=lifecycle_collector,
+    )
 
 
 def _introspection_enabled() -> bool:

--- a/src/elbysodic/web/worker_draining.py
+++ b/src/elbysodic/web/worker_draining.py
@@ -14,10 +14,16 @@ import logging
 import os
 import sys
 import threading
-from typing import Any, cast
+from collections.abc import Awaitable, Callable, MutableMapping
+from typing import Any
 
-from chirp._internal.asgi import Receive, Scope, Send
 from chirp.app import App
+
+from elbysodic.web.pounce_railway import run_chirp_asgi_adapter
+
+type Scope = MutableMapping[str, Any]
+type Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+type Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
 
 _DRAIN_EVENT: asyncio.Event | None = None
 _PLOTTING_STREAMS_ACTIVE = 0
@@ -92,11 +98,11 @@ def plotting_stream_closed() -> int:
     return active
 
 
-async def _worker_lifecycle_receive() -> dict[str, Any]:
+async def _worker_lifecycle_receive() -> MutableMapping[str, Any]:
     return {"type": "http.disconnect"}
 
 
-async def _worker_lifecycle_send(_message: object) -> None:
+async def _worker_lifecycle_send(_message: MutableMapping[str, Any]) -> None:
     return None
 
 
@@ -113,10 +119,6 @@ class DrainingAwareApp:
         """Inner Chirp app for contract checks (not the ASGI drain proxy)."""
         return self._app
 
-    @property
-    def _runtime(self):
-        return self._app._runtime
-
     def __getattr__(self, name: str) -> Any:
         return getattr(self._app, name)
 
@@ -128,9 +130,9 @@ class DrainingAwareApp:
         lifecycle_collector: Any | None = None,
     ) -> None:
         """Launch Pounce with this proxy as the runtime ASGI application."""
-        self._app._ensure_frozen()
-        self._app._server.run(
-            cast(App, self),
+        run_chirp_asgi_adapter(
+            self._app,
+            self,
             host=host,
             port=port,
             lifecycle_collector=lifecycle_collector,

--- a/tests/test_railway_probe_smoke.py
+++ b/tests/test_railway_probe_smoke.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
+from chirp.app import App
 from pounce._health import build_health_response
 from pounce._request_pipeline import maybe_build_builtin_response
 from pounce.config import ServerConfig
 
-from elbysodic.web.pounce_railway import _railway_server_config_kwargs
+from elbysodic.web.pounce_railway import (
+    _railway_server_config_kwargs,
+    run_chirp_asgi_adapter,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RAILWAY_JSON = REPO_ROOT / "railway.json"
@@ -53,6 +58,45 @@ def test_railway_bundle_uses_single_worker_until_process_drain_is_fixed() -> Non
 
     assert config["workers"] == 1
     assert config["health_check_path"] == "/readyz"
+
+
+def test_chirp_launch_adapter_uses_public_freeze_and_serves_wrapper() -> None:
+    calls: list[tuple[object, ...]] = []
+    runtime_app = object()
+    lifecycle_collector = object()
+
+    class Launcher:
+        def run(
+            self,
+            app: object,
+            *,
+            host: str | None,
+            port: int | None,
+            lifecycle_collector: Any | None,
+        ) -> None:
+            calls.append(("run", app, host, port, lifecycle_collector))
+
+    class ChirpCanary:
+        _server = Launcher()
+
+        def freeze(self) -> None:
+            calls.append(("freeze",))
+
+        def _ensure_frozen(self) -> None:
+            raise AssertionError("Chirp 0.10 public freeze must be preferred")
+
+    run_chirp_asgi_adapter(
+        cast(App, ChirpCanary()),
+        runtime_app,
+        host="127.0.0.1",
+        port=8080,
+        lifecycle_collector=lifecycle_collector,
+    )
+
+    assert calls == [
+        ("freeze",),
+        ("run", runtime_app, "127.0.0.1", 8080, lifecycle_collector),
+    ]
 
 
 @pytest.mark.process

--- a/tests/test_stream_read_efficiency.py
+++ b/tests/test_stream_read_efficiency.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+import contextlib
+import types
+from collections.abc import AsyncIterator, Callable
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+
+from elbysodic.db import ForumRepository, connect, create_schema
+from elbysodic.services import create_services
+from elbysodic.services.notifications import notification_inbox
+from elbysodic.services.plotting import read_plotting_room_messages
+from tests._sql_probe import trace_sql
+from tests.test_forum_slice import _link_seed_plotting_room_to_sentinel, _seeded_services
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STREAM_PAGE = (
+    REPO_ROOT
+    / "src"
+    / "elbysodic"
+    / "web"
+    / "pages"
+    / "plotting"
+    / "{room_id}"
+    / "stream"
+    / "page.py"
+)
+
+
+def test_post_id_batch_is_tenant_scoped() -> None:
+    connection = connect()
+    create_schema(connection)
+    repo = ForumRepository(connection)
+
+    def create_post(community_slug: str, index: int):
+        community = repo.create_community(community_slug, community_slug.title())
+        role = repo.create_role(community.id, "member", "Member")
+        user = repo.create_user(f"batch-{index}@example.com", "hash")
+        membership = repo.create_membership(
+            community.id,
+            user.id,
+            role.id,
+            f"writer-{index}",
+            f"Writer {index}",
+        )
+        character = repo.create_character(
+            community.id,
+            membership.id,
+            f"face-{index}",
+            f"Face {index}",
+        )
+        board = repo.create_board(community.id, "scenes", "Scenes")
+        thread = repo.create_thread(
+            community.id,
+            board.id,
+            character.id,
+            f"scene-{index}",
+            f"Scene {index}",
+        )
+        return community, repo.create_post(
+            community.id,
+            thread.id,
+            character.id,
+            f"post {index}",
+        )
+
+    try:
+        default, default_post = create_post("default", 1)
+        _hosted, hosted_post = create_post("hosted", 2)
+
+        posts = repo.list_posts_by_ids(
+            default.id,
+            [default_post.id, hosted_post.id],
+        )
+
+        assert posts == {default_post.id: default_post}
+    finally:
+        connection.close()
+
+
+def _add_messages(services, room_id: int, *, start: int, stop: int) -> None:
+    character = services.seed.default_character
+    assert character is not None
+    for index in range(start, stop):
+        services.repo.create_plotting_room_message(
+            services.seed.community.id,
+            room_id,
+            services.seed.membership.id,
+            f"message {index}",
+            author_character_id=character.id,
+        )
+
+
+def test_plotting_room_history_has_constant_query_cost() -> None:
+    services = _seeded_services()
+    room = _link_seed_plotting_room_to_sentinel(services)
+    try:
+        _add_messages(services, room.id, start=0, stop=10)
+        services.read_plotting_room(room.id)
+        with trace_sql(services.repo.connection) as ten_message_trace:
+            ten_message_detail = services.read_plotting_room(room.id)
+
+        _add_messages(services, room.id, start=10, stop=100)
+        with trace_sql(services.repo.connection) as hundred_message_trace:
+            hundred_message_detail = services.read_plotting_room(room.id)
+
+        assert len(ten_message_detail.messages) == 10
+        assert len(hundred_message_detail.messages) == 100
+        assert hundred_message_trace.count == ten_message_trace.count
+        assert hundred_message_trace.count <= 40
+    finally:
+        services.close()
+
+
+def test_incremental_plotting_read_finds_cross_worker_rows_at_constant_cost() -> None:
+    services = _seeded_services()
+    room = _link_seed_plotting_room_to_sentinel(services)
+    try:
+        character = services.seed.default_character
+        assert character is not None
+        _add_messages(services, room.id, start=0, stop=10)
+        first_cursor = services.read_plotting_room(room.id).messages[-1].message.id
+        direct_message = services.repo.create_plotting_room_message(
+            services.seed.community.id,
+            room.id,
+            services.seed.membership.id,
+            "written outside the local stream queue",
+            author_character_id=character.id,
+        )
+        with trace_sql(services.repo.connection) as short_history_trace:
+            first_batch = services.read_plotting_room_messages(
+                room.id,
+                after_id=first_cursor,
+            )
+
+        _add_messages(services, room.id, start=11, stop=100)
+        long_cursor = services.read_plotting_room(room.id).messages[-1].message.id
+        final_message = services.repo.create_plotting_room_message(
+            services.seed.community.id,
+            room.id,
+            services.seed.membership.id,
+            "another worker row after a long history",
+            author_character_id=character.id,
+        )
+        with trace_sql(services.repo.connection) as long_history_trace:
+            second_batch = services.read_plotting_room_messages(
+                room.id,
+                after_id=long_cursor,
+            )
+
+        assert [item.message.id for item in first_batch.messages] == [direct_message.id]
+        assert first_batch.last_message_id == direct_message.id
+        assert [item.message.id for item in second_batch.messages] == [final_message.id]
+        assert second_batch.last_message_id == final_message.id
+        assert long_history_trace.count == short_history_trace.count
+        assert long_history_trace.count <= 25
+    finally:
+        services.close()
+
+
+def test_incremental_plotting_read_rechecks_current_access() -> None:
+    services = _seeded_services()
+    room = _link_seed_plotting_room_to_sentinel(services)
+    try:
+        stale_viewer = services.viewer()
+        services.repo.connection.execute(
+            "UPDATE community_memberships SET is_active = 0 WHERE id = ?",
+            (services.seed.membership.id,),
+        )
+        services.repo.connection.commit()
+
+        with pytest.raises(PermissionError, match="cannot view room"):
+            read_plotting_room_messages(
+                services.repo,
+                stale_viewer,
+                room.id,
+                after_id=None,
+            )
+    finally:
+        services.close()
+
+
+def test_notification_inbox_batches_snippet_context() -> None:
+    services = create_services(":memory:")
+    viewer = services.viewer()
+    character = viewer.current_character
+    assert character is not None
+    created = services.start_thread_with_post(
+        board_slug="danger-room",
+        character_id=character.id,
+        title="Bounded inbox",
+        body="original",
+    )
+    try:
+        unrelated_post_ids = {
+            services.repo.create_post(
+                viewer.community.id,
+                created.thread.id,
+                character.id,
+                f"unrelated scene history {index}",
+            ).id
+            for index in range(200)
+        }
+        notification_post_ids: list[int] = []
+        for index in range(50):
+            post = services.repo.create_post(
+                viewer.community.id,
+                created.thread.id,
+                character.id,
+                f"inbox snippet {index}",
+            )
+            notification_post_ids.append(post.id)
+            services.repo.create_notification(
+                viewer.community.id,
+                viewer.membership.id,
+                kind="thread_reply",
+                thread_id=created.thread.id,
+                post_id=post.id,
+                actor_membership_id=viewer.membership.id,
+                actor_character_id=character.id,
+            )
+
+        with (
+            patch.object(
+                services.repo,
+                "list_posts_by_ids",
+                wraps=services.repo.list_posts_by_ids,
+            ) as post_loader,
+            trace_sql(services.repo.connection) as trace,
+        ):
+            inbox = notification_inbox(services.repo, viewer, limit=50)
+
+        full_roster_queries = [
+            statement
+            for statement in trace.statements
+            if "FROM characters" in statement and "ORDER BY name, id" in statement
+        ]
+        membership_queries = [
+            statement for statement in trace.statements if "FROM community_memberships" in statement
+        ]
+        assert len(inbox.items) == 50
+        assert inbox.items[0].snippet == "inbox snippet 49"
+        assert len(full_roster_queries) <= 1
+        assert len(membership_queries) <= 3
+        post_loader.assert_called_once_with(
+            viewer.community.id,
+            sorted(notification_post_ids),
+        )
+        loaded_post_ids = set(post_loader.call_args.args[1])
+        assert loaded_post_ids.isdisjoint(unrelated_post_ids)
+        assert not any(
+            "thread_id IN (SELECT value FROM json_each" in sql for sql in trace.statements
+        )
+    finally:
+        services.close()
+
+
+def test_cancelled_plotting_stream_awaits_every_child_task() -> None:
+    source = STREAM_PAGE.read_text()
+    function = next(
+        node
+        for node in ast.parse(source).body
+        if isinstance(node, ast.FunctionDef) and node.name == "get"
+    )
+
+    class Services:
+        def read_plotting_room(self, _room_id: int):
+            return types.SimpleNamespace(messages=[])
+
+        async def subscribe_plotting_room_live(self, _room_id: int) -> asyncio.Queue:
+            return asyncio.Queue()
+
+        async def unsubscribe_plotting_room_live(self, *_args: object) -> None:
+            return None
+
+    async def exercise() -> None:
+        drain_event = asyncio.Event()
+        services = Services()
+        namespace: dict[str, Any] = {
+            "asyncio": asyncio,
+            "get_services": lambda *_args: services,
+            "_parse_room_id": int,
+            "plotting_stream_opened": lambda: None,
+            "plotting_stream_closed": lambda: None,
+            "is_worker_draining": lambda: False,
+            "wait_for_worker_draining": drain_event.wait,
+            "_PLOTTING_POLL_INTERVAL": 0.25,
+            "close_request_services": lambda _request: None,
+            "EventStream": lambda generator: generator,
+        }
+        exec(  # noqa: S102 -- isolate the checked route generator with controlled fakes
+            "from __future__ import annotations\n" + ast.unparse(function),
+            namespace,
+        )
+        get_stream = cast(
+            Callable[[object, str], AsyncIterator[Any]],
+            namespace["get"],
+        )
+        stream = get_stream(object(), "1")
+
+        async def consume_one() -> Any:
+            return await anext(stream)
+
+        consumer = asyncio.create_task(consume_one())
+        await asyncio.sleep(0.01)
+        consumer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer
+        await asyncio.sleep(0)
+
+        pending = [
+            task
+            for task in asyncio.all_tasks()
+            if task is not asyncio.current_task() and not task.done()
+        ]
+        assert pending == []
+
+    asyncio.run(exercise())
+
+
+def test_local_queue_message_rechecks_access_before_rendering() -> None:
+    source = STREAM_PAGE.read_text()
+    function = next(
+        node
+        for node in ast.parse(source).body
+        if isinstance(node, ast.FunctionDef) and node.name == "get"
+    )
+
+    class Services:
+        def __init__(self) -> None:
+            self.authorized = True
+            self.queue: asyncio.Queue[object] = asyncio.Queue()
+
+        def read_plotting_room(self, _room_id: int):
+            return types.SimpleNamespace(messages=[])
+
+        def read_plotting_room_messages(self, _room_id: int, *, after_id: int | None):
+            if not self.authorized:
+                raise PermissionError("participant access revoked")
+            return types.SimpleNamespace(messages=[], last_message_id=after_id)
+
+        async def subscribe_plotting_room_live(self, _room_id: int) -> asyncio.Queue:
+            await self.queue.put(types.SimpleNamespace(kind="ready", message=None))
+            return self.queue
+
+        async def unsubscribe_plotting_room_live(self, *_args: object) -> None:
+            return None
+
+    async def exercise() -> None:
+        drain_event = asyncio.Event()
+        services = Services()
+        namespace: dict[str, Any] = {
+            "asyncio": asyncio,
+            "get_services": lambda *_args: services,
+            "_parse_room_id": int,
+            "plotting_stream_opened": lambda: None,
+            "plotting_stream_closed": lambda: None,
+            "is_worker_draining": lambda: False,
+            "wait_for_worker_draining": drain_event.wait,
+            "_PLOTTING_POLL_INTERVAL": 30.0,
+            "close_request_services": lambda _request: None,
+            "EventStream": lambda generator: generator,
+            "SSEEvent": lambda **values: types.SimpleNamespace(**values),
+            "_message_fragment": lambda *_args: "private message",
+            "_unseen_messages": lambda messages, _seen: messages,
+        }
+        exec(  # noqa: S102 -- isolate the checked route generator with controlled fakes
+            "from __future__ import annotations\n" + ast.unparse(function),
+            namespace,
+        )
+        get_stream = cast(
+            Callable[[object, str], AsyncIterator[Any]],
+            namespace["get"],
+        )
+        stream = get_stream(object(), "1")
+        ready = await anext(stream)
+        assert ready.event == "plotting-room-ready"
+
+        services.authorized = False
+        await services.queue.put(
+            types.SimpleNamespace(
+                kind="message",
+                message=types.SimpleNamespace(message=types.SimpleNamespace(id=1)),
+            )
+        )
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+
+    asyncio.run(exercise())


### PR DESCRIPTION
Draft for immediate review. Focused checks pass; final integrated validation is still being completed. The original local commit history is preserved; this review branch uses an identical code tree with GitHub noreply authorship.

## Summary

- Parent leaf/epic: #357 / #353
- Outcome: Plotting streams now await every child task, read new messages through a current-access-checked incremental cursor, and treat process-local messages only as wakeups so a revoked participant cannot receive queued content. Plotting message and notification author context is batched; notification posts are loaded by tenant-scoped target IDs without loading unrelated scene history. Chirp lifecycle coupling is reduced to one documented, canary-tested launcher adapter.

## Owned paths

- `src/elbysodic/services/plotting.py`
- `src/elbysodic/services/notifications.py`
- `src/elbysodic/services/posts.py`
- `src/elbysodic/services/read_models.py`
- `src/elbysodic/services/forum.py` (plotting read facade only)
- `src/elbysodic/db/repositories/posts.py` (authorized narrow carveout: tenant-aware target-ID batch lookup)
- `src/elbysodic/web/pages/plotting/{room_id}/stream/page.py`
- `src/elbysodic/web/worker_draining.py`
- `src/elbysodic/web/pounce_railway.py` (compatibility adapter only)
- `tests/test_stream_read_efficiency.py`
- `tests/test_railway_probe_smoke.py` (adapter canary only)
- `docs/architecture/stream-read-contracts.md`
- `changelog.d/+bounded-stream-reads.fixed.md`

## Decisions frozen (do not reopen in review)

- ADR 0004 clause 6: SSE generators own, cancel, and await child tasks; polling reads authorized incremental rows, preserves cross-worker delivery, and batches notification/author context.
- ADR 0004 clause 9: use supported Chirp seams where available and isolate any essential private compatibility bridge without changing dependencies. Chirp 0.10 exposes public `freeze` and ASGI call seams, but its public `run` always serves the Chirp object; the remaining `_server` launcher lookup is isolated in `run_chirp_asgi_adapter` and guarded by a lifecycle canary.
- Existing tenant, membership, participant, role, notification visibility, and unread-state boundaries remain authoritative.

## Acceptance run

```bash
PYTHONPATH=src /tmp/elbysodic-audit-stable/bin/python -m pytest tests/test_stream_read_efficiency.py tests/test_railway_probe_smoke.py -m 'not process' -q
# 11 passed

PYTHONPATH=src /tmp/elbysodic-audit-stable/bin/python -m pytest tests/test_forum_slice.py -k 'plotting_room_sse_closes_cleanly_on_worker_draining or plotting_room_sse_ready_event_uses_safe_channel' -q
# 2 passed

PYTHONPATH=src /tmp/elbysodic-audit-stable/bin/python -m pytest tests/test_notification_contracts.py tests/test_tenant_repository.py -k 'notification or post_id_batch' -q
# 13 passed

PYTHONPATH=src /tmp/elbysodic-audit-stable/bin/python -m ty check --python /tmp/elbysodic-audit-stable/bin/python src/elbysodic/ tests/
# All checks passed
```

Probe evidence:

- Stream cancellation: `ORPHAN_TASKS 2` before, `ORPHAN_TASKS 0` after.
- Full plotting read: 10 messages = 36 SQL statements and 100 messages = 36; the 100-message path was 234 before.
- At four polls per second, the 100-message path fell from 936 to 144 statements per second.
- A direct repository write is returned by the incremental read after the cursor, with the same 24-query cost after short and long histories.
- A cached viewer whose membership becomes inactive is denied before rows are returned.
- A local message queued after access revocation closes the stream without rendering a fragment; local messages cannot starve the authorization poll because each message wakeup performs that read.
- A 50-item inbox fell from 702 to 308 selects, from 50 to 1 full-roster loads, and from 151 to 3 membership queries.
- The notification regression seeds 200 unrelated posts in the notified scene and proves the batch loader receives only the 50 notification target IDs. A separate regression proves cross-tenant IDs are excluded.

## Pre-push lint

```bash
PYTHONPATH=src /tmp/elbysodic-audit-stable/bin/python -m ruff check .
# All checks passed
```

- [x] Ruff clean on this branch

## Steward Notes

- Consulted: root constitution plus service, database, web, test, docs, and changelog stewards.
- Accepted / deferred: Accepted cancellation ownership, incremental authorized polling, local-queue revocation protection, target-ID notification batching, and removal of avoidable Chirp private references. Deferred only the essential Chirp 0.10 `_server` launch bridge; it is isolated and must be reevaluated on a Chirp upgrade or supported wrapped-app launch API.
- Proof: Cancellation, cross-worker delivery, access revocation, fixed history cost, tenant-scoped post batching, inbox snippets/privacy/read state, and lifecycle launch order have executable regressions. Existing plotting drain and notification contract tests remain green.
- Collateral: `docs/architecture/stream-read-contracts.md` and `changelog.d/+bounded-stream-reads.fixed.md`.

## Notes

- Field-guide update? (`field-guide/`) — no
- New ADR needed? — no; implements accepted `docs/adr/0004-engineering-audit-corrections.md`
- Orchestrator merges; worker leaves PR open unless `ship` said merge

Closes #357. Parent epic: #353.
